### PR TITLE
set tmpdir to web tmpdir when using remote VCFs

### DIFF
--- a/modules/EnsEMBL/Web/DBSQL/DBConnection.pm
+++ b/modules/EnsEMBL/Web/DBSQL/DBConnection.pm
@@ -63,6 +63,7 @@ sub {
   if($c && $vdb->can('use_vcf')) {
     $vdb->vcf_config_file($c->{'CONFIG'});
     $vdb->vcf_root_dir($sd->DATAFILE_BASE_PATH);
+    $vdb->vcf_tmp_dir($sd->ENSEMBL_TMP_DIR);
     $vdb->use_vcf($c->{'ENABLED'});
   }
 },


### PR DESCRIPTION
This is a change to support e!Genomes using the VCF backend with FTP-hosted VCFs.

The relevant support for this is only on master in ensembl-variation (not release/84), so only committing to master here.

@nicklangridge do you need this for release/84 too???