### PR TITLE
Code added to call get_trans_spliced_transcript_info method added in the commit 395509e18215ecbc2bce3300cd267d51c596c0a6.

### DIFF
--- a/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
@@ -129,6 +129,12 @@ sub content {
 
   $table->add_row('Frameshift introns', $self->glossary_helptip('Frameshift introns', 'Frameshift intron') . " occur at intron number(s)  $frameshift_introns.") if $frameshift_introns;
 
+
+  ## add trans-spliced transcript info
+  my $trans_spliced_transcript_info = $object->get_trans_spliced_transcript_info;
+  $table->add_row($trans_spliced_transcript_info->name, $trans_spliced_transcript_info->description) if $trans_spliced_transcript_info;
+
+  
   ## add stop gained/lost variation info
   my @attrib_codes = qw(StopLost StopGained);
   my $codons;


### PR DESCRIPTION
This code calls a method
get_trans_spliced_transcript_info which was created in the commit 395509e18215ecbc2bce3300cd267d51c596c0a6

This code was initially added to eg-web-common into a method which overrides its equivalent method in ensembl-webcode. 

Now adding it in ensembl-webcode to make it work on ensembl website too.