### PR TITLE
Added error handling for Assembly Converter. 

### DIFF
--- a/modules/EnsEMBL/Web/Component/UserData/PreviewConvert.pm
+++ b/modules/EnsEMBL/Web/Component/UserData/PreviewConvert.pm
@@ -37,6 +37,10 @@ sub caption {
 
 sub content {
   my $self = shift;
+
+  if ($self->hub->param('error')) {
+    return $self->error();
+  }
   my $object = $self->object;
   my $html = qq(<h2>Preview converted file(s)</h2>
 <p>The first ten lines of each file are displayed below. Click on the file name to download the complete file</p>
@@ -79,6 +83,15 @@ sub content {
     }
   }
   
+  return $html;
+}
+
+sub error { 
+  my $self = shift;
+
+  my $html = qq(<h2>Preview converted file(s)</h2>);
+  $html .= '<p>Sorry, there was a problem uploading your data.</p>';
+  $html .= "<p>Error: ".$self->hub->param('error')."</p>";
   return $html;
 }
 


### PR DESCRIPTION
In my particular case, when there is no seq_region, it fails and shows an ajax error.
https://www.ebi.ac.uk/panda/jira/browse/ENSEMBL-3241
Now it can show a returned error.
Test scenario:
1. go to Tools > Assembly Converter
2. Copy& paste the below in the Paste data field.
Chr1 26346 26453 MACS_peak_1 36.18
Chr1 43809 43930 MACS_peak_2 25.28
Chr1 48424 48491 MACS_peak_3 32.64
3. Click submit.
