### PR TITLE
Lost taxa are now stored with the "lost_species_tree_node_id" tags

### DIFF
--- a/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
@@ -104,13 +104,12 @@ sub content {
     order => 4
   }) unless $is_root || $is_leaf || $is_supertree;
 
-  if (defined $tagvalues->{'lost_taxon_id'}) {
-    my $lost_taxa = $tagvalues->{'lost_taxon_id'};
-       $lost_taxa = [ $lost_taxa ] if ref $lost_taxa ne 'ARRAY';
+  if (defined $tagvalues->{'lost_species_tree_node_id'}) {
+    my $lost_taxa = $node->lost_taxa;
        
     $self->add_entry({
       type  => 'Lost taxa',
-      label => join(', ', map { $hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'TAXON_NAME'}->{$_} || "taxon_id: $_" }  @$lost_taxa ),
+      label => join(', ', map { $hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'TAXON_NAME'}->{$_->taxon_id} || $_->node_name }  @$lost_taxa ),
       order => 5.6
     });
   }


### PR DESCRIPTION
In e74, we changed the way the information about lost taxa is stored in the gene trees

befeore: http://www.ensembl.org/Homo_sapiens/Gene/Compara_Tree?db=core;g=ENSG00000073910;r=13:32605437-32870794
after: http://enssand-01.internal.sanger.ac.uk:9073/Homo_sapiens/Gene/Compara_Tree?db=core;g=ENSG00000073910;r=13:32605437-32870794

If you click on the blue squares off the collapsed the nodes ("Old World rodents: 2 homologs", "Laurasiatherian mammals: 12 homologs", etc), you'll see that the "Lost taxa" entry is not shown on the zmenus of the live site
