### PR TITLE
bugfix: expand all sub-trees

### DIFF
--- a/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
@@ -135,7 +135,7 @@ sub content {
       label         => 'expand all sub-trees',
       link_class    => 'update_panel',
       order         => 8,
-      update_params => '<input type="hidden" class="update_url" name="collapse" value="none" />',
+      update_params => qq{<input type="hidden" class="update_url" name="collapse" value="$collapse" />},
       link          => $hub->url('Component', {
         type     => $hub->type,
         action   => $action,


### PR DESCRIPTION
The initial RT ticket was #373851, and was supposed to be fixed by the #5,
but it appears that the fix was only partial (RT #428238)
The "collapse" field was only updated in the ZMenu, but not in the URL
