### PR TITLE
fix(regression): add back changes in 03a3273 and 0c6239a that were ov…

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -379,7 +379,6 @@ sub collapsed_nodes {
   my $action                 = shift;
   my $highlight_genome_db_id = shift;
   my $highlight_gene         = shift;
-  return unless $node;
   
   die "Need a GeneTreeNode, not a $tree" unless $tree->isa('Bio::EnsEMBL::Compara::GeneTreeNode');
   die "Need an GeneTreeMember, not a $node" if $node && !$node->isa('Bio::EnsEMBL::Compara::GeneTreeMember');
@@ -389,6 +388,7 @@ sub collapsed_nodes {
   
   # View current gene
   if ($action eq 'gene') {
+    return unless $node;
     $collapsed_nodes{$_->node_id} = $_ for @{$node->get_all_adjacent_subtrees};
     
     if ($highlight_gene) {
@@ -404,6 +404,7 @@ sub collapsed_nodes {
       }
     }
   } elsif ($action eq 'paralogs') { # View all paralogs
+    return unless $node;
     my $gdb_id = $node->genome_db_id;
     
     foreach my $leaf (@{$tree->get_all_leaves}) {
@@ -426,7 +427,7 @@ sub collapsed_nodes {
     }
   } elsif ($action =~ /rank_(\w+)/) {
     my $asked_rank = $1;
-    my @rank_order = qw(subspecies species subgenus genus subfamily family superfamily parvorder infraorder suborder order superorder infraclass subclass class superclass subphylum phylum superphylum subkingdom kingdom);
+    my @rank_order = qw(subspecies species subgenus genus subfamily family superfamily parvorder infraorder suborder order superorder infraclass subclass class superclass subphylum phylum superphylum subkingdom kingdom superkingdom);
     my %rank_pos = map {$rank_order[$_] => $_} 0..(scalar(@rank_order)-1);
     my @nodes_to_check = ($tree);
     while (@nodes_to_check) {
@@ -448,6 +449,7 @@ sub collapsed_nodes {
       } else {
         $this_rank = $rank_pos{$this_rank};
       }
+      $this_rank = scalar(@rank_order) unless defined $this_rank;
       if ($this_rank <= $rank_pos{$asked_rank}) {
         $collapsed_nodes{$internal_node->node_id} = $internal_node;
       } else {


### PR DESCRIPTION
…erwritten in change f91ecf1

The changes to fix the issue ENSEMBL-4488 (https://github.com/Ensembl/ensembl-webcode/pull/428/commits/03a327359a359acc91927db67dbae1afdd241aad, https://github.com/Ensembl/ensembl-webcode/pull/428/commits/0c6239a23b5d8360c55ddfbb7ec883be493a9cd4
) were overwritten by the change to fix the issue ENSWEB-2565:
https://github.com/Ensembl/ensembl-webcode/commit/f91ecf11cbb70655d6803dd5029160f0b64a245c

Both issues were tested OK.