### PR TITLE
Species groups in the gene-tree stats page

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/Compara/GeneTrees.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara/GeneTrees.pm
@@ -173,10 +173,13 @@ List of available views:
 
 } elsif ($page eq 'coverage')  {
 
+    my $n_group = scalar(@$ordered_species)-1;
     $html .= q{<h2>Gene-tree coverage (per species)</h2>};
+    $html .= '<p>Quick links: '.join(', ', map {sprintf('<a href="#cladegroup%d">%s</a>', $_, $ordered_species->[$_]->[0])} 1..$n_group).'</p>' if scalar(@$ordered_species) > 1;
     $html .= $self->piechart_header([qw(#fc0 #909 #69f #a22 #25a #8a2)]);
-    foreach my $set (@$ordered_species) {
-      $html .= sprintf('<h3>%s</h3>', ucfirst $set->[0] || 'Others') if scalar(@$ordered_species) > 1;
+    for (0..$n_group) {
+      my $set = $ordered_species->[$_];
+      $html .= sprintf('<h3><a name="cladegroup%d"></a>%s</h3>', $_, ucfirst $set->[0] || 'Others') if scalar(@$ordered_species) > 1;
       $html .= $self->get_html_for_gene_tree_coverage($set->[0], $set->[1], $method, \$counter_raphael_holders);
     }
 


### PR DESCRIPTION
Anne noticed that the species order on http://www.ensembl.org/info/genome/compara/prot_tree_stats.html?page=coverage was not ideal: Laurasiatheria at the top, species not in the alphabetical order.
We then realised that the species groups used on this page are the Compara ones (we store them in our database) and not the groups defined on the main site (cf the drop down list of species on the first page)

With this commit, the Ensembl groups are now used on the gene-tree stats page. I've also added the favourite species on top, and some quick-links within the page.
See result on my sandbox: http://enssand-01.internal.sanger.ac.uk:9073/info/genome/compara/prot_tree_stats.html?page=coverage
