### PR TITLE
Faster way to detect whether a species is "low-coverage" or not

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/_alignment_multiple.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/_alignment_multiple.pm
@@ -239,14 +239,9 @@ sub element_features {
     $group_id = $feature->group_id unless ($constrained_element);
     my $cigar_line = $feature->reference_genomic_align->cigar_line unless ($constrained_element);
 
-    #Establish if the species is low coverage. Need to look at the whole GenomicAlign cigar line.
-    #Should be a better way of doing this eg comparing the high and low coverage species sets
     my $is_low_coverage_species = 0;
     unless ($constrained_element) {
-        my $ga_adaptor = $db->get_adaptor('GenomicAlign');
-        my $ref_ga = $ga_adaptor->fetch_by_dbID($feature->reference_genomic_align->{_original_dbID});
-        my $whole_cigar_line = $ref_ga->cigar_line;
-        $is_low_coverage_species = 1 if ($whole_cigar_line =~ /X/);
+        $is_low_coverage_species = $feature->reference_genomic_align->genome_db->has_karyotype ? 0 : 1;
     }
 
     


### PR DESCRIPTION
This fixes some warnings noticed by Anne in the logs whilst working on ENSWEB-1690