### PR TITLE
Display a warning message instead of the karyotype and the table if ther...

### DIFF
--- a/modules/EnsEMBL/Web/Component/Phenotype/Locations.pm
+++ b/modules/EnsEMBL/Web/Component/Phenotype/Locations.pm
@@ -44,6 +44,11 @@ sub content {
     my $object = $self->object;
     if ($object && $object->can('convert_to_drawing_parameters')) {
       $features = $object->convert_to_drawing_parameters;
+
+      # If too many data to display
+      foreach my $obj_type (keys(%$features)) {
+        return $self->_warning("Sorry there are too many to display", $features->{$obj_type}->[0][0]{'warning_msg'}) if ($features->{$obj_type}->[0][0]{'warning_msg'});
+      }
     }
   }
   my $html = $self->_render_features(\@id, $features);

--- a/modules/EnsEMBL/Web/Data/Bio/Variation.pm
+++ b/modules/EnsEMBL/Web/Data/Bio/Variation.pm
@@ -42,7 +42,15 @@ sub convert_to_drawing_parameters {
   my @phen_ids = $hub->param('ph');
   my $ga       = $hub->database('core')->get_adaptor('Gene');
   my (@results, %associated_genes, %p_value_logs, %p_values, %phenotypes_sources, %phenotypes_studies,%gene_ids);
-  
+
+  # Threshold to display the variations on the karyotype view. Use BioMart instead.
+  my $max_features = 1000;
+  my $count_features = scalar(@$data);
+  if ($count_features > $max_features) {
+    my $message = qq{There are <b>$count_features</b> genomic locations associated with this phenotype). Please, use <a href="/biomart/martview/">BioMart</a> to retrieve a table of all the variants associated with this phenotype instead as there are too many to display on a karyotype.};
+    return [[{'warning_msg' => $message}],[]];
+  }
+
   # getting associated phenotypes and associated genes
   foreach my $pf (@{$data || []}) {
     my $object_id   = $pf->object_id;


### PR DESCRIPTION
...e are too many phenotype locations to display (threshold set to 1000)

The view becomes useless when there are a lot of locations associated with a phenotype. So it will display a warning message instead, suggesting to use BioMart.
