### PR TITLE
Use Compara's precomputed JSONs

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
@@ -159,7 +159,7 @@ sub _init {
     ($f->{x}) = sort{$b<=>$a} int($f->{_x_offset} * $nodes_scale), $min_x;
     
     if ($f->{_cigar_line}){
-      push @alignments, [ $f->{y} , $f->{_cigar_line}, $f->{_collapsed}, $f->{_aligned_exon_lengths}] ;
+      push @alignments, [ $f->{y} , $f->{_cigar_line}, $f->{_collapsed}, $f->{_aligned_exon_coords}] ;
     }
 
     # Node glyph, coloured for for duplication/speciation
@@ -446,12 +446,10 @@ sub _init {
   #      "WIDTH: $alignment_width, MIN: $min_length");    
   foreach my $a (@alignments) {
     if(@$a) {        
-      my ($yc, $al, $collapsed, $exon_lengths) = @$a;
+      my ($yc, $al, $collapsed, $exon_coords) = @$a;
   
       # Draw the exon splits under the boxes
-      my $exon_end = 0;
-      foreach my $exon_length (@$exon_lengths) {
-        $exon_end += $exon_length;
+      foreach my $exon_end (@$exon_coords) {
         my $e = $self->Line({
           'x'         => $alignment_start + $exon_end * $alignment_scale,
           'y'         => $yc - 3 - $EXON_TICK_SIZE,
@@ -789,13 +787,18 @@ sub features {
       $f->{'_cigar_line'} = $tree->cigar_line;
       
       if ($show_exons) {
-        eval {
-          my $aligned_sequences_bounded_by_exon = $tree->alignment_string('exon_bounded');
-          my (@bounded_exons) = split ' ', $aligned_sequences_bounded_by_exon;
-          pop @bounded_exons;
-          
-          $f->{'_aligned_exon_lengths'} = [ map length($_), @bounded_exons ];
-        };
+        my $ref_genetree = $tree->tree;
+        $ref_genetree = $ref_genetree->alternative_trees->{default} if $ref_genetree->clusterset_id ne 'default';
+        unless ($ref_genetree->{_exon_boundaries_hash}) {
+          my $gtos_adaptor = $tree->adaptor->db->get_GeneTreeObjectStoreAdaptor;
+          my $json_string = $gtos_adaptor->fetch_by_GeneTree_and_label($ref_genetree, 'exon_boundaries');
+          if ($json_string) {
+              $ref_genetree->{_exon_boundaries_hash} = JSON->new->decode($json_string);
+          } else {
+              $ref_genetree->{_exon_boundaries_hash} = {};
+          }
+        }
+        $f->{'_aligned_exon_coords'} = $ref_genetree->{_exon_boundaries_hash}->{$tree->seq_member_id}->{positions};
       }
       
       if (my $display_label = $member->display_label) {

--- a/modules/EnsEMBL/Web/Component/Gene/SpeciesTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/SpeciesTree.pm
@@ -61,7 +61,6 @@ sub content {
   my $stable_id   = $hub->param('g');
 
   my $is_speciestree = $object->isa('EnsEMBL::Web::Object::SpeciesTree') ? 1 : 0;
-  my $show_exons     = $hub->param('exons') eq 'on' ? 1 : 0; 
     
   my ($gene, $member, $tree, $node, $html);
  

--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -1140,6 +1140,32 @@ sub get_SpeciesTree {
   return $self->{$cache_key};
 }
 
+# Function to call compara API to get the species Tree precomputed in JSON
+sub get_SpeciesTreeJSON {
+  my $self       = shift;
+  my $compara_db = shift || 'compara';
+
+  my $hub            = $self->hub;
+  my $collapsability = $hub->param('collapsability');
+  my $cache_key      = "_json_species_tree_".$collapsability."_".$compara_db;
+  my $database       = $self->database($compara_db);
+
+  if (!$self->{$cache_key}) {
+    my $geneTree_Adaptor = $database->get_GeneTreeAdaptor();
+    my $gtos_Adaptor     = $database->get_GeneTreeObjectStoreAdaptor();
+
+    my $json_label = $collapsability eq 'part' ? 'cafe_lca' : 'cafe';
+
+    my $member   = $self->get_compara_Member($compara_db)           || return;
+    my $geneTree = $geneTree_Adaptor->fetch_default_for_Member($member) || return;
+    my $cafeTree = $gtos_Adaptor->fetch_by_GeneTree_and_label($geneTree, $json_label) || return;
+
+    $self->{$cache_key} = $cafeTree;
+  }
+
+  return $self->{$cache_key};
+}
+
 # Calls for GeneSNPView
 
 # Valid user selections


### PR DESCRIPTION
The related schema + API changes are on Compara master (=e84). We haven't handed over yet, but I have successfully run this on the protein-trees database

In the end, I found a relatively simple solution to make the species-tree view work, and it shouldn't impact the fallback view. There is a related pull-request in public-plugins/widget https://github.com/Ensembl/public-plugins/pull/48