### PR TITLE
show variants with identical alleles when descriptions normalised

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -743,7 +743,7 @@ sub three_prime_co_located{
   
     return [
       'Variants with equivalent alleles',
-      sprintf('<p>This variant has <strong>%s</strong> variants with equivalent alleles - <a title="Click to show variants" rel="shifted_co_located" href="#" class="toggle_link toggle %s _slide_toggle set_cookie ">%s</a></p><div class="shifted_co_located twocol-cell"><div class="toggleable" style="font-weight:normal;%s"><ul>%s</ul></div></div>',
+      sprintf('<p>There are <strong>%s</strong> variants with equivalent alleles to this variant- <a title="Click to show variants" rel="shifted_co_located" href="#" class="toggle_link toggle %s _slide_toggle set_cookie ">%s</a></p><div class="shifted_co_located twocol-cell"><div class="toggleable" style="font-weight:normal;%s"><ul>%s</ul></div></div>',
         $count,
         $show ? 'open' : 'closed',        
         $show ? 'Hide' : 'Show',

--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -56,6 +56,7 @@ sub content {
     $self->evidence_status,
     $self->clinical_significance,
     $self->synonyms,
+    $self->object->vari_class eq 'SNP' ? () : $self->three_prime_co_located(),
     $self->hgvs,
     $self->sets,
     @str_array ? ['About this variant', sprintf('This variant %s.', $self->join_with_and(@str_array))] : ()
@@ -715,6 +716,48 @@ sub most_severe_consequence {
     }
   }
   return ();
+}
+
+## if an insertion/ deletion is described at its most 3' location 
+## possible, is it co-located with other variants?
+sub three_prime_co_located{
+  my $self  = shift;
+
+  my $shifted_co_located = $self->object->get_three_prime_co_located();
+
+  return undef unless defined $shifted_co_located;
+
+  my $count;
+  my @scl;
+
+  foreach my $scl (@{$shifted_co_located}){
+    my $link      = $self->hub->url({ action => 'Explore', v => $scl });
+
+    my $variation = qq{<a href="$link">$scl</a>};
+    $count++;
+    push @scl, $variation;
+  }
+
+  if ($count > 3) {
+    my $show = $self->hub->get_cookie_value('toggle_shifted_co_located') eq 'open';
+  
+    return [
+      'Variants with equivalent alleles',
+      sprintf('<p>This variant has <strong>%s</strong> variants with equivalent alleles - <a title="Click to show variants" rel="shifted_co_located" href="#" class="toggle_link toggle %s _slide_toggle set_cookie ">%s</a></p><div class="shifted_co_located twocol-cell"><div class="toggleable" style="font-weight:normal;%s"><ul>%s</ul></div></div>',
+        $count,
+        $show ? 'open' : 'closed',        
+        $show ? 'Hide' : 'Show',
+        $show ? '' : 'display:none',
+        join('', map "<li>$_</li>", @scl)
+      )
+    ];
+  }
+  else {
+
+    my $html = join ', ', @scl;
+    my $s = ($count > 1) ? 's' : '';
+    return ["Variant$s with equivalent alleles", $html];
+  }
 }
 
 sub text_separator {

--- a/modules/EnsEMBL/Web/Object/Variation.pm
+++ b/modules/EnsEMBL/Web/Object/Variation.pm
@@ -1735,6 +1735,21 @@ sub hgvs_url {
   return [ $hub->url($p), encode_entities($refseq), encode_entities($hgvs_string) ];
 }
 
+
+## extract the names of any variants whch would be in the same location
+## if both were described at the most 3' location possible
+## insertions/ deletions only
+sub get_three_prime_co_located{
+
+    my $self = shift;
+
+    my $attribs = $self->Obj->get_all_attributes();
+
+    @{$self->{'shifted_co_located'}}  = ( exists $attribs->{"co-located allele"} ? split/\,/, $attribs->{"co-located allele"} : '');
+    return $self->{'shifted_co_located'};
+}
+
+
 ## extract data for table of publications citing this variant
 sub get_citation_data{
 


### PR DESCRIPTION
Insertions and deletions in dbSNP do not have their positions normalised, so a variant in a repetitive sequence may have multiple records with with different rs ids reflecting different possible positions. We are now comparing all insertions/deletions and flagging matching records.