### PR TITLE
(Gene-trees) Long wedges are shortened and hatched

### DIFF
--- a/modules/Bio/EnsEMBL/GlyphSet/genetree.pm
+++ b/modules/Bio/EnsEMBL/GlyphSet/genetree.pm
@@ -246,7 +246,8 @@ sub _init {
             'points' => [ $x, $y,
                           $x + $width, $y - ($height / 2 ),
                           $x + $width, $y + ($height / 2 ) ],
-            'colour' => $collapsed_colour,
+            $f->{_collapsed_cut} ? ('patterncolour' => $collapsed_colour, 'pattern' => ($f->{_collapsed_cut} == 1 ? 'hatch_vert' : 'pin_vert'))
+                                 : ('colour' => $collapsed_colour),
             'href'   => $node_href,
           });
 
@@ -664,8 +665,13 @@ sub features {
     
     $f->{'_collapsed'}          = 1,
     $f->{'_collapsed_count'}    = $leaf_count;
-    $f->{'_collapsed_distance'} = $sum_dist/$leaf_count;
     $f->{'_collapsed_cut'}      = 0;
+    while ($sum_dist > $leaf_count) {
+      $sum_dist /= 10;
+      $f->{'_collapsed_cut'}++;
+    }
+    $f->{'_collapsed_distance'} = $sum_dist/$leaf_count;
+
     $f->{'_height'}             = 12 * log($f->{'_collapsed_count'});
     $f->{'_genome_dbs'}         = \%genome_dbs;
     $f->{'_genes'}              = \%genes;


### PR DESCRIPTION
(copy of the earlier pull-request)

Hi again,

When the branches are too long, they are divided by 10, 100, etc, but not when they are collapsed. It causes pictures like: http://www.ensembl.org/Homo_sapiens/Gene/Compara_Tree?g=ENSG00000155363;r=1:113215763-113243368

The fix divides the length of the wedges by 10, 100, etc, following the same rule, and draws the wedges with hatchings:
http://enssand-01.internal.sanger.ac.uk:9073/Homo_sapiens/Gene/Compara_Tree?g=ENSG00000155363;r=1:113215763-113243368

Another example:
http://www.ensembl.org/Homo_sapiens/Gene/Compara_Tree?db=core;g=ENSG00000073910;r=13:32605437-32870794
http://enssand-01.internal.sanger.ac.uk:9073/Homo_sapiens/Gene/Compara_Tree?db=core;g=ENSG00000073910;r=13:32605437-32870794

I didn't manage to add the symbols to the legend. I've found where to add entries, but I couldn't make triangles with the same pattern

Matthieu
