### PR TITLE
Fix ASSEMBLY_VERSION bug - don't assume top rank will be 1 

### DIFF
--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -339,17 +339,14 @@ sub _summarise_core_tables {
 # * Assemblies...
 # This is a bit ugly, because there's no easy way to sort the assemblies via MySQL
   $t_aref = $dbh->selectall_arrayref(
-    'select version, attrib, rank from coord_system where version is not null' 
+    'select version, attrib from coord_system where version is not null order by rank' 
   );
   my (%default, %not_default);
   foreach my $row (@$t_aref) {
     my $version = $row->[0];
     my $attrib  = $row->[1];
-    my $rank    = $row->[2];
     if ($attrib =~ /default_version/) {
-      if ($rank == 1) {    
-        $self->db_tree->{'ASSEMBLY_VERSION'} = $version;
-      }
+      $self->db_tree->{'ASSEMBLY_VERSION'} ||= $version; # get top ranked default_version
       $default{$version}++;
     }
     else {


### PR DESCRIPTION
e.g. table may only contain ranks 3,4,5, in which case we want to choose 3