### PR TITLE
Compara stats

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/Compara.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara.pm
@@ -85,7 +85,7 @@ sub format_wga_list {
           my $cgc = $colors[int($gc/25)];
           my $cec = $colors[int($ec/25)];
           $table->add_row({
-            'species' => sprintf('%s (%s)', $info->{$sp}{'common_name'}, $info->{$sp}{'long_name'}),
+            'species' => sprintf('%s (<em>%s</em>)', $info->{$sp}{'common_name'}, $info->{$sp}{'long_name'}),
             'asm'     => $info->{$sp}{'assembly'},
             'gl'      => $self->thousandify($info->{$sp}{'genome_length'}),
             'gc'      => $self->thousandify($info->{$sp}{'genome_coverage'}),

--- a/modules/EnsEMBL/Web/Document/HTML/Compara/BlastZ.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara/BlastZ.pm
@@ -47,7 +47,7 @@ sub render {
       if ($values->[2]) {
           my $mlss_id = $values->[1];
           my $url = '/info/genome/compara/mlss.html?mlss='.$mlss_id;
-          $html .= sprintf '<li><a href="%s">%s (%s)</a></li>', $url, $info->{$other}{'common_name'}, $info->{$other}{'long_name'};
+          $html .= sprintf '<li><a href="%s">%s (<em>%s</em>)</a></li>', $url, $info->{$other}{'common_name'}, $info->{$other}{'long_name'};
       } else {
           $html .= sprintf('<li>%s (%s)</li>', $info->{$other}{'common_name'}, $info->{$other}{'long_name'});
       }

--- a/modules/EnsEMBL/Web/Document/HTML/Compara/BlastZ.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara/BlastZ.pm
@@ -31,6 +31,7 @@ sub render {
   ## Get all the data 
   my $methods = ['BLASTZ_NET', 'LASTZ_NET'];
   my ($species_list, $data) = $self->mlss_data($methods);
+  my ($synt_spec, $data_synt) = $self->mlss_data( ['SYNTENY'] );
 
   ## Do some munging
   my ($species_order, $info) = $self->get_species_info($species_list, 1);
@@ -47,7 +48,14 @@ sub render {
       if ($values->[2]) {
           my $mlss_id = $values->[1];
           my $url = '/info/genome/compara/mlss.html?mlss='.$mlss_id;
-          $html .= sprintf '<li><a href="%s">%s (<em>%s</em>)</a></li>', $url, $info->{$other}{'common_name'}, $info->{$other}{'long_name'};
+          my $txt = sprintf '<a href="%s">%s (<em>%s</em>)</a>', $url, $info->{$other}{'common_name'}, $info->{$other}{'long_name'};
+          if ($sp eq $other) {
+              $txt .= ' [self-alignment]';
+          } elsif ($data_synt->{$sp}{$other} and $data_synt->{$sp}{$other}->[2]) {
+              my $url_synt = '/info/genome/compara/mlss.html?mlss='.$data_synt->{$sp}{$other}->[1];
+              $txt .= sprintf ' with <a href="%s">synteny analysis</a>', $url_synt;
+          }
+          $html .= '<li>'.$txt.'</li>';
       } else {
           $html .= sprintf('<li>%s (%s)</li>', $info->{$other}{'common_name'}, $info->{$other}{'long_name'});
       }

--- a/modules/EnsEMBL/Web/Document/HTML/Compara/MLSS.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara/MLSS.pm
@@ -64,6 +64,9 @@ our %pretty_method = (
   LASTZ_NET           => 'LastZ',
   TRANSLATED_BLAT_NET => 'Translated Blat',
   SYNTENY             => 'Synteny',
+  PECAN               => 'Pecan',
+  EPO                 => 'EPO',
+  EPO_LOW_COVERAGE    => 'EPO-Low-coverage',
 );
 
 our $references = {
@@ -72,6 +75,14 @@ our $references = {
   'BlastZ'          => qq{
     <a href="http://www.genome.org/cgi/content/abstract/13/1/103">Schwartz S et al., Genome Res.;13(1):103-7</a>, 
     <a href="http://www.pnas.org/cgi/content/full/100/20/11484">Kent WJ et al., Proc Natl Acad Sci U S A., 2003;100(20):11484-9</a>
+  },
+  'EPO'             => qq{
+    <a href="http://genome.cshlp.org/content/18/11/1814">Paten B et al., Genome Res,;18(11):1814-28</a>
+    <a href="http://genome.cshlp.org/content/18/11/1829">Paten B et al., Genome Res.;18(11):1829-43</a>
+  },
+  'EPO-Low-coverage'=> qq{
+    <a href="http://genome.cshlp.org/content/18/11/1814">Paten B et al., Genome Res,;18(11):1814-28</a>
+    <a href="http://genome.cshlp.org/content/18/11/1829">Paten B et al., Genome Res.;18(11):1829-43</a>
   }
 };
 
@@ -114,6 +125,8 @@ sub render {
     return $self->render_pairwise($mlss);
   } elsif ($mlss->method->class eq 'SyntenyRegion.synteny') {
     return $self->render_pairwise($mlss);
+  } elsif ($mlss->method->class =~ /^GenomicAlign/) {
+    return $self->print_wga_stats($mlss);
   } else {
     return $self->error_message('No statistics', sprintf('There are no statistics available for the analysis "%s".', $mlss->name), 'warning');
   }

--- a/modules/EnsEMBL/Web/Document/HTML/Compara/MLSS.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara/MLSS.pm
@@ -78,9 +78,10 @@ our $references = {
 ## HTML OUTPUT ######################################
 
 sub error_message {
-  my ($self, $title, $message) = @_;
+  my ($self, $title, $message, $type) = @_;
+  $type ||= 'error';
   return qq{
-      <div class="error left-margin right-margin">
+      <div class="$type left-margin right-margin">
         <h3>$title</h3>
         <div class="message-pad">
           $message
@@ -113,6 +114,8 @@ sub render {
     return $self->render_pairwise($mlss);
   } elsif ($mlss->method->class eq 'SyntenyRegion.synteny') {
     return $self->render_pairwise($mlss);
+  } else {
+    return $self->error_message('No statistics', sprintf('There are no statistics available for the analysis "%s".', $mlss->name), 'warning');
   }
 }
 

--- a/modules/EnsEMBL/Web/Document/HTML/Compara/MLSS.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara/MLSS.pm
@@ -395,8 +395,8 @@ sub fetch_pairwise_input {
     my $ref_species                   = $mlss->get_value_for_tag('reference_species');
     my $non_ref_species               = $mlss->get_value_for_tag('non_reference_species');
     my $pairwise_params               = $mlss->get_value_for_tag('param');
-    my $ref_genome_db                 = $genome_db_adaptor->fetch_by_name_assembly($ref_species);
-    my $non_ref_genome_db             = $genome_db_adaptor->fetch_by_name_assembly($non_ref_species);
+    my $ref_genome_db                 = $genome_db_adaptor->fetch_by_name_assembly($ref_species) || die "Could not find the GenomeDB '$ref_species' for mlss $mlss_id";
+    my $non_ref_genome_db             = $genome_db_adaptor->fetch_by_name_assembly($non_ref_species) || die "Could not find the GenomeDB '$non_ref_species' for mlss $mlss_id";
       
     ## hack for double-quotes
     my $string_ref_dna_collection_config  = $mlss->get_value_for_tag("ref_dna_collection");

--- a/modules/EnsEMBL/Web/Document/HTML/Compara/MLSS.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara/MLSS.pm
@@ -91,12 +91,12 @@ our $references = {
 sub error_message {
   my ($self, $title, $message, $type) = @_;
   $type ||= 'error';
+  $message .= '<p>Please email a report giving the URL and details on how to replicate the error (for example, how you got here), to helpdesk@ensembl.org</p>' if $type ne 'info';
   return qq{
       <div class="$type left-margin right-margin">
         <h3>$title</h3>
         <div class="message-pad">
           $message
-          <p>Please email a report giving the URL and details on how to replicate the error (for example, how you got here), to helpdesk\@ensembl.org</p>
         </div>
       </div>
   };


### PR DESCRIPTION
Several changes in the Compara documention

http://enssand-01.internal.sanger.ac.uk:9073/info/genome/compara/analyses.html is quite different and is faster than http://www.ensembl.org/info/genome/compara/analyses.html

Multiple alignments have their own page:
http://enssand-01.internal.sanger.ac.uk:9073/info/genome/compara/mlss.html?mlss=780

Stats for self-alignments are not duplicated any more:
http://enssand-01.internal.sanger.ac.uk:9073/info/genome/compara/mlss.html?mlss=739
http://www.ensembl.org/info/genome/compara/mlss.html?mlss=739