### PR TITLE
Do not link out if we're missing the extra data

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/Compara.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara.pm
@@ -165,11 +165,11 @@ sub mlss_data {
           # Alignment between 2+ species
           foreach my $nonref_db (@non_ref_genome_dbs) {
             $species->{ucfirst($nonref_db->name)}++;
-            $data->{$ref_name}{ucfirst($nonref_db->name)} = [$method, $mlss->dbID];
+            $data->{$ref_name}{ucfirst($nonref_db->name)} = [$method, $mlss->dbID, $mlss->has_tag('ref_mis_matches')];
           }
         } else {
             # Self-alignment. No need to increment $species->{$ref_name} as it has been done earlier
-            $data->{$ref_name}{$ref_name} = [$method, $mlss->dbID];
+            $data->{$ref_name}{$ref_name} = [$method, $mlss->dbID, $mlss->has_tag('ref_mis_matches')];
         }
       }
     }
@@ -277,11 +277,11 @@ sub draw_stepped_table {
       else {
         $cbg = $j % 2 ? 'bg3' : 'bg4';
       }
-      my ($method, $mlss_id) = @{$data->{$other_species}{$species}||[]};
+      my ($method, $mlss_id, $with_extra_info) = @{$data->{$other_species}{$species}||[]};
       my $content = '-';
 
       if ($mlss_id) {
-        if ($method eq 'SYNTENY') {
+        if (($method eq 'SYNTENY') or not $with_extra_info) {
           $content = '<b>YES</b>';
         }
         else {

--- a/modules/EnsEMBL/Web/Document/HTML/Compara/BlastZ.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara/BlastZ.pm
@@ -44,10 +44,13 @@ sub render {
       my $values = $data->{$sp}{$other};
       next unless $values;  
         
-      my $mlss_id = $values->[1];
-      my $url = '/info/genome/compara/mlss.html?mlss='.$mlss_id;
-      $html .= sprintf '<li><a href="%s">%s (%s)</a></li>', 
-                          $url, $info->{$other}{'common_name'}, $info->{$other}{'long_name'};
+      if ($values->[2]) {
+          my $mlss_id = $values->[1];
+          my $url = '/info/genome/compara/mlss.html?mlss='.$mlss_id;
+          $html .= sprintf '<li><a href="%s">%s (%s)</a></li>', $url, $info->{$other}{'common_name'}, $info->{$other}{'long_name'};
+      } else {
+          $html .= sprintf('<li>%s (%s)</li>', $info->{$other}{'common_name'}, $info->{$other}{'long_name'});
+      }
     } 
     $html .= '</ul>';
   }


### PR DESCRIPTION
If we haven't included the statistics, parameters, etc, data for a pairwise
alignment, we shouldn't provide a link to that page

This will fix https://rt.sanger.ac.uk/Ticket/Display.html?id=424264 

Test:
http://enssand-01.internal.sanger.ac.uk:9073/info/genome/compara/analyses.html
http://test.ensembl.org/info/genome/compara/analyses.html
