### PR TITLE
Preventing code from failure in case variation is undef. Lots of EG spec...

### DIFF
--- a/modules/EnsEMBL/Web/DBSQL/DBConnection.pm
+++ b/modules/EnsEMBL/Web/DBSQL/DBConnection.pm
@@ -139,12 +139,10 @@ sub get_databases_species {
   for my $database (@databases){
     unless( defined($self->{'_dbs'}->{$species}->{$database}) ) {
       my $dba = $reg->get_DBAdaptor( $species, $database );
-      if($database eq 'variation') {
-        $dba->include_failed_variations(1);
-      }
       if (!defined($dba) || $database eq 'glovar'){
         $self->_get_databases_common( $species, $database );
       } else{
+        $dba->include_failed_variations(1) if $database eq 'variation';
         $self->{'_dbs'}->{$species}->{$database} = $dba;
       }
     }


### PR DESCRIPTION
In EG some species have no variation DB. Changed to call include_failed_variation only in case variation db exists.