### PR TITLE
Fix intermittent 'no data' bug for population image/table

### DIFF
--- a/modules/EnsEMBL/Web/Component/Transcript/PopulationImage.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/PopulationImage.pm
@@ -36,6 +36,17 @@ sub content {
   my $stable_id = $object->stable_id;
   my $extent    = $object->extent;
   
+  # set up VCF if needed
+  my $vdb           = $object->Obj->adaptor->db->get_db_adaptor('variation');
+  my $species_defs  = $self->hub->species_defs;
+  my $collections   = $species_defs->ENSEMBL_VCF_COLLECTIONS;
+
+  if($collections && $vdb->can('use_vcf')) {
+    $vdb->vcf_config_file($collections->{'CONFIG'});
+    $vdb->vcf_root_dir($species_defs->DATAFILE_BASE_PATH);
+    $vdb->use_vcf($collections->{'ENABLED'});
+  }
+  
   # Get two slices -  gene (4/3x) transcripts (+-EXTENT)
   foreach my $slice_type (
     [ 'transcript',     'normal', '20%'  ],

--- a/modules/EnsEMBL/Web/Component/Transcript/PopulationTable.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/PopulationTable.pm
@@ -103,6 +103,18 @@ sub get_page_data {
   my $object     = $self->object;
   my $transcript = $object->Obj;
   my %snp_data;
+  
+  # set up VCF if needed
+  my $vdb           = $object->Obj->adaptor->db->get_db_adaptor('variation');
+  my $species_defs  = $self->hub->species_defs;
+  my $collections   = $species_defs->ENSEMBL_VCF_COLLECTIONS;
+
+  if($collections && $vdb->can('use_vcf')) {
+    $vdb->vcf_config_file($collections->{'CONFIG'});
+    $vdb->vcf_root_dir($species_defs->DATAFILE_BASE_PATH);
+    $vdb->use_vcf($collections->{'ENABLED'});
+  }
+  
   my $strain_slice_adaptor = $hub->database('variation')->get_StrainSliceAdaptor;
   
   my $con_format = $hub->param('consequence_format');


### PR DESCRIPTION
More details in JIRA ENSEMBL-4500

This fix configures the variation db to use VCF files if that is what is configured for the species - without it we will sometimes get adaptors that don't use the VCF and so return no data.

It's a pragmatic fix; it feels like a hack to put this configuration in the components and better solution might be to do it in a generic way at the time the adaptors are created. But after talking with @ens-ds23 it sounds like this approach has been tried before and is difficult to get right.