### PR TITLE
Rely on the Compara-defined descriptions of homologies

### DIFF
--- a/modules/EnsEMBL/Web/Constants.pm
+++ b/modules/EnsEMBL/Web/Constants.pm
@@ -103,17 +103,6 @@ sub APPRIS_CODES {
   };
 }
 
-sub HOMOLOGY_TYPES {
-### Lookup for compara acronyms
-  return {
-    'BRH'  => 'Best Reciprocal Hit',
-    'UBRH' => 'Unique Best Reciprocal Hit',
-    'MBRH' => 'Multiple Best Reciprocal Hit',
-    'RHS'  => 'Reciprocal Hit based on Synteny around BRH',
-    'DWGA' => 'Derived from Whole Genome Alignment'
-  };
-}
-
 sub GENE_JOIN_TYPES {
 ### Another compara lookup, this time for orthologues,
 ### paralogues, etc

--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -33,7 +33,7 @@ use strict;
 
 use EnsEMBL::Web::Constants; 
 use EnsEMBL::Web::Cache;
-use Bio::EnsEMBL::Compara::GenomeDB;
+use Bio::EnsEMBL::Compara::Homology;
 
 use Time::HiRes qw(time);
 
@@ -720,19 +720,6 @@ sub get_homology_matches {
     my $adaptor_call = $self->param('gene_adaptor') || 'get_GeneAdaptor';
     my %homology_list;
 
-    # Convert descriptions into more readable form
-    my %desc_mapping = (
-      ortholog_one2one          => '1-to-1',
-      apparent_ortholog_one2one => '1-to-1 (apparent)', 
-      ortholog_one2many         => '1-to-many',
-      possible_ortholog         => 'possible ortholog',
-      ortholog_many2many        => 'many-to-many',
-      within_species_paralog    => 'paralogue (within species)',
-      other_paralog             => 'other paralogue (within species)',
-      putative_gene_split       => 'putative gene split',
-      contiguous_gene_split     => 'contiguous gene split'
-    );
-    
     foreach my $display_spp (keys %$homologues) {
       my $order = 0;
       
@@ -746,7 +733,7 @@ sub get_homology_matches {
         next if $homology_list{$display_spp}{$homologue->stable_id} && $homology_desc eq 'other_paralog';
         
         $homology_list{$display_spp}{$homologue->stable_id} = { 
-          homology_desc       => $desc_mapping{$homology_desc} || 'no description',
+          homology_desc       => $Bio::EnsEMBL::Compara::Homology::PLAIN_TEXT_WEB_DESCRIPTIONS{$homology_desc} || 'no description',
           description         => $homologue->description       || 'No description',
           display_id          => $homologue->display_label     || 'Novel Ensembl prediction',
           homology_subtype    => $homology_subtype,

--- a/modules/EnsEMBL/Web/Object/LRG.pm
+++ b/modules/EnsEMBL/Web/Object/LRG.pm
@@ -22,6 +22,7 @@ use strict;
 
 use Time::HiRes qw(time);
 use Bio::EnsEMBL::Compara::GenomeDB;
+use Bio::EnsEMBL::Compara::Homology;
 use Exporter;
 
 use EnsEMBL::Web::Cache;
@@ -756,19 +757,6 @@ sub get_homology_matches {
     my $adaptor_call  = $self->param('gene_adaptor') || 'get_GeneAdaptor';
     my %homology_list;
 
-    # Convert descriptions into more readable form
-    my %desc_mapping = (
-      'ortholog_one2one'          => '1-to-1',
-      'apparent_ortholog_one2one' => '1-to-1 (apparent)', 
-      'ortholog_one2many'         => '1-to-many',
-      'between_species_paralog'   => 'paralogue (between species)',
-      'ortholog_many2many'        => 'many-to-many',
-      'within_species_paralog'    => 'paralogue (within species)',
-      'other_paralog'             => 'other paralogue (within species)',
-      'putative_gene_split'       => 'putative gene split',
-      'contiguous_gene_split'     => 'contiguous gene split'
-    );
-    
     foreach my $display_spp (keys %$homologues){
       my $order = 0;
       
@@ -781,7 +769,7 @@ sub get_homology_matches {
         next if $homology_list{$display_spp}{$homologue->stable_id} && $homology_desc eq 'other_paralog';
  
         $homology_list{$display_spp}{$homologue->stable_id} = {
-          homology_desc       => $desc_mapping{$homology_desc} || 'no description',
+          homology_desc       => $Bio::EnsEMBL::Compara::Homology::PLAIN_TEXT_WEB_DESCRIPTIONS{$homology_desc} || 'no description',
           description         => $homologue->description       || 'No description',
           display_id          => $homologue->display_label     || 'Novel Ensembl prediction',
           homology_subtype    => $homology_subtype,


### PR DESCRIPTION
I have defined the plain-text descriptions of the homology types in the Compara Homology module. It simplifies the webcode a lot :) !

I've also changed the call to the HomologyAdaptor to only get orthologues / paralogues depending on the view

Finally, I had to define two descriptions for the orthology types because they're only displayed as "1-to-1" in the table, but a true description should rather be "1-to-1 orthologues"
So the table of homologues uses %PLAIN_TEXT_WEB_DESCRIPTIONS, whereas the alignment page uses %PLAIN_TEXT_DESCRIPTIONS
# List of orthologues

http://enssand-01.internal.sanger.ac.uk:9073/Homo_sapiens/Gene/Compara_Ortholog?g=ENSG00000139618;r=13:32315474-32400266
# Alignment of orthologues

http://enssand-01.internal.sanger.ac.uk:9073/Homo_sapiens/Gene/Compara_Ortholog/Alignment?db=core;g=ENSG00000073910;g1=ENSVPAG00000010883;r=13:32031300-32299122
# List of paralogues

http://enssand-01.internal.sanger.ac.uk:9073/Homo_sapiens/Gene/Compara_Paralog?g=ENSG00000073910;r=13:32031300-32299122
# Alignment of paralogues

enssand-01.internal.sanger.ac.uk:9073/Homo_sapiens/Gene/Compara_Ortholog/Alignment?db=core;g=ENSG00000073910;g1=ENSVPAG00000010883;r=13:32031300-32299122
