### PR TITLE
bugfix: contrained elements [Ensembl #414558]

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/_alignment_multiple.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/_alignment_multiple.pm
@@ -68,7 +68,7 @@ sub draw_features {
   #colours to distinguish alternating features for GenomicAlignBlock objects only 
   my @block_colours;
   if ($constrained_element) {
-      push @block_colours, $feature_colour;
+      @block_colours = ($feature_colour, $feature_colour);
   } else {
       @block_colours =($feature_colour, $self->{'config'}->colourmap->mix($feature_colour,'white',0.5));
 


### PR DESCRIPTION
This fixes a bug reported by Kathryn
The problem is that only alternate constrained elements are displayed
e.g. the 2 displays differ by 10 bases and show different alternate constrained elements
http://www.ensembl.org/Homo_sapiens/Share/52ec3510c99fd366db80fd610d0cf8d0146396359
http://www.ensembl.org/Homo_sapiens/Share/140a3c4e7efab265ae337bcddb1e1829146396359

I think the problem is in the file
ensembl-webcode/modules/EnsEMBL/Draw/GlyphSet/_alignment_multiple.pm in sub
draw_features. I added an array @block_colours to enable the shading of
alternate GenomicAlignBlocks to help distinguish them when they were next
to one another. Originally this was also done for the constrained elements
but we decided that these were better as a single colour. However, the
@block_colours array has 2 colours for GenomicAlignBlocks but only one
colour for constrained elements:

  #colours to distinguish alternating features for GenomicAlignBlock objects only
  my @block_colours;
  if ($constrained_element) {
      push @block_colours, $feature_colour;
  } else {
      @block_colours =($feature_colour, $self->{'config'}->colourmap->mix($feature_colour,'white',0.5));

  }

I think a solution is to add another $feature_colour when using $constrained_element
e.g.
if ($constrained_element) {
    @block_colours = ($feature_colour, $feature_colour);
} else {
    …..
}
