### PR TITLE
Ensembl 3871

### DIFF
--- a/modules/EnsEMBL/Web/Component/UserData/PreviewConvert.pm
+++ b/modules/EnsEMBL/Web/Component/UserData/PreviewConvert.pm
@@ -23,6 +23,7 @@ use warnings;
 no warnings "uninitialized";
 
 use base qw(EnsEMBL::Web::Component::UserData);
+use EnsEMBL::Web::TmpFile::Text;
 
 sub _init {
   my $self = shift;

--- a/modules/EnsEMBL/Web/Component/UserData/PreviewConvertIDs.pm
+++ b/modules/EnsEMBL/Web/Component/UserData/PreviewConvertIDs.pm
@@ -23,6 +23,7 @@ use warnings;
 no warnings "uninitialized";
 
 use base qw(EnsEMBL::Web::Component::UserData);
+use EnsEMBL::Web::TmpFile::Text;
 
 sub _init {
   my $self = shift;


### PR DESCRIPTION
Causes Ajax Error when click on 'View Text' link on the VEP page.


Ajax error:
Runtime Error in component "EnsEMBL::Web::Component::UserData::PreviewConvertIDs [content]"

Function EnsEMBL::Web::Component::UserData::PreviewConvertIDs fails to execute due to the following error:

Can't locate object method "new" via package "EnsEMBL::Web::TmpFile::Text" (perhaps you forgot to load
... "EnsEMBL::Web::TmpFile::Text"?) at
... /net/isilonP/public/rw/ensembl/ensembl-genomes/release-26/bacteria/ensembl-webcode/modules/EnsEMBL/Web/Comp
... onent/UserData/PreviewConvertIDs.pm line 60.


How to replicate:
Go to
http://bacteria.ensembl.org/bacteroides_fragilis_638r/Info/Index/
Click VEP
The data field populate with:
FQ312004 258140 258146 TCTACAA/- +

On the next page click 'View Text'