### PR TITLE
Updated links to Decipher

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -494,8 +494,8 @@ DBSNPSS                  = http://www.ncbi.nlm.nih.gov/SNP/snp_ss.cgi?subsnp_id=
 DBSNPSSID                = http://www.ncbi.nlm.nih.gov/projects/SNP/snp_viewTable.cgi?handle=###ID###
 DBSTS_HOME               = http://www.ncbi.nlm.nih.gov/dbSTS/
 DBSTS                    = http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?db=unists&cmd=search&term=###ID###
-DDG2P                    = http://decipher.sanger.ac.uk/
-DECIPHER                 = https://decipher.sanger.ac.uk/patient/###ID####t_features
+DDG2P                    = https://decipher.sanger.ac.uk/
+DECIPHER                 = https://decipher.sanger.ac.uk/patient/###ID###
 DS                       = http://www-genome.wi.mit.edu/cgi-bin/contig/sts_info?sts=###ID###
 EC                       = http://www.expasy.ch/cgi-bin/nicezyme.pl?###ID###
 EC_PATHWAY               = http://srs.ebi.ac.uk/srsbin/cgi-bin/wgetz?-e+[ENZYME:###ID###]


### PR DESCRIPTION
Decipher is only available on https (http does a redirect).
#t_features no longer exists.