### PR TITLE
Fixed intermediate tree display for ncRNAtrees

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
@@ -653,9 +653,12 @@ sub features {
     my %leaves;
 
     my $species_tree_node_id = $tree->get_tagvalue('species_tree_node_id');
-    my $speciesTreeNode      = $tree->adaptor->db->get_SpeciesTreeNodeAdaptor->fetch_node_by_node_id($species_tree_node_id);
-    my $node_name            = $self->species_defs->multi_hash->{'DATABASE_COMPARA'}{'TAXON_NAME'}->{$speciesTreeNode->taxon_id}
-                               || $speciesTreeNode->node_name;
+    my $node_name;
+    if (defined $species_tree_node_id) {
+        my $speciesTreeNode      = $tree->adaptor->db->get_SpeciesTreeNodeAdaptor->fetch_node_by_node_id($species_tree_node_id);
+        $node_name               = $self->species_defs->multi_hash->{'DATABASE_COMPARA'}{'TAXON_NAME'}->{$speciesTreeNode->taxon_id}
+            || $speciesTreeNode->node_name;
+    }
 
     foreach my $leaf (@{$tree->get_all_leaves}) {
       my $dist = $leaf->distance_to_ancestor($tree);


### PR DESCRIPTION
Due to a data bug the intermediate ncRNAtrees don't have the 'species_tree_node_id' tag. This fix tries to alleviate this problem. The Z-menus of these trees will not be working fine, but at least we have trees to display.
