### PR TITLE
ENSEMBL-4008 - Added feature to retrieve trans-spliced transcript information if the transcrpt is trans-spliced    

### DIFF
--- a/modules/EnsEMBL/Web/Object/Transcript.pm
+++ b/modules/EnsEMBL/Web/Object/Transcript.pm
@@ -493,6 +493,19 @@ sub get_frameshift_introns {
   return $frameshift_introns;
 }
 
+sub get_trans_spliced_transcript_info {
+    my $self = shift;
+    my $trans_spliced_transcript_info = $self->Obj->get_all_Attributes('trans_spliced');
+
+    if ( $trans_spliced_transcript_info->[0] ) {
+        return @$trans_spliced_transcript_info->[0];
+    }
+    else {
+        return 0;
+    }
+
+}
+
 sub get_domain_genes {
   my $self = shift;
   my $a = $self->gene ? $self->gene->adaptor : $self->Obj->adaptor;


### PR DESCRIPTION
A new feature has been introduced by James Allen team to indicate a transcript is trans-spliced or not. This method gets the information when a particular transcript is trans-spliced. 

At the moment, I am calling this method/sub from EnsEMBL::Web::Component::Transcript::TranscriptSummary (see below) on eg-web-common to populate the information on the page and will be pushed once this pull request is accepted.

 ``` my $trans_spliced_transcript_info = $object->get_trans_spliced_transcript_info;```
 ``` $table->add_row($trans_spliced_transcript_info->name, $trans_spliced_transcript_info->description) if $trans_spliced_transcript_info;```

I was told this feature will also be needed in Ensembl(Please read the ticket ENSEMBL-4008) - So, this pull request - For example, for fruit fly and few vertebrate species whose transcripts might be trans-spliced. 


Thanks,
Sanjay
