### PR TITLE
Bugfix: taxon names in the gene-tree displays

### DIFF
--- a/modules/Bio/EnsEMBL/GlyphSet/genetree.pm
+++ b/modules/Bio/EnsEMBL/GlyphSet/genetree.pm
@@ -651,8 +651,8 @@ sub features {
 
     my $species_tree_node_id = $tree->get_tagvalue('species_tree_node_id');
     my $speciesTreeNode      = $tree->adaptor->db->get_SpeciesTreeNodeAdaptor->fetch_node_by_node_id($species_tree_node_id);
-    my $taxon_id             = $speciesTreeNode->taxon_id;
-
+    my $node_name            = $self->species_defs->multi_hash->{'DATABASE_COMPARA'}{'TAXON_NAME'}->{$speciesTreeNode->taxon_id}
+                               || $speciesTreeNode->node_name;
 
     foreach my $leaf (@{$tree->get_all_leaves}) {
       my $dist = $leaf->distance_to_ancestor($tree);
@@ -676,7 +676,7 @@ sub features {
     $f->{'_genome_dbs'}         = \%genome_dbs;
     $f->{'_genes'}              = \%genes;
     $f->{'_leaves'}             = \%leaves;
-    $f->{'label'}               = sprintf '%s: %d homologs', ($self->species_defs->multi_hash->{'DATABASE_COMPARA'}{'TAXON_NAME'}->{$taxon_id}, $leaf_count);
+    $f->{'label'}               = sprintf '%s: %d homologs', ($node_name, $leaf_count);
 
   }
   

--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -1171,21 +1171,16 @@ sub _summarise_compara_db {
   ###################################################################
   ## Section for storing the taxa properties
   
-  # Default name is the scientific name
-  $res_aref = $dbh->selectall_arrayref(qq(SELECT DISTINCT taxon_id, name FROM ncbi_taxa_name JOIN gene_tree_node_tag ON taxon_id=value WHERE tag='lost_taxon_id' AND name_class='scientific name'));
-  foreach my $row (@$res_aref) {
-    my ($taxon_id, $taxon_name) = @$row;
-    $self->db_tree->{$db_name}{'TAXON_NAME'}{$taxon_id} = $taxon_name;
-  }
+  # Default name is the name stored in species_tree_node: the glyphset will use it by default
 
-  # Better name is the ensembl alias
+  # But a better name is the ensembl alias
   $res_aref = $dbh->selectall_arrayref(qq(SELECT taxon_id, name FROM ncbi_taxa_name WHERE name_class='ensembl alias name'));
   foreach my $row (@$res_aref) {
     my ($taxon_id, $taxon_name) = @$row;
     $self->db_tree->{$db_name}{'TAXON_NAME'}{$taxon_id} = $taxon_name;
   }
 
-  # And the age of each ancestor
+  # And we need the age of each ancestor
   $res_aref = $dbh->selectall_arrayref(qq(SELECT taxon_id, name FROM ncbi_taxa_name WHERE name_class='ensembl timetree mya'));
   foreach my $row (@$res_aref) {
     my ($taxon_id, $taxon_mya) = @$row;

--- a/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
@@ -69,8 +69,7 @@ sub content {
   my $speciesTreeNode      = $tree->adaptor->db->get_SpeciesTreeNodeAdaptor->fetch_node_by_node_id($species_tree_node_id);
   my $taxon_id             = $speciesTreeNode->taxon_id;
      $taxon_id        = $node->genome_db->taxon_id if !$taxon_id && $is_leaf && not $is_supertree;
-  my $NCBITaxon            = $tree->adaptor->db->get_NCBITaxonAdaptor->fetch_node_by_node_id($taxon_id);
-  my $taxon_name           = $NCBITaxon->scientific_name();
+  my $taxon_name           = $speciesTreeNode->node_name;
      $taxon_name      = $node->genome_db->taxon->name if !$taxon_name && $is_leaf && not $is_supertree;
 
   my $taxon_mya       = $hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'TAXON_MYA'}->{$taxon_id};


### PR DESCRIPTION
Hi !

If you have a look at the gene tree http://www.ensembl.org/Homo_sapiens/Gene/Compara_Tree?db=core;g=ENSG00000073910;r=13:32605437-32870794 you'll see ": 2 homologs" on its first line, whilst other nodes have a taxon name in front of the colon.

The bug is related to the changes in the SpeciesTree API that we've made in e74.
This commit fixes 3 things:
- There is a name in $speciesTreeNode->node_name
- We only need to fill the $self->db_tree->{$db_name}{'TAXON_NAME'} hash with common names to override $speciesTreeNode->node_name. The common name are stored internally as "ensembl alias name"
- The webcode doesn't need to get NCBITaxon objects as the names are either in the $speciesTreeNode object, or in the packed config

With the commit, the tree looks like http://enssand-01.internal.sanger.ac.uk:9073/Homo_sapiens/Gene/Compara_Tree?db=core;g=ENSG00000073910;r=13:32605437-32870794
