### PR TITLE
Trees may be missing the taxon annotation. Skip those

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -418,6 +418,7 @@ sub collapsed_nodes {
     while (@nodes_to_check) {
       my $internal_node = shift @nodes_to_check;
       next if $internal_node->is_leaf;
+      next unless $internal_node->species_tree_node;
       my $taxon = $internal_node->species_tree_node->taxon;
       my $this_rank = $taxon->rank;
       if ($this_rank eq 'no rank') {


### PR DESCRIPTION
Fixes a bug of the live website:

1. go to http://www.ensembl.org/Homo_sapiens/Gene/Compara_Tree?collapse=none;db=core;g=ENSG00000276057;r=22:30971296-30971382;t=ENST00000614234 
2. Click "configure this page"
3. In "Model used for the tree reconstruction" choose another option
4. Close the panel
You'll get
```
AJAX error - Runtime Error in component "EnsEMBL::Web::Component::Gene::ComparaTree [content]"

Function EnsEMBL::Web::Component::Gene::ComparaTree fails to execute due to the following error:

	Can't call method "taxon" on an undefined value at
	... /ensemblweb/www/www_82/ensembl-webcode/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm line 421, <DATA>
	... line 1000.
```

Tried on my sandbox http://enssand-01.internal.sanger.ac.uk:9073/Homo_sapiens/Gene/Compara_Tree?collapse=none;db=core;g=ENSG00000276057;r=22:30971296-30971382;t=ENST00000614234