### PR TITLE
force flagged variants to be displayed

### DIFF
--- a/modules/EnsEMBL/Web/Factory/Variation.pm
+++ b/modules/EnsEMBL/Web/Factory/Variation.pm
@@ -42,7 +42,8 @@ sub createObjects {
     
     my $variation_db = $dbs->{'variation'};
        $variation_db->include_non_significant_phenotype_associations(0);
-    
+       $variation_db->include_failed_variations(1);    
+
     return $self->problem('fatal', 'Database Error', 'Could not connect to the variation database.') unless $variation_db;
     
     $variation_db->dnadb($dbs->{'core'});


### PR DESCRIPTION
Hi,

The QC-failed variants are behaving oddly on staging, it looks as if the db->include_failed_variations flag is being lost sometimes triggering the 'Could not find variation rs..' message when additional panels are launched from the side bar. An example is:

http://staging.ensembl.org/Homo_sapiens/Variation/Explore?v=rs16990303

If no one is looking at this one already, this PR would fix the problem.

Sarah 
