### PR TITLE
fix(GeneTree): fix an issue in Compara tree view the "collapse all th…

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -378,7 +378,6 @@ sub collapsed_nodes {
   my $action                 = shift;
   my $highlight_genome_db_id = shift;
   my $highlight_gene         = shift;
-  return unless $node;
   
   die "Need a GeneTreeNode, not a $tree" unless $tree->isa('Bio::EnsEMBL::Compara::GeneTreeNode');
   die "Need an GeneTreeMember, not a $node" if $node && !$node->isa('Bio::EnsEMBL::Compara::GeneTreeMember');
@@ -388,6 +387,7 @@ sub collapsed_nodes {
   
   # View current gene
   if ($action eq 'gene') {
+    return unless $node;
     $collapsed_nodes{$_->node_id} = $_ for @{$node->get_all_adjacent_subtrees};
     
     if ($highlight_gene) {
@@ -403,6 +403,7 @@ sub collapsed_nodes {
       }
     }
   } elsif ($action eq 'paralogs') { # View all paralogs
+    return unless $node;
     my $gdb_id = $node->genome_db_id;
     
     foreach my $leaf (@{$tree->get_all_leaves}) {

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -426,7 +426,7 @@ sub collapsed_nodes {
     }
   } elsif ($action =~ /rank_(\w+)/) {
     my $asked_rank = $1;
-    my @rank_order = qw(subspecies species subgenus genus subfamily family superfamily parvorder infraorder suborder order superorder infraclass subclass class superclass subphylum phylum superphylum subkingdom kingdom);
+    my @rank_order = qw(subspecies species subgenus genus subfamily family superfamily parvorder infraorder suborder order superorder infraclass subclass class superclass subphylum phylum superphylum subkingdom kingdom superkingdom);
     my %rank_pos = map {$rank_order[$_] => $_} 0..(scalar(@rank_order)-1);
     my @nodes_to_check = ($tree);
     while (@nodes_to_check) {
@@ -448,6 +448,7 @@ sub collapsed_nodes {
       } else {
         $this_rank = $rank_pos{$this_rank};
       }
+      $this_rank = scalar(@rank_order) unless defined $this_rank;
       if ($this_rank <= $rank_pos{$asked_rank}) {
         $collapsed_nodes{$internal_node->node_id} = $internal_node;
       } else {


### PR DESCRIPTION
…e nodes at rank X" doesn't work

This issue was caused by the early return by one of the subroutines. Check the validity of an argument only when needed to ensure other branches still work as before.

Related to ENSEMBL-4488.