### PR TITLE
feat(Ontology): add "View associated genes" link if we don't have chr…

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/Go.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/Go.pm
@@ -101,7 +101,7 @@ sub process_data {
     my $hash        = $data->{$go} || {};
     my $go_link     = $hub->get_ExtURL_link($go, $extdb, $go);
     my $mart_link   = $self->biomart_link($go) ? "<li>".$self->biomart_link($go)."</li>": "";
-    my $loc_link    = scalar @{$self->hub->species_defs->ENSEMBL_CHROMOSOMES} ? '<li><a rel="notexternal" href="'.$hub->url({type  => 'Location', action => 'Genome', ftype => 'Gene', id  => $go, gotype => $extdb}).'">View on karyotype</a></li>' : "";
+    my $loc_link    = '<li><a rel="notexternal" href="' . $hub->url({type  => 'Location', action => 'Genome', ftype => 'Gene', id  => $go, gotype => $extdb}) . ( scalar @{$self->hub->species_defs->ENSEMBL_CHROMOSOMES} ? '">View on karyotype</a></li>' : '">View associated genes</a></li>' );
 
     my $goslim      = $hash->{'goslim'} || {};
     my $row         = {};

--- a/modules/EnsEMBL/Web/Component/Location/Genome.pm
+++ b/modules/EnsEMBL/Web/Component/Location/Genome.pm
@@ -385,14 +385,47 @@ sub _feature_table {
 sub _configure_Gene_table {
   my ($self, $feature_type, $feature_set) = @_;
   my $rows = [];
- 
+
   my $header = 'Gene Information';
+  my $count  = scalar @{$feature_set->[0]};
   if ($self->hub->param('ftype') eq 'Domain') {
     ## Override default header
     my $domain_id = $self->hub->param('id');
-    my $count     = scalar @{$feature_set->[0]};
     my $plural    = $count > 1 ? 'genes' : 'gene';
     $header       = "Domain $domain_id maps to $count $plural:";
+  } elsif ( !( scalar ($self->hub->species_defs->ENSEMBL_CHROMOSOMES || []) && $self->hub->species_defs->MAX_CHR_LENGTH ) ) {
+    ## No karyotype image
+    my ( $go_link, $xref_type, $xref_name );
+    my $id = $self->hub->param('id');
+    
+    #add extra description only for GO (gene ontologies) which is determined by param gotype in url
+    my $go = $self->hub->param('gotype');
+    if ( $go ) {
+      my $adaptor = $self->hub->get_databases('go')->{'go'}->get_OntologyTermAdaptor;
+      my $go_hash = $adaptor->fetch_by_accession($id);
+      my $go_name = $go_hash->{name};
+      $go_link    = $self->hub->get_ExtURL_link($id, $go, $id)." ".$go_name; #get_ExtURL_link will return a text if $go is not valid
+    }
+
+    if ( $feature_type eq 'Xref' ) {
+      my $sample = $feature_set->[0];
+      $xref_type = $sample->{'label'};
+      $xref_name = $sample->{'extname'};
+      $xref_name =~ s/ \[#\]//;
+      $xref_name =~ s/^ //;
+    }
+    
+    my $assoc_name = $self->hub->param('name');
+    unless ( $assoc_name ) {
+      $assoc_name = $xref_type . ' ';
+      $assoc_name .= $go_link ? $go_link : $id;
+      $assoc_name .= " ($xref_name)" if $xref_name;
+    }
+
+    if ( $assoc_name ) {
+      my $plural = $count > 1 ? 'Genes' : 'Gene';
+      $header = "$plural associated with $assoc_name";
+    }
   }
 
   my $column_order = [qw(names loc extname)];

--- a/modules/EnsEMBL/Web/Component/Location/Genome.pm
+++ b/modules/EnsEMBL/Web/Component/Location/Genome.pm
@@ -395,7 +395,7 @@ sub _configure_Gene_table {
     $header       = "Domain $domain_id maps to $count $plural:";
   } elsif ( !( scalar ($self->hub->species_defs->ENSEMBL_CHROMOSOMES || []) && $self->hub->species_defs->MAX_CHR_LENGTH ) ) {
     ## No karyotype image
-    my ( $go_link, $xref_type, $xref_name );
+    my ( $go_link );
     my $id = $self->hub->param('id');
     
     #add extra description only for GO (gene ontologies) which is determined by param gotype in url
@@ -407,19 +407,9 @@ sub _configure_Gene_table {
       $go_link    = $self->hub->get_ExtURL_link($id, $go, $id)." ".$go_name; #get_ExtURL_link will return a text if $go is not valid
     }
 
-    if ( $feature_type eq 'Xref' ) {
-      my $sample = $feature_set->[0];
-      $xref_type = $sample->{'label'};
-      $xref_name = $sample->{'extname'};
-      $xref_name =~ s/ \[#\]//;
-      $xref_name =~ s/^ //;
-    }
-    
     my $assoc_name = $self->hub->param('name');
     unless ( $assoc_name ) {
-      $assoc_name = $xref_type . ' ';
       $assoc_name .= $go_link ? $go_link : $id;
-      $assoc_name .= " ($xref_name)" if $xref_name;
     }
 
     if ( $assoc_name ) {


### PR DESCRIPTION
…omosome

Previously in Ensembl, where we have a chromosome, the ontology table offers a link to view xrefs on the karyotype, e.g.'View on karyotype'.

This change offers a link ("View associated genes") to the whole genome view if we don't have a chromosome.

This change also shows titles like "Locations of Genes associated with GO:0005634 nucleus" for the gene table when there is no karyotype image.

Related to ENSEMBL-4466.