### PR TITLE
Fix #373851: expand all-subtrees (zmenu on gene trees)

### DIFF
--- a/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
@@ -128,6 +128,10 @@ sub content {
 
   # Expand all nodes
   if (grep $_ != $node_id, keys %collapsed_ids) {
+
+    my %subnodes = map {($_->node_id => 1)} @{$node->get_all_nodes};
+    my $collapse = join ',', (grep {not $subnodes{$_}} (keys %collapsed_ids));
+
     $self->add_entry({
       type          => 'Image',
       label         => 'expand all sub-trees',
@@ -137,7 +141,7 @@ sub content {
       link          => $hub->url('Component', {
         type     => $hub->type,
         action   => $action,
-        collapse => 'none' 
+        collapse => $collapse
       })
     });
   }


### PR DESCRIPTION
Paul Kersey opened this bug 2 weeks ago.

The "expand all sub-trees" option in the zmenu of gene trees is (i) not intuitive, as it expands everything in the tree, not only the sub-trees of the current node, (ii) redundant with the "View fully expanded tree" link at the bottom of the tree.
Instead, the option should really expand only the nodes under the node the user clicked on. That's basically what the commit is changing

Cheers,
Matthieu
