### PR TITLE
Fix hard-coded LD zoom of 20kb

### DIFF
--- a/modules/EnsEMBL/Web/Command/Export/LDExcelFile.pm
+++ b/modules/EnsEMBL/Web/Command/Export/LDExcelFile.pm
@@ -55,8 +55,7 @@ sub make_file {
   foreach (values %pop_params){ 
     my $pop_param   = $hub->param('pop'.$_);
     $pop_param      = $object->get_pop_name($pop_param); 
-    my $zoom        = 20000; # Currently non-configurable
-    my $ld_values   = $object->get_ld_values($pop_param, $params->{'v'}->[0], $zoom);
+    my $ld_values   = $object->get_ld_values($pop_param, $params->{'v'}->[0]);
     my $populations = {};
     
     map { $populations->{$_} = 1 } map { keys %{$ld_values->{$_}} } keys %$ld_values;

--- a/modules/EnsEMBL/Web/Component/Export/Output.pm
+++ b/modules/EnsEMBL/Web/Component/Export/Output.pm
@@ -53,9 +53,8 @@ sub ld_dump {
   foreach (values %pop_params) { 
     my $pop_param       = $hub->param("pop$_");
     $pop_param          = $object->get_pop_name($pop_param);
-    my $zoom            = 20000; # Currently non-configurable
     my @colour_gradient = ('ffffff', $hub->colourmap->build_linear_gradient(41, 'mistyrose', 'pink', 'indianred2', 'red'));
-    my $ld_values       = $object->get_ld_values($pop_param, $v, $zoom);
+    my $ld_values       = $object->get_ld_values($pop_param, $v);
     
     my %populations     = map { $_ => 1 } map { keys %$_ } values %$ld_values;
   


### PR DESCRIPTION
The LD code was hard-coded to export only start+20kb. This has been removed,
with the correct limits now coming from the Location object's coords. Links
in from a variation page already default to a 20kb window around the variant
so no need for the default limit to exist.
