### PR TITLE
Fixing BED. Missed conversion to 0-based start

### DIFF
--- a/modules/EnsEMBL/Web/Object/Export.pm
+++ b/modules/EnsEMBL/Web/Object/Export.pm
@@ -805,6 +805,8 @@ sub feature {
   }   
   if($format eq 'bed'){
     @mapping_result = qw(seqid start end name score strand);
+    # move coords into zero-based start
+    $vals{'start'} = $vals{'start'} - 1 if defined $vals{'start'};
     $vals{'name'} = $feature->display_id;
   }
   else {


### PR DESCRIPTION
Seems we did not minus 1 from our output when we were exporting into BED. Since BED is 0-based start and 1-based end we only need to minus this from the start. We assume all input coordinates are 1-based (they're from the API so this should be right).