### PR TITLE
Remove read coverage support

### DIFF
--- a/modules/EnsEMBL/Web/Component/Transcript/PopulationImage.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/PopulationImage.pm
@@ -184,10 +184,6 @@ sub sample_configs {
   my @containers_and_configs; ## array of containers and configs
   my @haplotype;
   
-  # THIS IS A HACK. IT ASSUMES ALL COVERAGE DATA IN DB IS FROM SANGER fc1
-  # Only display coverage data if source Sanger is on 
-  my $display_coverage = $hub->param('opt_sanger') eq 'off' ? 0 : 1;
-  
   foreach my $sample ($object->get_samples) {
     my $sample_slice = $transcript_slice->get_by_strain($sample); 
     next unless $sample_slice; 
@@ -224,8 +220,6 @@ sub sample_configs {
     }
     
     my ($allele_info, $consequences) = $object->getAllelesConsequencesOnSlice($sample, 'tsv_transcript', $sample_slice);
-    my ($coverage_level, $raw_coverage_obj) = $display_coverage ? $object->read_coverage($sample, $sample_slice) : ([], []);
-    my $munged_coverage = $object->munge_read_coverage($raw_coverage_obj);
     
     $sample_config->{'transcript'} = {
       sample         => $sample,
@@ -235,11 +229,9 @@ sub sample_configs {
       transcript     => $transcript,
       allele_info    => $allele_info,
       consequences   => $consequences,
-      coverage_level => $coverage_level,
-      coverage_obj   => $munged_coverage,
     };
     
-    unshift @haplotype, [ $sample, $allele_info, $munged_coverage ];
+    unshift @haplotype, [ $sample, $allele_info ];
     
     $sample_config->modify_configs(
       [ $sample_config->get_track_key('tsv_transcript', $object) ],

--- a/modules/EnsEMBL/Web/Component/Transcript/PopulationTable.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/PopulationTable.pm
@@ -141,8 +141,6 @@ sub get_page_data {
     
     next unless @$consequences && @$allele_info;
     
-    my ($coverage_level, $raw_coverage_obj) = $object->read_coverage($sample, $sample_slice);
-    my @coverage_obj = @{$raw_coverage_obj||[]} ? sort { $a->start <=> $b->start } @$raw_coverage_obj : ();
     my $index        = 0;
     
     foreach my $allele_ref (@$allele_info) {
@@ -189,25 +187,10 @@ sub get_page_data {
         $codons =~ tr/acgt/ACGT/;
       }
       
-      # read coverage in mouse?
-      if (grep $_ eq 'Sanger', @{$allele->get_all_sources || []}) {
-        my $allele_start = $allele->start;
-        my $coverage;
-        
-        foreach (@coverage_obj) {
-          next if $allele_start > $_->end;
-          last if $allele_start < $_->start;
-          $coverage = $_->level if $_->level > $coverage;
-        }
-        
-        $coverage = '>' . ($coverage - 1) if $coverage == $coverage_level->[-1];
-        $status   = "resequencing coverage $coverage";
-      } else {
-        my $tmp        = $allele->variation;
-        my @validation = $tmp ? @{$tmp->get_all_validation_states || []} : ();
-        $status        = join ', ',  @validation;
-        $status        =~ s/freq/frequency/;
-      }
+      my $tmp        = $allele->variation;
+      my @validation = $tmp ? @{$tmp->get_all_validation_states || []} : ();
+      $status        = join ', ',  @validation;
+      $status        =~ s/freq/frequency/;
       
       # url
       my $vid = $allele->variation_name;

--- a/modules/EnsEMBL/Web/ImageConfig/transcript_population.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/transcript_population.pm
@@ -103,7 +103,6 @@ sub init_sample_transcript {
   my $self = shift;
   
   $self->add_tracks('other',
-    [ 'coverage_top',   '', 'coverage',       { display => 'on',     strand => 'r', menu => 'no', type => 'top', caption => 'Resequence coverage'     }],
     [ 'tsv_variations', '', 'tsv_variations', { display => 'normal', strand => 'r', menu => 'no', colours => $self->species_defs->colour('variation') }],
   );
 }

--- a/modules/EnsEMBL/Web/Object/Transcript.pm
+++ b/modules/EnsEMBL/Web/Object/Transcript.pm
@@ -829,31 +829,6 @@ sub munge_gaps_split {
   return @return;
 }
 
-sub read_coverage {
-  my ($self, $sample, $sample_slice) = @_;
-
-  my $individual_adaptor = $self->Obj->adaptor->db->get_db_adaptor('variation')->get_IndividualAdaptor; 
-  my $sample_objs = $individual_adaptor->fetch_all_by_name($sample);
-  return ([], []) unless @$sample_objs; 
-  my $sample_obj = $sample_objs->[0]; 
-
-  my $rc_adaptor = $self->Obj->adaptor->db->get_db_adaptor('variation')->get_ReadCoverageAdaptor; 
-  my $coverage_level = $rc_adaptor->get_coverage_levels; 
-  my $coverage_obj = $rc_adaptor->fetch_all_by_Slice_Individual_depth($sample_slice, $sample_obj); 
-  return ($coverage_level, $coverage_obj);
-}
-
-sub munge_read_coverage {
-  my ($self, $coverage_obj) = @_;
-  
-  my @filtered_obj =
-    sort { $a->[2]->start <=> $b->[2]->start }
-    map  { $self->munge_gaps_split('tsv_transcript', $_->start, $_->end, $_) }
-    @$coverage_obj;
-    
-  return  \@filtered_obj;
-}
-
 #-- end transcript SNP view ----------------------------------------------
 
 =head2 gene


### PR DESCRIPTION
This is the minimum needed to remove the references to read coverage from the variation API.

There are still some modules in ensembl-draw which have not been removed or modified as they are in use by another track/view (hsp_query_plot.pm); these can be removed/disentangled next release, or left intact if this is easier.
