### PR TITLE
remove hard coded values from genotyping chip code

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -612,19 +612,12 @@ sub sets{
   my $hub            = $self->hub;
   my $object         = $self->object;
   my $status         = $object->status;
-  my @variation_sets = sort @{$object->get_variation_set_string};
+  my @variation_sets = sort @{$object->get_variation_sub_sets('Genotyping chip variants')};
 
   my @genotyping_sets_list;
 
   foreach my $vs (@variation_sets){
-    next unless $vs =~/Affy|Illumina/;  ## only showing genotyping chip sets
-    if($vs =~/Genotyping chip variants/){  ## tidy up display for human
-	$vs =~ s/Genotyping chip variants \(|\)//g;
-	@genotyping_sets_list = split/\,/,  $vs;
-    }
-    else{
-	push @genotyping_sets_list,  $vs;
-    }
+      push @genotyping_sets_list,  $vs->name();    
   }
   my $count = scalar @genotyping_sets_list;  
   

--- a/modules/EnsEMBL/Web/Object/Variation.pm
+++ b/modules/EnsEMBL/Web/Object/Variation.pm
@@ -1141,6 +1141,20 @@ sub get_variation_sets {
   return $sets;
 }
 
+sub get_variation_sub_sets {
+
+  my $self          = shift;
+  my $superset_name = shift;
+
+  my $vari_set_adaptor = $self->hub->database('variation')->get_VariationSetAdaptor;
+
+  my $superset_obj = $vari_set_adaptor->fetch_by_name($superset_name);
+
+  my $sets = $vari_set_adaptor->fetch_all_by_Variation_super_VariationSet($self->vari, $superset_obj); 
+  return $sets;
+}
+
+
 # Variation mapping ###########################################################
 
 


### PR DESCRIPTION
This is a small change to improve the genotyping chip code which will allow EnsemblGenomes to display different chip name types. It depends on a new method in the VariationSet adaptor.
