### PR TITLE
Update the newick formats for gene trees

### DIFF
--- a/modules/EnsEMBL/Web/Constants.pm
+++ b/modules/EnsEMBL/Web/Constants.pm
@@ -182,7 +182,6 @@ sub NEWICK_OPTIONS {
     'species_short_name'      => 'Short species name',
     'ncbi_taxon'              => 'NCBI taxon',
     'ncbi_name'               => 'NCBI name',
-    'njtree'                  => 'NJ tree',
     'phylip'                  => 'PHYLIP',
   );
 }


### PR DESCRIPTION
The "NJ tree" format for gene trees has been removed. It is the same as "NCBI taxon".
