### PR TITLE
Use the hit description before looking for interpro description

### DIFF
--- a/modules/EnsEMBL/Web/Component/Transcript/DomainSpreadsheet.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/DomainSpreadsheet.pm
@@ -92,7 +92,7 @@ sub content {
       
       $table->add_row({
         type     => $db,
-        desc     => $domain->idesc || '-',
+        desc     => $domain->hdescription || $domain->idesc || '-',
         acc      => $hub->get_ExtURL_link($id, uc $db, $id),
         start    => $domain->start,
         end      => $domain->end,


### PR DESCRIPTION
Requested by @markmcdowall
Seems reasonable, but not sure if Ensembl has specific reason to avoid the hit description.