### PR TITLE
Allow hubs to be attached using UCSC_GOLDEN_PATH and ASSEMBLY_VERSION

### DIFF
--- a/modules/EnsEMBL/Web/ImageConfig.pm
+++ b/modules/EnsEMBL/Web/ImageConfig.pm
@@ -813,9 +813,10 @@ sub _add_datahub {
 
     my $menu     = $existing_menu || $self->tree->append_child($self->create_submenu($menu_name, $menu_name, { external => 1, datahub_menu => 1 }));
 
+    my $assembly_default = $self->hub->species_defs->get_config($self->species, 'ASSEMBLY_VERSION');
     my $assembly = $self->hub->species_defs->get_config($self->species, 'UCSC_GOLDEN_PATH')
-                        || $self->hub->species_defs->get_config($self->species, 'ASSEMBLY_VERSION');
-    my $node = $hub_info->{'genomes'}{$assembly}{'tree'};
+                        || $assembly_default;
+    my $node = $hub_info->{'genomes'}{$assembly}{'tree'} || $hub_info->{'genomes'}{$assembly_default}{'tree'};
    
     if ($node) {
       $self->_add_datahub_node($node, $menu, $menu_name);


### PR DESCRIPTION
Under the current code, a TrackHub can be attached using the value of UCSC_GOLDEN_PATH or ASSEMBLY_VERSION.  However, if UCSC_GOLDEN_PATH is defined for the species, the image config will not show any tracks from hubs using the ASSEMBLY_VERSION (even though the hub shows as correctly attached).  This change allows configuration of tracks where the ASSEMBLY_VERSION is being used in the hub.

This was causing a problem for C. elegans users where ce10 and WBcel235 are both commonly accepted assembly names (even though UCSC's ce10 assembly is considerably older than WormBase's WBcel235...), so users may be using either in their TrackHubs, but most likely to be using the (correct) WBcel235 value.