### PR TITLE
Added margin bottom to the long_label in the trackhub label display

### DIFF
--- a/htdocs/components/90_configurator.css
+++ b/htdocs/components/90_configurator.css
@@ -39,7 +39,7 @@ form.configuration div.config h3                                    { margin: 10
 form.configuration div.config h4                                    { margin: 10px 0 5px 5px; color: [[PAGE_TEXT]]; }
 div.config_wrapper div.config img                                   { height: 17px; width: 17px; margin-right: 4px; padding: 2px; vertical-align: top; }
 
-div.config_wrapper div.config div.long_label                        { font-style: italic; font-size: 90%; }
+div.config_wrapper div.config div.long_label                        { font-style: italic; font-size: 90%; margin-bottom:10px; }
 
 div.config_wrapper div.config div.select_all                        { margin: 10px 0 5px; padding: 2px 0; }
 div.config_wrapper div.config div.select_all strong                 { text-decoration: underline; font-size: 14px; padding: 2px 5px; cursor: pointer; line-height: 17px; }


### PR DESCRIPTION
A very small css update - Added margin bottom to long label. Please see the attached images for clarity. No space between long label and the next line in the case of single track[Image 1]. But when we have multiple tracks with the line 'Enable/disable all ..', there is enough space[Image 2].

![screen shot 2015-08-26 at 10 36 42](https://cloud.githubusercontent.com/assets/12697042/9490422/a1e96804-4bdf-11e5-865e-5742a447805a.png)





![screen shot 2015-08-26 at 10 37 05](https://cloud.githubusercontent.com/assets/12697042/9490423/a1f5048e-4bdf-11e5-9a07-7544c5fe92b5.png)


Thanks,
Sanjay