### PR TITLE
get_SimpleAlign is faster when called on GeneTree rather than GeneTreeNode

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -547,7 +547,7 @@ sub get_export_data {
   }
   else {
     return $node ? $node->get_SimpleAlign(-APPEND_SP_SHORT_NAME => 1) 
-                 : $tree->get_SimpleAlign;
+                 : $tree->tree->get_SimpleAlign;
   }
 }
 


### PR DESCRIPTION
manually cherry-picked from 139351b (it couldn't be merged automatically)
