### PR TITLE
MetaDataBlast does not need to be loaded at start-up

### DIFF
--- a/conf/perl.startup
+++ b/conf/perl.startup
@@ -252,8 +252,6 @@ if (Apache2::ServerUtil::restart_count == 1) { # Only parse the config on first 
   $conf->ENSEMBL_BASE_URL, $conf->ENSEMBL_JSCSS_TYPE, $conf->ENSEMBL_CSS_NAME,
   $conf->ENSEMBL_BASE_URL, $conf->ENSEMBL_JSCSS_TYPE, $conf->ENSEMBL_JS_NAME,
   join("\n                     ", grep(/::/, @{$conf->ENSEMBL_PLUGINS || []}), $extra);
-  
-  require EnsEMBL::Web::BlastView::MetaDataBlast;
 }
 
 1;


### PR DESCRIPTION
Also, this only loads the core module and does not load any plugins that may override it.
For Ensembl Genomes we have to override this module because our BLAST set-up is not compatible with the core module. We can't start our server until we remove this line.
