### PR TITLE
Species genus order

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
@@ -236,7 +236,6 @@ sub _init {
 
     my $collapsed_xoffset = 0;
     if ($f->{_bg_colour}) {
-      my $width  = $bitmap_width;
       my $y = $f->{y_from} + 2;
       my $height = $f->{y_to} - $f->{y_from} - 1;
       my $x = $f->{x};

--- a/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
@@ -194,11 +194,11 @@ sub _init {
       } elsif( $f->{_genes}->{$current_gene} ){
         $label_colour     = 'red';
         $collapsed_colour = 'red';
-        $node_colour = "royalblue";
+        $node_colour = 'navyblue';
         $bold = defined($other_genome_db_id);
       } elsif( $f->{_genome_dbs}->{$current_genome_db_id} ){
         $label_colour     = 'blue';
-        $collapsed_colour = 'royalblue';
+        $collapsed_colour = 'navyblue';
         $bold = defined($other_genome_db_id);
       }
     }

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -108,7 +108,7 @@ sub content {
 
   my $column_name = $self->html_format ? 'Compare' : 'Description';
   
-  my $columns = [
+  $columns = [
     { key => 'Species',    align => 'left', width => '10%', sort => 'html'                                                },
     { key => 'Type',       align => 'left', width => '5%',  sort => 'string'                                              },
     { key => 'dN/dS',      align => 'left', width => '5%',  sort => 'numeric'                                             },

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -74,23 +74,23 @@ sub content {
   if ($species_sets) {
     $html .= qq{
       <h3>Summary of orthologues of this gene</h3>
-      <p class="space-below">Click on 'Show' to display the orthologues for one or more groups, or click on 'Configure this page' to choose a custom list of species</p>
+      <p class="space-below">Click on 'Show details' to display the orthologues for one or more groups of species. Alternatively, click on 'Configure this page' to choose a custom list of species.</p>
     };
  
     $columns = [
-      { key => 'set',       title => 'Species set',    align => 'left',    width => '20%' },
+      { key => 'set',       title => 'Species set',    align => 'left',    width => '26%' },
       { key => 'show',      title => 'Show details',   align => 'center',  width => '10%' },
-      { key => '1:1',       title => '1:1',            align => 'center',  width => '20%' },
-      { key => '1:many',    title => '1:many',         align => 'center',  width => '20%' },
-      { key => 'many:many', title => 'many:many',      align => 'center',  width => '20%' },
-      { key => 'none',      title => 'No orthologues', align => 'center',  width => '20%' },
+      { key => '1:1',       title => 'With 1:1 orthologues',       align => 'center',  width => '16%', help => 'Number of species with 1:1 orthologues' },
+      { key => '1:many',    title => 'With 1:many orthologues',    align => 'center',  width => '16%', help => 'Number of species with 1:many orthologues' },
+      { key => 'many:many', title => 'With many:many orthologues', align => 'center',  width => '16%', help => 'Number of species with many:many orthologues' },
+      { key => 'none',      title => 'Without orthologues',        align => 'center',  width => '16%', help => 'Number of species without orthologues' },
     ];
 
     foreach my $set (@$set_order) {
       my $set_info = $species_sets->{$set};
       
       push @rows, {
-        'set'       => "<strong>$set_info->{'title'}</strong><br />$set_info->{'desc'}",
+        'set'       => "<strong>$set_info->{'title'}</strong> (<i>$set_info->{'all'} species</i>)<br />$set_info->{'desc'}",
         'show'      => qq{<input type="checkbox" class="table_filter" title="Check to show these species in table below" name="orthologues" value="$set" />},
         '1:1'       => $set_info->{'1-to-1'}       || 0,
         '1:many'    => $set_info->{'1-to-many'}    || 0,


### PR DESCRIPTION
1. New option to collapse the gene-tree nodes at a given taxonomic rank
There is a new drop-down menu at the bottom of the gene-tree display, after the other links to collapse / expand nodes. The code lists the nodes that are under the rank cutoff and collapses them
http://enssand-01.internal.sanger.ac.uk:9073/Homo_sapiens/Gene/Compara_Tree?;db=core;g=ENSG00000139618;r=13:32315474-32400266

2. Table header in the Orthologues page
Feedback from workshops tells that there is sometimes some confusion in this table. People think that the numbers represent #orthologues. They are in fact #species
OLD http://staging.ensembl.org/Homo_sapiens/Gene/Compara_Ortholog?db=core;g=ENSG00000139618;r=13:32315474-32400266
NEW http://enssand-01.internal.sanger.ac.uk:9073/Homo_sapiens/Gene/Compara_Ortholog?db=core;g=ENSG00000139618;r=13:32315474-32400266
