### PR TITLE
Mice are not the only Mus

### DIFF
--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -252,7 +252,7 @@ sub transcript_table {
        { key => 'biotype',    sort => 'html',    title => 'Biotype'       },
     );
 
-    push @columns, { key => 'ccds', sort => 'html', title => 'CCDS' } if $species =~ /^Homo|Mus/;
+    push @columns, { key => 'ccds', sort => 'html', title => 'CCDS' } if $species =~ /^Homo_sapiens|Mus_musculus/;
     
     my @rows;
    


### PR DESCRIPTION
E.g. ferret (mustela putorius furo) and housefly (musca domestica)

Must be a better solution; CCDS flag in the meta table? Or maybe process the transcript data before building the table and only include the column if $ccds got populated - might not be a good solution if there is significance in showing absence of CCDS.
