### PR TITLE
Genomic align tree

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
@@ -655,6 +655,7 @@ sub features {
   my @features;
   my $n_members = ($tree->isa('Bio::EnsEMBL::Compara::CAFEGeneFamilyNode'))? $tree->n_members : '';
   $cut = 0 if ($tree->isa('Bio::EnsEMBL::Compara::CAFEGeneFamilyNode')); #only for cafe tree, cut is 0 so that the branch are single blue line (no dotted or other colours)
+  $n_members = $tree->{_counter_position} if $tree->isa('Bio::EnsEMBL::Compara::GenomicAlignTree');
 
   my $f = {
     _distance    => $distance,

--- a/modules/EnsEMBL/Web/Component/Compara_Alignments.pm
+++ b/modules/EnsEMBL/Web/Component/Compara_Alignments.pm
@@ -351,9 +351,17 @@ sub draw_tree {
   #Get cigar lines from each Slice which will be passed to the genetree.pm drawing code
   my $slice_cigar_lines;
 
+  # The nodes should be in the same order as the slices, so we can match
+  # the internal nodes to the ancestral slices
+  my @internal_nodes = grep {not $_->is_leaf} @{$restricted_tree->get_all_sorted_genomic_align_nodes};
   foreach my $this_slice (@$slices) {
-    next if (lc($this_slice->{name}) eq "ancestral_sequences"); #skip cigar lines for ancestral seqs
-    push @$slice_cigar_lines, $this_slice->{cigar_line};
+    if (lc($this_slice->{name}) eq "ancestral_sequences") {
+      #skip cigar lines for ancestral seqs and transfer the counter_position flag
+      my $ga_node = shift @internal_nodes;
+      $ga_node->{_counter_position} = $this_slice->{_counter_position};
+    } else {
+      push @$slice_cigar_lines, $this_slice->{cigar_line};
+    }
   }
 
   #Get low coverage species from the EPO_LOW_COVERAGE species set
@@ -424,7 +432,7 @@ sub get_slice_table {
         $number_padding = length $end    if length $end    > $number_padding;
       }
       
-      if ($species eq 'Ancestral sequences') {
+      if ($species =~ /^Ancestral sequences/) {
         $table_rows .= $slice->{'_tree'};
         $ancestral_sequences = 1;
       } else {

--- a/modules/EnsEMBL/Web/Object.pm
+++ b/modules/EnsEMBL/Web/Object.pm
@@ -418,8 +418,18 @@ sub get_slices {
     };
     if ($name eq 'Ancestral_sequences') {
         $counter++;
-        $formatted_slices[-1]->{_counter_position} = $counter;
-        $formatted_slices[-1]->{display_name} .= " $counter";
+        my $ga_node = $formatted_slices[-1]->{underlying_slices}->[0]->{_node_in_tree};
+        my $removed_species = $_->{_align_slice}->{_removed_species};
+        # The current slice has to be discarded if it is an ancestral node
+        # that fully maps to hidden species on one of its sides
+        my $c1 = scalar(grep {not $removed_species->{$_->genomic_align_group->genome_db->name} } @{$ga_node->children->[0]->get_all_leaves});
+        my $c2 = scalar(grep {not $removed_species->{$_->genomic_align_group->genome_db->name} } @{$ga_node->children->[1]->get_all_leaves});
+        if ($c1 and $c2) {
+          $formatted_slices[-1]->{_counter_position} = $counter;
+          $formatted_slices[-1]->{display_name} .= " $counter";
+        } else {
+          pop @formatted_slices;
+        }
     }
 
     $length ||= $_->length; # Set the slice length value for the reference slice only

--- a/modules/EnsEMBL/Web/Object.pm
+++ b/modules/EnsEMBL/Web/Object.pm
@@ -400,6 +400,7 @@ sub get_slices {
     push @slices, $args->{slice}; # If no alignment selected then we just display the original sequence as in geneseqview
   }
 
+  my $counter = 0;
   foreach (@slices) {
     next unless $_;
     my $name = $_->can('display_Slice_name') ? $_->display_Slice_name : $args->{species};
@@ -415,6 +416,11 @@ sub get_slices {
       display_name      => $self->get_slice_display_name($name, $_),
       cigar_line        => $cigar_line,
     };
+    if ($name eq 'Ancestral_sequences') {
+        $counter++;
+        $formatted_slices[-1]->{_counter_position} = $counter;
+        $formatted_slices[-1]->{display_name} .= " $counter";
+    }
 
     $length ||= $_->length; # Set the slice length value for the reference slice only
   }


### PR DESCRIPTION
This fixes the issues raised by Paul in Hinxton#442240

- Prune the tree if the species are hidden (alignment lines are now in front of their species)
- Remove the unneeded ancestral species from the sequence view
- Ancestral sequences are now numbered and the numbers are used in the tree

Note that you'll have to update ensembl-compara as well to make this work.

Matthieu