### PR TITLE
Compara self-alignments

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/Compara.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara.pm
@@ -160,11 +160,16 @@ sub mlss_data {
         $species->{$ref_name}++;
 
         ## Build data matrix
-        foreach my $nonref_db (@{$mlss->species_set_obj->genome_dbs}) {
-          $species->{ucfirst($nonref_db->name)}++;
-          if ($mlss->source eq "ucsc" || ($nonref_db->dbID != $ref_genome_db->dbID)) {
+        my @non_ref_genome_dbs = grep {$_->dbID != $ref_genome_db->dbID} @{$mlss->species_set_obj->genome_dbs};
+        if (scalar(@non_ref_genome_dbs)) {
+          # Alignment between 2+ species
+          foreach my $nonref_db (@non_ref_genome_dbs) {
+            $species->{ucfirst($nonref_db->name)}++;
             $data->{$ref_name}{ucfirst($nonref_db->name)} = [$method, $mlss->dbID];
           }
+        } else {
+            # Self-alignment. No need to increment $species->{$ref_name} as it has been done earlier
+            $data->{$ref_name}{$ref_name} = [$method, $mlss->dbID];
         }
       }
     }


### PR DESCRIPTION
http://staging.ensembl.org/info/genome/compara/analyses.html doesn't show human-vs-human any more.
This is because we now compute this alignment in-house instead of importing it from UCSC.

The code that generates the list assumes that only UCSC self-alignments are allowed, and this commits fixes that assumption.

NB: I haven't tried it on my sandbox. I could do it later today / tomorrow as I have to test another change anyway
