### PR TITLE
feat(Ontology): add "View associated genes" link if we don't have chr…

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/Go.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/Go.pm
@@ -101,7 +101,7 @@ sub process_data {
     my $hash        = $data->{$go} || {};
     my $go_link     = $hub->get_ExtURL_link($go, $extdb, $go);
     my $mart_link   = $self->biomart_link($go) ? "<li>".$self->biomart_link($go)."</li>": "";
-    my $loc_link    = scalar @{$self->hub->species_defs->ENSEMBL_CHROMOSOMES} ? '<li><a rel="notexternal" href="'.$hub->url({type  => 'Location', action => 'Genome', ftype => 'Gene', id  => $go, gotype => $extdb}).'">View on karyotype</a></li>' : "";
+    my $loc_link    = '<li><a rel="notexternal" href="' . $hub->url({type  => 'Location', action => 'Genome', ftype => 'Gene', id  => $go, gotype => $extdb}) . ( scalar @{$self->hub->species_defs->ENSEMBL_CHROMOSOMES} ? '">View on karyotype</a></li>' : '">View associated genes</a></li>' );
 
     my $goslim      = $hash->{'goslim'} || {};
     my $row         = {};


### PR DESCRIPTION
…omosome

Previously in Ensembl, where we have a chromosome, the ontology table offers a link to view xrefs on the karyotype, e.g.'View on karyotype'.

This change offers a link ("View associated genes") to the whole genome view if we don't have a chromosome.

This change also shows titles like "Locations of Genes associated with GO:0005634 nucleus" even if there is no karyotype image.

Related to ENSEMBL-4466.