### PR TITLE
url for VGNC symbols

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -324,6 +324,7 @@ GENOSCOPE_PRED_TRANSCRIPT   =
 GO                          = http://www.ebi.ac.uk/ego/GTerm?id=###ID###
 GOSLIM_GOA                  = http://www.ebi.ac.uk/ego/GTerm?id=###ID###
 HGNC                        = http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=###ID###
+VGNC                        = http://vertebrate.genenames.org/data/gene-symbol-report/#/vgnc_id/###ID###
 HPA                         = http://www.proteinatlas.org/tissue_profile.php?antibody_id=###ID###
 IMGT/GENE_DB                = http://www.imgt.org/IMGT_GENE-DB/GENElect?query=2+###ID###&species=Homo+sapiens
 INTERACTIVEFLY              = http://www.sdbonline.org/fly###ID###


### PR DESCRIPTION
we have new VGNC (Vertebrate Gene Nomenclature Committee) symbols for this release, only for chimp
note the website is not live yet, but they promised it would be by the end of the week