### PR TITLE
More WGA stats

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/Compara.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara.pm
@@ -78,7 +78,7 @@ sub print_wga_stats {
       if ($species_order && scalar(@{$species_order||[]})) {
         my $rel = $mlss->get_value_for_tag('ensembl_release');
         my $nblocks = $self->thousandify($mlss->get_value_for_tag('num_blocks'));
-        my $max_align = $self->thousandify($mlss->max_alignment_length);
+        my $max_align = $self->thousandify($mlss->max_alignment_length - 1);
         my $count = scalar(@$species_order);
         $html .= sprintf('<h1>%s</h1>', $mlss->name);
         $html .= qq{<p>This alignment has been generated in $site release $rel and is composed of $nblocks blocks (up to $max_align&nbsp;bp long).</p>};

--- a/modules/EnsEMBL/Web/Document/HTML/Compara/MLSS.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara/MLSS.pm
@@ -359,12 +359,14 @@ some being recent and almost identical, others being much older and indicators o
             <b>Uncovered</b>: %s out of %s<br />
             <b>Matches</b>: %s out of %s<br />
             <b>Mismatches</b>: %s out of %s<br />
-            <b>Insertions</b>: %s out of %s
+            <b>Insertions</b>: %s out of %s<br />
+            <em>Identity over aligned base-pairs: %.1f%%</em>
           </p>',
           $self->thousandify($uncovered), $self->thousandify($total),
           $self->thousandify($matches), $self->thousandify($total),
           $self->thousandify($mismatches), $self->thousandify($total),
           $self->thousandify($insertions), $self->thousandify($total),
+          100 * $matches/($matches+$mismatches+$insertions),
         );
 
         my $match_pc  = round($matches/$total * 100);


### PR DESCRIPTION
A couple of commits to add more stats in the WGA pages:
 - a barplot distribution of the size of the alignment blocks
 - added the %identity at the exon level
All the stats were already in the database, so it was just a matter of displaying them

Pairwise alignments:
http://enssand-01.internal.sanger.ac.uk:9073/info/genome/compara/mlss.html?mlss=688 vs http://www.ensembl.org/info/genome/compara/mlss.html?mlss=688

Multiple alignments
http://enssand-01.internal.sanger.ac.uk:9073/info/genome/compara/mlss.html?mlss=647 vs http://www.ensembl.org/info/genome/compara/mlss.html?mlss=647