### PR TITLE
genome_db.assembly_default has been removed in e82

### DIFF
--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -1178,7 +1178,7 @@ sub _summarise_compara_db {
 
   ###################################################################
   ## Section for storing the genome_db_ids <=> species_name
-  $res_aref = $dbh->selectall_arrayref('SELECT genome_db_id, name, assembly FROM genome_db WHERE assembly_default = 1');
+  $res_aref = $dbh->selectall_arrayref('SELECT genome_db_id, name, assembly FROM genome_db');
   
   foreach my $row (@$res_aref) {
     my ($genome_db_id, $species_name) = @$row;


### PR DESCRIPTION
Also, we can simply take all the GenomeDBs regardless of their first/last_release status