### PR TITLE
Renamed "Protein families" to "Ensembl protein families"

### DIFF
--- a/modules/EnsEMBL/Web/Configuration/DataExport.pm
+++ b/modules/EnsEMBL/Web/Configuration/DataExport.pm
@@ -46,7 +46,7 @@ sub populate_tree {
   $self->create_node('Homologs', 'Alignments', ['alignments', 'EnsEMBL::Web::Component::DataExport::Homologs']);
   $self->create_node('Orthologs', 'Orthologues', ['orthologues', 'EnsEMBL::Web::Component::DataExport::Orthologs']);
   $self->create_node('Paralogs', 'Paralogues', ['paralogues', 'EnsEMBL::Web::Component::DataExport::Paralogs']);
-  $self->create_node('Family', 'Protein Family', ['family', 'EnsEMBL::Web::Component::DataExport::Family']);
+  $self->create_node('Family', 'Ensembl protein Family', ['family', 'EnsEMBL::Web::Component::DataExport::Family']);
   $self->create_node('GeneTree', 'Gene Tree', ['genetree', 'EnsEMBL::Web::Component::DataExport::GeneTree']);
   $self->create_node('SpeciesTree', 'Species Tree', ['species_tree', 'EnsEMBL::Web::Component::DataExport::SpeciesTree']);
 

--- a/modules/EnsEMBL/Web/Configuration/Gene.pm
+++ b/modules/EnsEMBL/Web/Configuration/Gene.pm
@@ -139,9 +139,9 @@ sub populate_tree {
   
   $compara_menu->append($pl_node);
   
-  my $fam_node = $self->create_node('Family', 'Protein families ([[counts::families]])',
+  my $fam_node = $self->create_node('Family', 'Ensembl protein families ([[counts::families]])',
     [qw( family EnsEMBL::Web::Component::Gene::Family )],
-    { 'availability' => 'family', 'concise' => 'Protein families' }
+    { 'availability' => 'family', 'concise' => 'Ensembl protein families' }
   );
   
   $fam_node->append($self->create_subnode('Family/Genes', uc($species_defs->get_config($hub->species, 'SPECIES_COMMON_NAME')) . ' genes in this family',

--- a/modules/EnsEMBL/Web/ViewConfig/Gene/Family.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Gene/Family.pm
@@ -34,7 +34,7 @@ sub init {
   });
   
   $self->code  = 'Gene::Family';
-  $self->title = 'Protein families';
+  $self->title = 'Ensembl protein families';
 }
 
 sub form {


### PR DESCRIPTION
"Protein families" is too ambiguous, especially in respect of resources like InterPro, etc

I have updated utils/indexing/indexXMLDumper . Can someone check it doesn't break something else downstream ?
