### PR TITLE
Remove eval and erroneous empty hashref return

### DIFF
--- a/modules/EnsEMBL/Web/Component/Transcript/Haplotypes.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/Haplotypes.pm
@@ -203,11 +203,7 @@ sub render_haplotype_row {
   my $pop_struct  = $self->object->population_structure($pop_objs);
   my %pop_descs   = map {$_->name => $_->description} @$pop_objs;
 
-  my $flags;
-  if ($ht->can('get_all_flags')) {
-    $flags = eval { $ht->get_all_flags(); };
-  }
-  return {} if ($@ || !scalar(@{$flags||[]}));
+  my $flags = $ht->can('get_all_flags')) ? $flags = $ht->get_all_flags() : [];
   
   my $flags_html;
 


### PR DESCRIPTION
get_all_flags method only exists on ProteinHaplotype but not on CDSHaplotype, so the can() test is valid and doesn't require eval