### PR TITLE
Constrain lower boundary

### DIFF
--- a/modules/EnsEMBL/Web/Component/Location/ViewBottomNav.pm
+++ b/modules/EnsEMBL/Web/Component/Location/ViewBottomNav.pm
@@ -191,6 +191,7 @@ sub nav_url {
   ($s, $e) = (1, $e - $s || 1) if $s < 1;
   ($s, $e) = ($max - ($e - $s), $max) if $e > $max;
   
+  $s = 1  if $s < 1;
   $s = $e if $s > $e;
   
   return $object->seq_region_name . ":$s-$e" if $self->{'update'};


### PR DESCRIPTION
If the new window is wider than the whole region, the current logic will result in a negative start position, so we need check and to adjust back to 1.
