### PR TITLE
ensembl-fix: ensembl-4088 Chromosome summary not scaled properly

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/V_density.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/V_density.pm
@@ -20,6 +20,7 @@ package EnsEMBL::Draw::GlyphSet::V_density;
 use strict;
 use base qw(EnsEMBL::Draw::GlyphSet);
 use Data::Dumper;
+use List::Util qw( max );
 
 ### Parent module for vertical density tracks - does some generic data munging
 ### and draws the histogram/graph components
@@ -87,6 +88,8 @@ sub build_tracks {
     $T->{'max_len'}   = $max_len;
     $T->{'bin_size'}  = $bin_size;
     $T->{'v_offset'}  = $v_offset;
+
+    my $current_max = max @$scores;
     if (uc($chr) eq 'MT') {
       $T->{'max_value'} = undef;
     }
@@ -109,8 +112,16 @@ sub build_tracks {
 		  $chr_min_data = $mean if ($mean < $chr_min_data || $chr_min_data eq undef); 
 		  $chr_max_data = $mean if $mean > $chr_max_data;
       ## Scale data for actual display
-      my $max = $T->{'max_value'} || $chr_max_data || 1; 
-      $local_max = $max if $max > $local_max;
+      my $max;
+
+      if ($T->{'max_value'}) {
+        $max = $T->{'max_value'};  
+        $max = $current_max if ($current_max > $max);
+      } else {
+        $max = ($current_max > $chr_max_data) ? $current_max : $chr_max_data;
+      }
+      $local_max = $max;
+
       push @$scaled_scores, $mean/$max * $width;
 	  }
     $T->{'scores'} = $scaled_scores;


### PR DESCRIPTION
Original ticket https://www.ebi.ac.uk/panda/jira/browse/ENSEMBL-4088?filter=-1

Chromosome summary doesn't appropriately scale the bars showing gene counts.
The max value for the image should be set based on the real array values
rather than $image_config->get_parameter( 'max_value' )

Currently, in some cases $image_config->get_parameter( 'max_value' ) <  max value of the array elements and the image is scaled incorrectly, adding horizontal scrolling to the page.