### PR TITLE
Remove base pair rounding in location string

### DIFF
--- a/modules/EnsEMBL/Web/Component/Transcript/DomainGenes.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/DomainGenes.pm
@@ -106,7 +106,7 @@ sub content {
     my $readable_location = sprintf(
       '%s: %s',
       $self->neat_sr_name($gene->slice->coord_system->name, $gene->slice->seq_region_name),
-      $self->round_bp($gene->start)
+      $gene->start
     );
     
     $row->{'loc'}= sprintf '<a href="%s">%s</a>', $hub->url({ type => 'Location', action => 'View', g => $stable_id, __clear => 1}), $readable_location;


### PR DESCRIPTION
Makes no sense to do rounding on an exact location (?)

e.g. see genome location column here http://www.ensembl.org/Homo_sapiens/Transcript/Domains/Genes?db=core;domain=IPR001766;g=ENSG00000128573;r=6:165317945-168116556;t=ENST00000403559
