### PR TITLE
Add 'directly' to phenotypes message so that it does not look contradict...

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/GenePhenotype.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GenePhenotype.pm
@@ -138,7 +138,7 @@ sub gene_phenotypes {
     }
   }
   else {
-    $html = "<p>No phenotypes associated with gene $g_name.</p>";
+    $html = "<p>No phenotypes directly associated with gene $g_name.</p>";
   }
   return $html;
 }


### PR DESCRIPTION
...ory when there are no phontypes here, but there are some associated with variation annotations (see ticket ENSEMBL-3129 for example)