### PR TITLE
ensembl-3452: Removing blank line between headers when export sequence

### DIFF
--- a/modules/EnsEMBL/Web/Object/Export.pm
+++ b/modules/EnsEMBL/Web/Object/Export.pm
@@ -377,8 +377,6 @@ sub fasta {
           $self->string($fasta) while $fasta = substr $_->[1], 0, 60, '';
         }
       }
-      
-      $self->string('');
     }
   }
 


### PR DESCRIPTION
Removing an emty line between headers when we export a sequence. 
(GO to an example transcript page, click the Export Data button, then select FASTA, export as text.)
http://www.ensembl.org/Danio_rerio/Transcript/Summary?db=core;g=ENSDARG00000062187;r=22:22801609-22839541;t=ENSDART00000089622