### PR TITLE
get_SimpleAlign is faster when called on GeneTree rather than GeneTreeNode

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -536,7 +536,7 @@ sub get_export_data {
       return $tree;
     }
     else {
-      return $tree->get_SimpleAlign;
+      return $tree->tree->get_SimpleAlign;
     }
   } 
 }


### PR DESCRIPTION
In this piece of code, $tree is in fact the root node of the tree. $tree->tree is the tree object itself
