### PR TITLE
Clean up the code by using the Variation flag 'include_failed_variations...

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -194,9 +194,8 @@ sub variation_source {
 
 sub co_located {
   my ($self, $feature_slice) = @_;
-  my $hub        = $self->hub;
-  my $adaptor    = $hub->get_adaptor('get_VariationFeatureAdaptor', 'variation');
-  $adaptor->db->include_failed_variations(1);
+  my $hub     = $self->hub;
+  my $adaptor = $hub->get_adaptor('get_VariationFeatureAdaptor', 'variation');
 
   my $slice;
   if ($feature_slice->start > $feature_slice->end) { # Insertion
@@ -696,7 +695,7 @@ sub most_severe_consequence {
       });
  
       my $html = sprintf(
-         '%s | <a href="%s">See all predicted consequences <small>[Genes and regulation]</small></a>',
+         '<div>%s | <a href="%s">See all predicted consequences <small>[Genes and regulation]</small></a></div>',
          $self->render_consequence_type($vf_object,1),
          $url
       );

--- a/modules/EnsEMBL/Web/Factory/Feature.pm
+++ b/modules/EnsEMBL/Web/Factory/Feature.pm
@@ -115,7 +115,6 @@ sub _create_Phenotype {
   
   my $id         = $self->param('id');   
   my $dbc        = $self->hub->database('variation');
-	$dbc->include_failed_variations(1);
   my $a          = $dbc->get_adaptor('VariationFeature');
   my $func       = $self->param('somatic') ? 'fetch_all_somatic_with_phenotype' : 'fetch_all_with_phenotype';
   my $variations = $a->$func(undef, undef, $id);

--- a/modules/EnsEMBL/Web/Factory/Phenotype.pm
+++ b/modules/EnsEMBL/Web/Factory/Phenotype.pm
@@ -54,7 +54,6 @@ sub createObjects {
 
     my $dbc = $self->hub->database('variation');
     return unless $dbc;
-    $dbc->include_failed_variations(1);
     $dbc->include_non_significant_phenotype_associations(0);    
     my $adaptor = $dbc->get_adaptor('PhenotypeFeature');
 

--- a/modules/EnsEMBL/Web/Factory/StructuralVariation.pm
+++ b/modules/EnsEMBL/Web/Factory/StructuralVariation.pm
@@ -36,8 +36,7 @@ sub createObjects {
    
   if (!$structural_variation) {
     return $self->problem('fatal', 'Structural Variation ID required', $self->_help('A structural variation ID is required to build this page.')) unless $identifier;
-    
-    $db->include_failed_variations(1);
+
     $db->include_non_significant_phenotype_associations(0);
     
     $structural_variation = $db->get_StructuralVariationAdaptor->fetch_by_name($identifier);

--- a/modules/EnsEMBL/Web/Factory/Variation.pm
+++ b/modules/EnsEMBL/Web/Factory/Variation.pm
@@ -42,7 +42,6 @@ sub createObjects {
     
     my $variation_db = $dbs->{'variation'};
        $variation_db->include_non_significant_phenotype_associations(0);
-       $variation_db->include_failed_variations(1);    
 
     return $self->problem('fatal', 'Database Error', 'Could not connect to the variation database.') unless $variation_db;
     

--- a/modules/EnsEMBL/Web/Hub.pm
+++ b/modules/EnsEMBL/Web/Hub.pm
@@ -211,6 +211,10 @@ sub database {
 
   if ($_[0] =~ /compara/) {
     return Bio::EnsEMBL::Registry->get_DBAdaptor('multi', $_[0], 1);
+  } elsif ($_[0] =~ /variation/) {
+    my $dba = $self->databases->get_DBAdaptor(@_);
+    $dba->include_failed_variations(1); # Force to display failed variants
+    return $dba;
   } else {
     return $self->databases->get_DBAdaptor(@_);
   }


### PR DESCRIPTION
...(1)' in the Hub module, instead of setting the flag in every module where a Variation adaptor is created
