### PR TITLE
Check if useScore is set before trying to use the score method

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/_alignment.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/_alignment.pm
@@ -330,7 +330,7 @@ sub render_normal {
       }
       $on_screen++;
       
-      if ($config) {
+      if ($config->{'useScore'}) {
         my $score = $feat[0][2]->score || 0;
         
         # implicit_colour means that a colour has been arbitrarily assigned


### PR DESCRIPTION
Checking for the config hash alone is not enough; it may exist for features that don't have a score method, e.g. probe features
