### PR TITLE
Experiment/FeatureEvidence source_label/info changes

### DIFF
--- a/modules/EnsEMBL/Web/Object/Experiment.pm
+++ b/modules/EnsEMBL/Web/Object/Experiment.pm
@@ -81,23 +81,17 @@ sub new {
   # Get info for all feature sets and pack it in an array of hashes
   foreach my $feature_set (@$feature_sets) {
 
-    my $input_set = $feature_set->get_InputSet;
+    my $experiment = $feature_set->experiment;
 
-    if (! defined $input_set) {
-      warn "Failed to get InputSet for FeatureSet:\t".$feature_set->name;
-      next;
-    }
-
-    my $experiment = $input_set->get_Experiment;
     if (! defined $experiment) {
-      warn "Failed to get Experiment for InputSet:\t".$input_set->name;
+      warn "Failed to get Experiment for FeatureSet:\t".$feature_set->name;
       next;
     }
 
     my $experiment_group  = $experiment->experimental_group;
     $experiment_group     = undef unless $experiment_group->is_project;
     my $project_name      = $experiment_group ? $experiment_group->name : '';
-    my $source_info       = $input_set->source_info; # returns [[source_label, source_link], [source_label, source_link], ...]
+    my $source_info       = $experiment->source_info; # returns [[source_label, source_link], [source_label, source_link], ...]
     my $cell_type         = $feature_set->cell_type;
     my $cell_type_name    = $cell_type->name;
     my $feature_type      = $feature_set->feature_type;

--- a/modules/EnsEMBL/Web/ZMenu/FeatureEvidence.pm
+++ b/modules/EnsEMBL/Web/ZMenu/FeatureEvidence.pm
@@ -27,8 +27,7 @@ sub content {
   my $hub                 = $self->hub;
   my $db_adaptor          = $hub->database($hub->param('fdb'));
   my $feature_set         = $db_adaptor->get_FeatureSetAdaptor->fetch_by_name($hub->param('fs')); 
-  my $input_set           = $feature_set->get_InputSet;
-  my ($chr, $start, $end) = split /\:|\-/g, $hub->param('pos'); 
+  my ($chr, $start, $end) = split /\:|\-/, $hub->param('pos'); 
   my $length              = $end - $start + 1;
   my $slice               = $hub->database('core')->get_SliceAdaptor->fetch_by_region('toplevel', $chr, $start, $end);
   my @a_features          = @{$db_adaptor->get_AnnotatedFeatureAdaptor->fetch_all_by_Slice($slice)};
@@ -58,21 +57,17 @@ sub content {
     label => $feature_set->display_label
   });
 
-  if ($input_set) {
-    my $source_info = $input_set->source_info; 
-    my $experiment_link = "";
 
-    foreach my $source (@{$source_info}){ 
-      my $source_link = sprintf '<a href="%s">%s</a> ',
-      $hub->url({'type' => 'Experiment', 'action' => 'Sources', 'ex' => 'name-'.$feature_set->name}),
-      $source->[0];
-      $experiment_link .= "$source_link";
-    }
+  my $source_label = $feature_set->source_label;
+
+  if(defined $source_label){
 
     $self->add_entry({
       type        => 'Source',
-      label_html  =>  $experiment_link
-    });
+      label_html  =>  sprintf '<a href="%s">%s</a> ',
+                      $hub->url({'type' => 'Experiment', 'action' => 'Sources', 'ex' => 'name-'.$feature_set->name}),
+                      $source_label
+                     });
   }
 
   my $loc_link = sprintf '<a href="%s">%s</a>', 


### PR DESCRIPTION
Experiment: Updated FeatureSet->input_set calls to use experiment. FeatureEvidence: Changed to use source_label instead of source_info. Saves 3 trips to the DB and should integrate project name when there is also an archive ID
