### PR TITLE
Export this image bug - Broken on live

### DIFF
--- a/modules/EnsEMBL/Web/Component/Transcript/PopulationImage.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/PopulationImage.pm
@@ -178,7 +178,7 @@ sub content {
 sub sample_configs {
   my ($self, $transcript_slice, $sub_slices, $fake_length) = @_;
   my $hub       = $self->hub;
-  my $object    = $self->object;
+  my $object    = $self->object || $self->hub->core_object('transcript');
   my $stable_id = $object->stable_id;
   my $extent    = $object->extent;
   my @containers_and_configs; ## array of containers and configs


### PR DESCRIPTION
This is broken on live on both E and EG. Please see the following page:
http://www.ensembl.org/Mus_musculus/Transcript/Population/Image?db=core;g=ENSMUSG00000041143;r=4:138972905-139059167;t=ENSMUST00000050949

This update seems to fix the issue on EG. Not sure how to test this fix against Ensembl site.

Thanks,
Sanjay