### PR TITLE
Don't assume TAXON_LABEL is always set

### DIFF
--- a/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
@@ -136,7 +136,7 @@ sub form_fields {
                                               type   => 'DropDown', 
                                               select => 'select',
                                               name   => "group_${group}_display",
-                                              label  => "Display options for ".($self->hub->species_defs->TAXON_LABEL->{$group} || $group),
+                                              label  => "Display options for ".($self->hub->species_defs->TAXON_LABEL ? $self->hub->species_defs->TAXON_LABEL->{$group} || $group : $group),
                                               values => [ 
                                                           { value => 'default',  caption => 'Default behaviour' },
                                                           { value => 'hide',     caption => 'Hide genes' },


### PR DESCRIPTION
As far as I know TAXON_LABEL is not a compulsory field in every species ini file (but I'm not sure how to verify this...?)