### PR TITLE
Display box for controlling gene tree colouring in the config menu

### DIFF
--- a/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
@@ -55,7 +55,7 @@ sub init {
 
 sub field_order {
   my $self = shift;
-  my @order = qw(collapsability clusterset_id exons super_tree);
+  my @order = qw(collapsability clusterset_id exons super_tree colouring);
   my @groups   = ('LOWCOVERAGE', @{ $self->hub->species_defs->TAXON_ORDER });
   push @order, 'group_'.$_.'_display' for @groups;
   return @order; 


### PR DESCRIPTION
The option to control taxonomic colouring of gene trees needs to be in the "order" list, otherwise it is omitted from the config menu.