### PR TITLE
Removed unused/obsolete code as it is causing error on EG

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/FamilyProteins.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/FamilyProteins.pm
@@ -118,7 +118,6 @@ sub content_ensembl {
   
   my $species_defs  = $hub->species_defs;
   my $sitename      = $species_defs->ENSEMBL_SITETYPE;
-  my $current_taxon = $hub->database('core')->get_MetaContainer->get_taxonomy_id;
   my @genomedbs     = @{$family->get_all_GenomeDBs_by_member_source_name('ENSEMBLPEP')}; ## Ensembl proteins
   my $count         = 0;
   my %data;


### PR DESCRIPTION
Could you merge it to Master and release/83 please?
That variable '$current_taxon' is not being used anywhere else in this module and is also causing issues on live EG sites.

Thanks,
Sanj