### PR TITLE
84 feature/update deprecated methods

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/_variation.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/_variation.pm
@@ -152,7 +152,8 @@ sub fetch_features {
         # Reset the flag for displaying of failed variations to its original state
         $variation_db_adaptor->include_failed_variations($orig_failed_flag);
       } else {
-        my @temp_variations = @{$slice->get_all_VariationFeatures(undef, undef, undef, $var_db) || []}; 
+        my $vf_adaptor = $variation_db_adaptor->get_VariationFeatureAdaptor;
+        my @temp_variations = @{$vf_adaptor->fetch_all_by_Slice($slice) || []}; 
         
         ## Add a filtering step here
         @vari_features =

--- a/modules/EnsEMBL/Draw/GlyphSet/_variation.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/_variation.pm
@@ -146,8 +146,8 @@ sub fetch_features {
     
         # Enable the display of failed variations in order to display the failed variation track
         $variation_db_adaptor->include_failed_variations(1) if $track_set =~ /failed/i;
-        
-        @vari_features = @{$slice->get_all_VariationFeatures_by_VariationSet($set_object, $var_db) || []};
+        my $vf_adaptor = $variation_db_adaptor->get_VariationFeatureAdaptor;
+        @vari_features = @{$vf_adaptor->fetch_all_by_Slice_VariationSet($slice, $set_object) || []};
         
         # Reset the flag for displaying of failed variations to its original state
         $variation_db_adaptor->include_failed_variations($orig_failed_flag);

--- a/modules/EnsEMBL/Draw/GlyphSet/cnv_probes.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/cnv_probes.pm
@@ -31,13 +31,15 @@ sub features {
   my $self   = shift; 
   my $slice  = $self->{'container'};
   my $source = $self->my_config('source');
+  my $var_db = $self->my_config('db') || 'variation';
+  my $svf_adaptor = $self->{'config'}->hub->get_adaptor('get_StructuralVariationFeatureAdaptor', $var_db);
 
   my $var_features;
   
   if ($source =~ /^\w/) {
-    $var_features = $slice->get_all_CopyNumberVariantProbeFeatures($source);
+    $var_features = $svf_adaptor->fetch_all_cnv_probe_by_Slice($slice, $source);
   } else {
-    $var_features = $slice->get_all_CopyNumberVariantProbeFeatures;
+    $var_features = $svf_adaptor->fetch_all_cnv_probe_by_Slice($slice);
   }
   
   return $var_features;  

--- a/modules/EnsEMBL/Draw/GlyphSet/structural_variation.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/structural_variation.pm
@@ -78,7 +78,6 @@ sub features {
     }
     else {
       my $source_name = $self->my_config('source');
-      my $source_ = $src_adaptor->fetch_by_name($source_name);
       my $min_size = $self->my_config('min_size');
       my $max_size = $self->my_config('max_size');
       my $start    = $slice->start;
@@ -86,7 +85,8 @@ sub features {
       my @display_features;
       
       # By source
-      if ($source) {
+      if ($source_name) {
+        my $source = $src_adaptor->fetch_by_name($source_name);
         my $func  = $self->somatic ? 'fetch_all_somatic_by_Slice_Source' : 'fetch_all_by_Slice_Source';
         $features = $svf_adaptor->$func($slice, $source, undef);
       }

--- a/modules/EnsEMBL/Draw/GlyphSet/structural_variation.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/structural_variation.pm
@@ -66,15 +66,19 @@ sub features {
     my $set_name   = $self->my_config('set_name');
     my $study_name = $self->my_config('study_name');
     my $var_db     = $self->my_config('db') || 'variation';
+    my $svf_adaptor = $self->{'config'}->hub->get_adaptor('get_StructuralVariationFeatureAdaptor', $var_db);
+    my $src_adaptor = $self->{'config'}->hub->get_adaptor('get_SourceAdaptor', $var_db);
+
     my ($features, %colours);
     
     if ($set_name) {
-      $features = $slice->get_all_StructuralVariationFeatures_by_VariationSet($self->{'config'}->hub->get_adaptor('get_VariationSetAdaptor', $var_db)->fetch_by_name($set_name), $var_db);
+      $features = $svf_adaptor->fetch_all_by_Slice_VariationSet($slice, $self->{'config'}->hub->get_adaptor('get_VariationSetAdaptor', $var_db)->fetch_by_name($set_name));
     } elsif ($study_name) {
-      $features = $slice->get_all_StructuralVariationFeatures_by_Study($self->{'config'}->hub->get_adaptor('get_StudyAdaptor', $var_db)->fetch_by_name($study_name), undef, $var_db);
+      $features = $svf_adaptor->fetch_all_by_Slice_Study($slice, $self->{'config'}->hub->get_adaptor('get_StudyAdaptor', $var_db)->fetch_by_name($study_name), undef);
     }
     else {
-      my $source     = $self->my_config('source');
+      my $source_name = $self->my_config('source');
+      my $source_ = $src_adaptor->fetch_by_name($source_name);
       my $min_size = $self->my_config('min_size');
       my $max_size = $self->my_config('max_size');
       my $start    = $slice->start;
@@ -83,12 +87,12 @@ sub features {
       
       # By source
       if ($source) {
-        my $func  = $self->somatic ? 'get_all_somatic_StructuralVariationFeatures_by_source' : 'get_all_StructuralVariationFeatures_by_source';
-        $features = $slice->$func($source, undef, $var_db);
+        my $func  = $self->somatic ? 'fetch_all_somatic_by_Slice_Source' : 'fetch_all_by_Slice_Source';
+        $features = $svf_adaptor->$func($slice, $source, undef);
       }
       else {
-        my $func  = $self->somatic ? 'get_all_somatic_StructuralVariationFeatures' : 'get_all_StructuralVariationFeatures';
-        $features = $slice->$func(undef, $var_db);
+        my $func  = $self->somatic ? 'fetch_all_somatic_by_Slice' : 'fetch_all_by_Slice';
+        $features = $svf_adaptor->$func($slice);
       }
       
       if ($min_size || $max_size) {

--- a/modules/EnsEMBL/Web/Component/Gene/TranscriptComparison.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/TranscriptComparison.pm
@@ -283,7 +283,7 @@ sub get_sequence_data {
 sub set_variations {
   my ($self, $config, $slice, $markup, $transcript, $sequence) = @_;
   my $vf_adaptor = $self->hub->database('variation')->get_VariationFeatureAdaptor;
-  my $variation_features = $config->{'population'} ? $vf_adaptor->fetch_all_by_Slice_Population($slice, $config->{'population'}, $config->{'min_frequency'}) : $vf_adaptor->fetch_all_by_Slice_Population($slice);
+  my $variation_features = $config->{'population'} ? $vf_adaptor->fetch_all_by_Slice_Population($slice, $config->{'population'}, $config->{'min_frequency'}) : $vf_adaptor->fetch_all_by_Slice($slice);
   my @transcript_variations = @{$self->hub->get_adaptor('get_TranscriptVariationAdaptor', 'variation')->fetch_all_by_VariationFeatures($variation_features, [ $transcript ])};
   @transcript_variations = grep $_->variation_feature->length <= $self->{'snp_length_filter'}, @transcript_variations if $config->{'hide_long_snps'};
   @transcript_variations = grep { !$self->too_rare_snp($_->variation_feature,$config) } @transcript_variations;

--- a/modules/EnsEMBL/Web/Component/Gene/TranscriptComparison.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/TranscriptComparison.pm
@@ -282,7 +282,8 @@ sub get_sequence_data {
 
 sub set_variations {
   my ($self, $config, $slice, $markup, $transcript, $sequence) = @_;
-  my $variation_features    = $config->{'population'} ? $slice->get_all_VariationFeatures_by_Population($config->{'population'}, $config->{'min_frequency'}) : $slice->get_all_VariationFeatures;
+  my $vf_adaptor = $self->hub->database('variation')->get_VariationFeatureAdaptor;
+  my $variation_features = $config->{'population'} ? $vf_adaptor->fetch_all_by_Slice_Population($slice, $config->{'population'}, $config->{'min_frequency'}) : $vf_adaptor->fetch_all_by_Slice_Population($slice);
   my @transcript_variations = @{$self->hub->get_adaptor('get_TranscriptVariationAdaptor', 'variation')->fetch_all_by_VariationFeatures($variation_features, [ $transcript ])};
   @transcript_variations = grep $_->variation_feature->length <= $self->{'snp_length_filter'}, @transcript_variations if $config->{'hide_long_snps'};
   @transcript_variations = grep { !$self->too_rare_snp($_->variation_feature,$config) } @transcript_variations;

--- a/modules/EnsEMBL/Web/Component/LRG/LRGDiff.pm
+++ b/modules/EnsEMBL/Web/Component/LRG/LRGDiff.pm
@@ -44,6 +44,7 @@ sub content {
   my $lrg  = $self->object->Obj;
   my $lrg_feature_slice = $lrg->feature_Slice;
   my $slice_adaptor = $hub->get_adaptor('get_SliceAdaptor');
+  my $vf_adaptor = $hub->database('variation')->get_VariationAdaptor; 
   my $html;
   
   my $columns = [
@@ -96,7 +97,7 @@ sub content {
       $seq_end   = $ref_end;
     }
 
-    my $vfs = ($diff_slice) ? $diff_slice->get_all_VariationFeatures : [];
+    my $vfs = ($diff_slice) ? $vf_adaptor->fetch_all_by_Slice($diff_slice) : [];
     
     foreach my $vf (@$vfs) {
       if ($vf->seq_region_start == $seq_start && $vf->seq_region_end == $seq_end) {

--- a/modules/EnsEMBL/Web/Component/Location/SequenceAlignment.pm
+++ b/modules/EnsEMBL/Web/Component/Location/SequenceAlignment.pm
@@ -21,7 +21,7 @@ package EnsEMBL::Web::Component::Location::SequenceAlignment;
 use strict;
 
 use Bio::EnsEMBL::MappedSliceContainer;
-use Bio::EnsEMBL::DBSQL::StrainSliceAdaptor;
+use Bio::EnsEMBL::Variation::DBSQL::StrainSliceAdaptor;
 
 use base qw(EnsEMBL::Web::Component::TextSequence EnsEMBL::Web::Component::Location);
 
@@ -114,7 +114,7 @@ sub content {
 sub get_slices {
   my ($self, $ref_slice_obj, $samples, $config) = @_;
   my $hub = $self->hub;
-  
+  my $vdb = $hub->database('variation');
   # Chunked request
   if (!defined $samples) {
     my $var_db = $hub->species_defs->databases->{'DATABASE_VARIATION'};
@@ -128,7 +128,8 @@ sub get_slices {
   
   my $msc = Bio::EnsEMBL::MappedSliceContainer->new(-SLICE => $ref_slice_obj, -EXPANDED => 1);
   
-  $msc->set_StrainSliceAdaptor(Bio::EnsEMBL::DBSQL::StrainSliceAdaptor->new($ref_slice_obj->adaptor->db));
+  $msc->set_StrainSliceAdaptor(Bio::EnsEMBL::Variation::DBSQL::StrainSliceAdaptor->new($vdb));
+
   $msc->attach_StrainSlice($_) for @$samples;
   
   my @slices = ({ 

--- a/modules/EnsEMBL/Web/Component/SVTable.pm
+++ b/modules/EnsEMBL/Web/Component/SVTable.pm
@@ -35,8 +35,8 @@ sub content {
   my $hub     = $self->hub;
   my $object  = $self->object;  
   my $slice   = $object->slice;
-  my $html    = $self->structural_variation_table($slice, 'Structural variants',         'sv',  ['get_all_StructuralVariationFeatures','get_all_somatic_StructuralVariationFeatures'], 1);
-     $html   .= $self->structural_variation_table($slice, 'Copy number variants probes', 'cnv', ['get_all_CopyNumberVariantProbeFeatures']);
+  my $html    = $self->structural_variation_table($slice, 'Structural variants',         'sv',  ['fetch_all_by_Slice','fetch_all_somatic_by_Slice'], 1);
+     $html   .= $self->structural_variation_table($slice, 'Copy number variants probes', 'cnv', ['fetch_all_cnv_probe_by_Slice']);
   
   return $html;
 }

--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -1138,6 +1138,7 @@ sub remove_redundant_xrefs {
 sub structural_variation_table {
   my ($self, $slice, $title, $table_id, $functions, $open) = @_;
   my $hub = $self->hub;
+  my $svf_adaptor = $hub->database('variation')->get_StructuralVariationFeatureAdaptor;
   my $rows;
   
   my $columns = [
@@ -1151,7 +1152,7 @@ sub structural_variation_table {
   
   my $svfs;
   foreach my $func (@{$functions}) {
-    push(@$svfs,@{$slice->$func});
+    push(@$svfs, @{$svf_adaptor->$func($slice)});
   }
   
   foreach my $svf (@{$svfs}) {

--- a/modules/EnsEMBL/Web/Component/TextSequence.pm
+++ b/modules/EnsEMBL/Web/Component/TextSequence.pm
@@ -269,7 +269,7 @@ sub set_variations {
     }
       
     eval {
-      map { $u_snps->{$_->variation_name} = $_ } @{$u_slice->get_all_VariationFeatures};
+      map { $u_snps->{$_->variation_name} = $_ } @{$vf_adaptor->fetch_all_by_Slice($u_slice)};
     };
   }
 

--- a/modules/EnsEMBL/Web/Component/TextSequence.pm
+++ b/modules/EnsEMBL/Web/Component/TextSequence.pm
@@ -252,8 +252,8 @@ sub set_variations {
         $snps = $vfa->fetch_all_with_maf_by_Slice($slice_data->{'slice'},abs $config->{'hide_rare_snps'},$config->{'hide_rare_snps'}>0);
       }
       else {
-        my @snps_list = (@{$slice_data->{'slice'}->get_all_VariationFeatures($config->{'consequence_filter'}, 1)},
-                         @{$slice_data->{'slice'}->get_all_somatic_VariationFeatures($config->{'consequence_filter'}, 1)});
+        my @snps_list = (@{$vf_adaptor->fetch_all_by_Slice_SO_terms($slice_data->{'slice'}, $config->{'consequence_filter'}, 1)},
+                         @{$vf_adaptor->fetch_all_somatic_by_Slice_SO_terms($slice_data->{'slice'}, $config->{'consequence_filter'}, 1)});
         $snps = \@snps_list;
       }
     };

--- a/modules/EnsEMBL/Web/Component/TextSequence.pm
+++ b/modules/EnsEMBL/Web/Component/TextSequence.pm
@@ -237,7 +237,7 @@ sub set_variations {
   my $snps   = [];
   my $u_snps = {};
   my $adaptor;
-
+  my $vf_adaptor = $hub->database('variation')->get_VariationAdaptor;
   if ($focus_snp_only) {
     push @$snps, $focus_snp_only;
   } else {
@@ -245,7 +245,7 @@ sub set_variations {
       # NOTE: currently we can't filter by both population and consequence type, since the API doesn't support it.
       # This isn't a problem, however, since filtering by population is disabled for now anyway.
       if ($config->{'population'}) {
-         $snps = $slice_data->{'slice'}->get_all_VariationFeatures_by_Population($config->{'population'}, $config->{'min_frequency'});
+        $snps = $vf_adaptor->fetch_all_by_Slice_Population($slice_data->{'slice'}, $config->{'population'}, $config->{'min_frequency'});
       }
       elsif ($config->{'hide_rare_snps'} && $config->{'hide_rare_snps'} ne 'off') {
         my $vfa = $hub->get_adaptor('get_VariationFeatureAdaptor','variation');

--- a/modules/EnsEMBL/Web/Component/Transcript/ExonsSpreadsheet.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/ExonsSpreadsheet.pm
@@ -310,7 +310,7 @@ sub add_variations {
   return if $adorn eq 'none';
 
   my $object = $self->object || $self->hub->core_object('transcript');
-  my $vf_adaptor = $self->hub->database('variation')->get_VariationAdaptor;
+  my $vf_adaptor = $self->hub->database('variation')->get_VariationFeatureAdaptor;
   my $variation_features    = $config->{'population'} ? $vf_adaptor->fetch_all_by_Slice_Population($slice, $config->{'population'}, $config->{'min_frequency'}) : $vf_adaptor->fetch_all_by_Slice($slice);
   my @transcript_variations;
   my @transcript_variations = @{$self->hub->get_adaptor('get_TranscriptVariationAdaptor', 'variation')->fetch_all_by_VariationFeatures($variation_features, [ $object->Obj ])};

--- a/modules/EnsEMBL/Web/Component/Transcript/ExonsSpreadsheet.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/ExonsSpreadsheet.pm
@@ -310,7 +310,8 @@ sub add_variations {
   return if $adorn eq 'none';
 
   my $object = $self->object || $self->hub->core_object('transcript');
-  my $variation_features    = $config->{'population'} ? $slice->get_all_VariationFeatures_by_Population($config->{'population'}, $config->{'min_frequency'}) : $slice->get_all_VariationFeatures;
+  my $vf_adaptor = $self->hub->database('variation')->get_VariationAdaptor;
+  my $variation_features    = $config->{'population'} ? $vf_adaptor->fetch_all_by_Slice_Population($slice, $config->{'population'}, $config->{'min_frequency'}) : $vf_adaptor->fetch_all_by_Slice($slice);
   my @transcript_variations;
   my @transcript_variations = @{$self->hub->get_adaptor('get_TranscriptVariationAdaptor', 'variation')->fetch_all_by_VariationFeatures($variation_features, [ $object->Obj ])};
   if($config->{'hide_rare_snps'}) {

--- a/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
@@ -504,6 +504,7 @@ sub detail_panel {
   my $self     = shift;
   my $object   = $self->object;
   my $hub      = $self->hub;
+  my $vf_adaptor = $hub->database('variation')->get_VariationAdaptor;
   my $allele   = $hub->param('allele');
   my $tr_id    = $hub->param('t');
   my $vf_id    = $hub->param('vf');
@@ -632,7 +633,7 @@ sub detail_panel {
       # find vars in same AA
       my @same_aa;
       
-      foreach my $other_vf(@{$vf->feature_Slice->expand(3, 3)->get_all_VariationFeatures}) {
+      foreach my $other_vf(@{$vf_adaptor->fetch_all_by_Slice($vf->feature_Slice->expand(3, 3))}) {
         next if $other_vf->dbID == $vf->dbID;
         
         foreach my $other_tv(@{$other_vf->get_all_TranscriptVariations([$tv->transcript])}) {

--- a/modules/EnsEMBL/Web/Component/VariationTable.pm
+++ b/modules/EnsEMBL/Web/Component/VariationTable.pm
@@ -663,6 +663,7 @@ sub _get_variation_features {
   my $self = shift;
 
   if(!exists($self->{_variation_features})) {
+    my $vfa = $self->hub->get_adaptor('get_VariationFeatureAdaptor', 'variation');
 
     # get appropriate slice
     my $slice = $self->object->Obj->feature_Slice->expand(
@@ -670,7 +671,7 @@ sub _get_variation_features {
       $Bio::EnsEMBL::Variation::Utils::VariationEffect::DOWNSTREAM_DISTANCE
     );
 
-    $self->{_variation_features} = {map {$_->dbID => $_} (@{$slice->get_all_VariationFeatures},@{$slice->get_all_somatic_VariationFeatures})};
+    $self->{_variation_features} = { map {$_->dbID => $_} (@{ $vfa->fetch_all_by_Slice($slice) }, @{ $vfa->fetch_all_somatic_by_Slice($slice) })};
   }
 
   return $self->{_variation_features};

--- a/modules/EnsEMBL/Web/Component/Variation_Context.pm
+++ b/modules/EnsEMBL/Web/Component/Variation_Context.pm
@@ -39,6 +39,7 @@ sub content {
   
   my $hub                = $self->hub;
   my $slice_adaptor      = $hub->get_adaptor('get_SliceAdaptor');
+  my $svf_adaptor        = $hub->database('variation')->get_StructuralVariationFeatureAdaptor;
   my $width              = $hub->param('context') || 30000;
   my $max_display_length = 1000000;
   my %mappings           = %{$object->variation_feature_mapping};  # first determine correct SNP location 
@@ -142,7 +143,7 @@ sub content {
   }
   
   
-  my $sv_count = scalar(@{$slice->get_all_StructuralVariationFeatures});
+  my $sv_count = scalar(@{$svf_adaptor->fetch_all_by_Slice($slice)});
     
   $html .= $self->_warning(
     "Structural variants display",
@@ -180,8 +181,8 @@ sub content {
     $html     .= "<h2>Features overlapping $vname:</h2>";
   }
   
-  $html .= $self->structural_variation_table($slice, 'Structural variants',         'sv',  ['get_all_StructuralVariationFeatures','get_all_somatic_StructuralVariationFeatures'], 1);
-  $html .= $self->structural_variation_table($slice, 'Copy number variants probes', 'cnv', ['get_all_CopyNumberVariantProbeFeatures']);
+  $html .= $self->structural_variation_table($slice, 'Structural variants',         'sv',  ['fetch_all_by_Slice','fetch_all_somatic_by_Slice'], 1);
+  $html .= $self->structural_variation_table($slice, 'Copy number variants probes', 'cnv', ['fetch_all_cnv_probe_by_Slice']);
   $html .= $self->regulatory_feature_table($var_slice,  $vname, $image_config) if $hub->species_defs->databases->{'DATABASE_FUNCGEN'};
   $html .= $self->constrained_element_table($var_slice, $vname);
   

--- a/modules/EnsEMBL/Web/Object/Export.pm
+++ b/modules/EnsEMBL/Web/Object/Export.pm
@@ -549,7 +549,9 @@ sub features {
   }
   
   if ($params->{'variation'}) {
-    foreach (@{$slice->get_all_VariationFeatures}) {
+    my $vdb = $self->database('variation'); 
+    my $vf_adaptor = $vdb->get_VariationFeatureAdaptor;     
+    foreach (@{$vfa->fetch_all_by_Slice($slice)}) {
       $self->feature('variation', $_, { variation_name => $_->variation_name });	    
     }
   }

--- a/modules/EnsEMBL/Web/Object/Export.pm
+++ b/modules/EnsEMBL/Web/Object/Export.pm
@@ -551,7 +551,7 @@ sub features {
   if ($params->{'variation'}) {
     my $vdb = $self->database('variation'); 
     my $vf_adaptor = $vdb->get_VariationFeatureAdaptor;     
-    foreach (@{$vfa->fetch_all_by_Slice($slice)}) {
+    foreach (@{$vf_adaptor->fetch_all_by_Slice($slice)}) {
       $self->feature('variation', $_, { variation_name => $_->variation_name });	    
     }
   }

--- a/modules/EnsEMBL/Web/Object/Location.pm
+++ b/modules/EnsEMBL/Web/Object/Location.pm
@@ -1352,7 +1352,8 @@ sub get_variation_features {
    my $self = shift;
    my $slice = $self->slice_cache;
    return unless $slice;
-   return $slice->get_all_VariationFeatures || [];
+   my $vf_adaptor = $self->hub->database('variation')->get_VariationAdaptor;
+   return $vf_adaptor->fetch_all_by_Slice($slice) || [];
 }
 
 sub slice_cache {

--- a/modules/EnsEMBL/Web/Object/Slice.pm
+++ b/modules/EnsEMBL/Web/Object/Slice.pm
@@ -113,14 +113,13 @@ sub getFakeMungedVariationFeatures {
   ### scalar - number of SNPs filtered out by the context filter
 
   my ($self, $subslices, $gene, $so_terms) = @_;
-  
+  my $vfa = $self->get_adaptor('get_VariationFeatureAdaptor', 'variation');
   if ($so_terms) {
-    my $vfa = $self->get_adaptor('get_VariationFeatureAdaptor', 'variation');
     $vfa->{_ontology_adaptor} ||= $self->hub->get_databases('go')->{'go'}->get_OntologyTermAdaptor;
   }
-  my $all_snps = [ @{$self->Obj->get_all_VariationFeatures($so_terms)} ];
+  my $all_snps = [ @{$vfa->fetch_all_by_Slice_SO_terms($self->Obj, $so_terms)} ];
   my $ngot =  scalar(@$all_snps);
-  push @$all_snps, @{$self->Obj->get_all_somatic_VariationFeatures()};
+  push @$all_snps, @{$vfa->fetch_all_somatic_by_Slice_SO_terms($self->Obj)};
 
   my @on_slice_snps = 
     map  { $_->[1] ? [ $_->[0]->start + $_->[1], $_->[0]->end + $_->[1], $_->[0] ] : () } # [ fake_s, fake_e, SNP ] Filter out any SNPs not on munged slice


### PR DESCRIPTION
This PR replaces methods from the core API that will be deprecated in release 84. All the methods are now in the variation API. We want to get rid of all variation API dependencies in the core API. You need the variation and core API master branches for this PR.