### PR TITLE
ENSEMBL-4243 - Incorrect message on ortholog page

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -53,7 +53,7 @@ sub content {
   my %skipped;
 
   my $mlss_adaptor = $hub->get_adaptor('get_MethodLinkSpeciesSetAdaptor', $cdb);
-  my %not_seen = map {$_->name => 1} @{$mlss_adaptor->fetch_all_by_method_link_type('PROTEIN_TREES')->[0]->species_set_obj->genome_dbs};
+  my %not_seen = map {ucfirst($_->name) => 1} @{$mlss_adaptor->fetch_all_by_method_link_type('PROTEIN_TREES')->[0]->species_set_obj->genome_dbs};
   delete $not_seen{$hub->species};
   
   foreach my $homology_type (@orthologues) {


### PR DESCRIPTION
On page:
http://www.ensembl.org/Homo_sapiens/Gene/Compara_Ortholog?g=ENSG00000139618;r=13:32315474-32400266

species under section 'Selected Orthologs' are again appearing under the section 'Species without orthologues'. This little tweak should fix it.