### PR TITLE
Some external files fail to attach when using proxy

### DIFF
--- a/modules/Bio/EnsEMBL/ExternalData/AttachedFormat/BAM.pm
+++ b/modules/Bio/EnsEMBL/ExternalData/AttachedFormat/BAM.pm
@@ -37,7 +37,7 @@ sub check_data {
   my $error = '';
   require Bio::DB::Sam;
 
-  $url = chase_redirects($url);
+  $url = $self->chase_redirects($url);
 
   if ($url =~ /^ftp:\/\//i && !$self->{'hub'}->species_defs->ALLOW_FTP_BAM) {
     $error = "The bam file could not be added - FTP is not supported, please use HTTP.";

--- a/modules/Bio/EnsEMBL/ExternalData/AttachedFormat/BIGBED.pm
+++ b/modules/Bio/EnsEMBL/ExternalData/AttachedFormat/BIGBED.pm
@@ -49,7 +49,7 @@ sub check_data {
   my $error = '';
   require Bio::DB::BigFile;
 
-  $url = chase_redirects($url);
+  $url = $self->chase_redirects($url);
   if ($url =~ /^ftp:\/\//i && !$self->{'hub'}->species_defs->ALLOW_FTP_BIGWIG) {
     $error = "The BigBed file could not be added - FTP is not supported, please use HTTP.";
   }

--- a/modules/Bio/EnsEMBL/ExternalData/AttachedFormat/BIGWIG.pm
+++ b/modules/Bio/EnsEMBL/ExternalData/AttachedFormat/BIGWIG.pm
@@ -33,7 +33,7 @@ sub check_data {
   my $error = '';
   require Bio::DB::BigFile;
 
-  $url = chase_redirects($url);
+  $url = $self->chase_redirects($url);
   if ($url =~ /^ftp:\/\//i && !$self->{'hub'}->species_defs->ALLOW_FTP_BIGWIG) {
     $error = "The BigWig file could not be added - FTP is not supported, please use HTTP.";
   }

--- a/modules/Bio/EnsEMBL/ExternalData/AttachedFormat/DATAHUB.pm
+++ b/modules/Bio/EnsEMBL/ExternalData/AttachedFormat/DATAHUB.pm
@@ -43,7 +43,7 @@ sub check_data {
   my $url  = $self->{'url'};
   my $error;
   
-  $url = chase_redirects($url);
+  $url = $self->chase_redirects($url);
   # try to open and use the datahub file
   # this checks that the datahub files is present and correct
   my $datahub = $self->{'datahub_adaptor'}->get_hub_info($url);

--- a/modules/Bio/EnsEMBL/ExternalData/AttachedFormat/VCF.pm
+++ b/modules/Bio/EnsEMBL/ExternalData/AttachedFormat/VCF.pm
@@ -32,7 +32,7 @@ sub check_data {
   my $error = '';
   require Bio::EnsEMBL::ExternalData::VCF::VCFAdaptor;
 
-  $url = chase_redirects($url);
+  $url = $self->chase_redirects($url);
   if ($url =~ /^ftp:\/\//i && !$self->{'hub'}->species_defs->ALLOW_FTP_VCF) {
     $error = "The VCF file could not be added - FTP is not supported, please use HTTP.";
   } 

--- a/modules/EnsEMBL/Web/Command/UserData/AttachRemote.pm
+++ b/modules/EnsEMBL/Web/Command/UserData/AttachRemote.pm
@@ -92,7 +92,7 @@ sub process {
       
       delete $options->{'name'};
 
-      $url = chase_redirects($url);
+      $url = $self->chase_redirects($url);
 
       my $assemblies = $options->{'assemblies'}
                         || [$hub->species_defs->get_config($hub->data_species, 'ASSEMBLY_NAME')];

--- a/modules/EnsEMBL/Web/Tools/RemoteURL.pm
+++ b/modules/EnsEMBL/Web/Tools/RemoteURL.pm
@@ -9,13 +9,16 @@ our @EXPORT_OK = qw(chase_redirects);
 
 use LWP::UserAgent;
 
+use Data::Dumper;
+
 sub chase_redirects {
-  my ($url,$max_follow) = @_;
+  my ($self,$url,$max_follow) = @_;
 
   $max_follow = 10 unless defined $max_follow;
   my $ua = LWP::UserAgent->new( max_redirect => $max_follow );
   $ua->timeout(10);
   $ua->env_proxy;
+  $ua->proxy([qw(http https)], $self->{'hub'}->species_defs->ENSEMBL_WWW_PROXY) || ();
   my $response = $ua->head($url);
   return $response->request->uri->as_string if($response->is_success);
   return undef;


### PR DESCRIPTION
When a ENSEMBL_WWW_PROXY is specified, as we do in Ensembl Genomes, some external files fail to attach to the genome browser as the new(ish) EnsEMBL::Web::Tools::RemoteURL does not use the proxy.  This commit fixes that issue.
