### PR TITLE
Removed deprecated calls

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -186,7 +186,7 @@ sub content {
           type   => 'Gene',
           action => 'Compara_Tree' . ($cdb =~ /pan/ ? '/pan_compara' : ''),
           g1     => $stable_id,
-          anc    => $orthologue->{'ancestor_node_id'},
+          anc    => $orthologue->{'gene_tree_node_id'},
           r      => undef
         })
       );

--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -701,7 +701,7 @@ sub get_homology_matches {
       my $order = 0;
       
       foreach my $homology (@{$homologues->{$display_spp}}) { 
-        my ($homologue, $homology_desc, $homology_subtype, $query_perc_id, $target_perc_id, $dnds_ratio, $ancestor_node_id) = @$homology;
+        my ($homologue, $homology_desc, $homology_subtype, $query_perc_id, $target_perc_id, $dnds_ratio, $gene_tree_node_id) = @$homology;
         
         next unless $homology_desc =~ /$homology_description/;
         next if $disallowed_homology && $homology_desc =~ /$disallowed_homology/;
@@ -718,7 +718,7 @@ sub get_homology_matches {
           query_perc_id       => $query_perc_id,
           target_perc_id      => $target_perc_id,
           homology_dnds_ratio => $dnds_ratio,
-          ancestor_node_id    => $ancestor_node_id,
+          gene_tree_node_id   => $gene_tree_node_id,
           order               => $order,
           location            => sprintf('%s:%s-%s:%s', map $homologue->$_, qw(chr_name chr_start chr_end chr_strand))
         };
@@ -800,7 +800,7 @@ sub fetch_homology_species_hash {
     
     # FIXME: ucfirst $genome_db_name is a hack to get species names right for the links in the orthologue/paralogue tables.
     # There should be a way of retrieving this name correctly instead.
-    push @{$homologues{ucfirst $genome_db_name}}, [ $target_member, $homology->description, $homology->subtype, $query_perc_id, $target_perc_id, $dnds_ratio, $homology->ancestor_node_id];
+    push @{$homologues{ucfirst $genome_db_name}}, [ $target_member, $homology->description, $homology->taxonomy_level, $query_perc_id, $target_perc_id, $dnds_ratio, $homology->{_gene_tree_node_id}];
   }
   
   $self->timer_push('homologies hacked', 6);

--- a/modules/EnsEMBL/Web/Object/LRG.pm
+++ b/modules/EnsEMBL/Web/Object/LRG.pm
@@ -763,7 +763,7 @@ sub get_homology_matches {
       my $order = 0;
       
       foreach my $homology (@{$homologues->{$display_spp}}){ 
-        my ($homologue, $homology_desc, $homology_subtype, $query_perc_id, $target_perc_id, $dnds_ratio, $ancestor_node_id) = @$homology;
+        my ($homologue, $homology_desc, $homology_subtype, $query_perc_id, $target_perc_id, $dnds_ratio, $gene_tree_node_id) = @$homology;
   
         next unless $homology_desc =~ /$homology_description/;
         next if $disallowed_homology && $homology_desc =~ /$disallowed_homology/;
@@ -780,7 +780,7 @@ sub get_homology_matches {
         $homology_list{$display_spp}{$homologue_id}{'target_perc_id'}      = $target_perc_id;
         $homology_list{$display_spp}{$homologue_id}{'homology_dnds_ratio'} = $dnds_ratio; 
         $homology_list{$display_spp}{$homologue_id}{'display_id'}          = $homologue->display_label || 'Novel Ensembl prediction';
-        $homology_list{$display_spp}{$homologue_id}{'ancestor_node_id'}    = $ancestor_node_id;
+        $homology_list{$display_spp}{$homologue_id}{'gene_tree_node_id'}   = $gene_tree_node_id;
         
         $order++;
       }
@@ -850,7 +850,7 @@ sub fetch_homology_species_hash {
         $dnds_ratio     = $homology->dnds_ratio; 
       }
     }  
-    push (@{$homologues{$genome_db_name}}, [ $target_member, $homology->description, $homology->subtype, $query_perc_id, $target_perc_id, $dnds_ratio, $homology->ancestor_node_id]);
+    push (@{$homologues{$genome_db_name}}, [ $target_member, $homology->description, $homology->taxonomy_level, $query_perc_id, $target_perc_id, $dnds_ratio, $homology->{_gene_tree_node_id}]);
   }
 
   $self->timer_push( 'homologies hacked', 6 );


### PR DESCRIPTION
I've just found that the webcode was still using a few calls that we've deprecated.
Here is the fix,

Matthieu
