### PR TITLE
ENSEMBL-3985 - Ensembl gene search not working - Now works for stable ids as well - Once this commit is merged into E, equivalent code in EG needs removing

### DIFF
--- a/modules/EnsEMBL/Web/Controller/Ajax.pm
+++ b/modules/EnsEMBL/Web/Controller/Ajax.pm
@@ -352,4 +352,36 @@ sub ajax_fetch_html {
   print $content;
 }
 
+sub ajax_check_stable_id {
+    my ( $self, $hub ) = @_;
+    my $gene_id = $hub->param('stable_id');
+    my @dbs = map lc( substr $_, 9 ),
+        @{ $hub->species_defs->core_like_databases || [] };
+    my $results = {};
+
+    foreach my $db (@dbs) {
+
+        my $gene_adaptor = $hub->get_adaptor( 'get_GeneAdaptor', $db );
+        if ( my $gene = $gene_adaptor->fetch_by_stable_id($gene_id) ) {
+            $gene = $gene->transform('toplevel');
+
+            # print Dumper($gene);
+            $results = {
+                uc $gene_id => {
+                    'label' => $gene_id,
+                    'r' => $gene->seq_region_name() . ':'
+                        . $gene->start() . "-"
+                        . $gene->end(),
+                    'db' => $db,
+                    'g'  => $gene_id
+
+                }
+            };
+            last;
+        } 
+    }
+    print $self->jsonify($results);
+}
+
+
 1;


### PR DESCRIPTION
As discussed with Harpreet, here is Ensembl Gene search with Stable ID fix[ENSEMBL-3985]. 

Once, this commit is accepted and merged, I will have to remove this equivalent code from EG to avoid duplication.

And, sorry about the white spaces and formatting issues. Please view the diff with whitespaces ignored for better clarity.

Thanks,
Sanjay