### PR TITLE
Allow for case where _prediction_transcript::href is called without a transcript

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/_prediction_transcript.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/_prediction_transcript.pm
@@ -50,6 +50,8 @@ sub features {
 sub href {
   my ($self, $gene, $transcript) = @_;
   
+  return $self->SUPER::href($gene) unless $transcript;
+  
   return $self->_url({
     type   => 'Transcript',
     action => 'Summary',


### PR DESCRIPTION
E.g. see call in parent class https://github.com/nicklangridge/ensembl-webcode/blob/master/modules/EnsEMBL/Draw/GlyphSet_transcript.pm#L129