### PR TITLE
add SIFT low confidence prediction strings

### DIFF
--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -1219,7 +1219,15 @@ sub render_sift_polyphen {
     'benign'            => 'good',
     'unknown'           => 'neutral',
     'tolerated'         => 'good',
-    'deleterious'       => 'bad'
+    'deleterious'       => 'bad',
+    
+    # slightly different format for SIFT low confidence states
+    # depending on whether they come direct from the API
+    # or via the VEP's no-whitespace processing
+    'tolerated - low confidence'   => 'neutral',
+    'deleterious - low confidence' => 'neutral',
+    'tolerated low confidence'     => 'neutral',
+    'deleterious low confidence'   => 'neutral',
   );
   
   my %ranks = (


### PR DESCRIPTION
This should fix the background colour rendering bug e.g. on this page:

http://www.ensembl.org/Homo_sapiens/Variation/Mappings?db=core;r=9:128322579-128323579;tl=G0g9KEdTlIpzyFBE-773424;v=rs377735694;vdb=variation;vf=67052133

(SIFT column has some values rendered white text on grey BG)

Would be nice if this could go on release/79 too, but wasn't sure how to do the git mpush thing with a forked repo.