### PR TITLE
Allow text string '0' to be rendered

### DIFF
--- a/modules/Sanger/Graphics/Renderer/gif.pm
+++ b/modules/Sanger/Graphics/Renderer/gif.pm
@@ -163,7 +163,7 @@ sub render_Rect {
 sub render_Text {
   my ($self, $glyph) = @_;
 
-  return unless $glyph->{'text'};
+  return unless length $glyph->{'text'};
   my $font   = $glyph->font();
   my $colour = $self->colour($glyph->{'colour'});
 


### PR DESCRIPTION
Check for string length instead of truthiness when rendering text.
