### PR TITLE
updates to use new ld binary from ensembl-variation

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -49,6 +49,7 @@ ENSEMBL_BINARIES_PATH         = /local/bin                  ;DotterView
 ENSEMBL_EMBOSS_PATH           = /local/bin/emboss           ;AlignView
 ENSEMBL_WISE2_PATH            = /local/bin/wise2            ;AlignView
 ENSEMBL_CALC_GENOTYPES_FILE   = /local/bin/calc_genotypes
+ENSEMBL_LD_VCF_FILE           = /local/bin/ld_vcf
 
 ;
 ; Free-text search configuration

--- a/modules/EnsEMBL/Web/Component/Location/LDImage.pm
+++ b/modules/EnsEMBL/Web/Component/Location/LDImage.pm
@@ -51,8 +51,9 @@ sub content {
   }
   
   ## set path information for LD calculations
-  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::BINARY_FILE = $hub->species_defs->ENSEMBL_CALC_GENOTYPES_FILE;
-  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::TMP_PATH    = $hub->species_defs->ENSEMBL_TMP_TMP;
+  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::BINARY_FILE     = $hub->species_defs->ENSEMBL_CALC_GENOTYPES_FILE;
+  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::VCF_BINARY_FILE = $hub->species_defs->ENSEMBL_LD_VCF_FILE;
+  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::TMP_PATH        = $hub->species_defs->ENSEMBL_TMP_TMP;
   
   my $image_config = $hub->get_imageconfig('ldview');
   my $parameters   = { 

--- a/modules/EnsEMBL/Web/Component/Variation/HighLD.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/HighLD.pm
@@ -252,8 +252,9 @@ sub linked_var_table {
   my $pop          = $variation->adaptor->db->get_PopulationAdaptor->fetch_by_dbID($selected_pop);
   
   ## set path information for LD calculations  
-  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::BINARY_FILE = $species_defs->ENSEMBL_CALC_GENOTYPES_FILE;
-  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::TMP_PATH    = $species_defs->ENSEMBL_TMP_TMP;
+  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::BINARY_FILE     = $species_defs->ENSEMBL_CALC_GENOTYPES_FILE;
+  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::VCF_BINARY_FILE = $species_defs->ENSEMBL_LD_VCF_FILE;
+  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::TMP_PATH        = $species_defs->ENSEMBL_TMP_TMP;
   
   my $v               = $object->name;
   my $source          = $variation->source_name;

--- a/modules/EnsEMBL/Web/Component/Variation/LDPlot.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/LDPlot.pm
@@ -59,8 +59,9 @@ sub content {
   }
   
   ## set path information for LD calculations
-  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::BINARY_FILE = $hub->species_defs->ENSEMBL_CALC_GENOTYPES_FILE;
-  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::TMP_PATH    = $hub->species_defs->ENSEMBL_TMP_TMP;
+  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::BINARY_FILE     = $hub->species_defs->ENSEMBL_CALC_GENOTYPES_FILE;
+  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::VCF_BINARY_FILE = $hub->species_defs->ENSEMBL_LD_VCF_FILE;
+  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::TMP_PATH        = $hub->species_defs->ENSEMBL_TMP_TMP;
 
   my $seq_region = $v->{'Chr'};
   my $seq_type   = $v->{'type'};

--- a/modules/EnsEMBL/Web/Component/Variation/PairwiseLD.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/PairwiseLD.pm
@@ -91,8 +91,9 @@ sub content_results {
   $second_variant_name =~ s/\s+$//;
 
   # set path information for LD calculations
-  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::BINARY_FILE = $species_defs->ENSEMBL_CALC_GENOTYPES_FILE;
-  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::TMP_PATH = $species_defs->ENSEMBL_TMP_TMP;
+  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::BINARY_FILE     = $species_defs->ENSEMBL_CALC_GENOTYPES_FILE;
+  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::VCF_BINARY_FILE = $species_defs->ENSEMBL_LD_VCF_FILE;
+  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::TMP_PATH        = $species_defs->ENSEMBL_TMP_TMP;
 
   my $ldfca = $variant->adaptor->db->get_LDFeatureContainerAdaptor;
   my $va = $variant->adaptor->db->get_VariationAdaptor;

--- a/modules/EnsEMBL/Web/Object/Location.pm
+++ b/modules/EnsEMBL/Web/Object/Location.pm
@@ -1218,8 +1218,9 @@ sub ld_for_slice {
 
   my ($self, $pop_obj, $width) = @_;
   ## set path information for LD calculations
-  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::BINARY_FILE = $self->species_defs->ENSEMBL_CALC_GENOTYPES_FILE;
-  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::TMP_PATH = $self->species_defs->ENSEMBL_TMP_TMP;
+  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::BINARY_FILE     = $self->species_defs->ENSEMBL_CALC_GENOTYPES_FILE;
+  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::VCF_BINARY_FILE = $self->species_defs->ENSEMBL_LD_VCF_FILE;
+  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::TMP_PATH        = $self->species_defs->ENSEMBL_TMP_TMP;
 
   my ($seq_region, $start, $end, $seq_type ) = ($self->seq_region_name, $self->seq_region_start, $self->seq_region_end, $self->seq_region_type);
   $width = $self->param('w') || $end - $start unless $width;
@@ -1373,8 +1374,9 @@ sub get_ld_values {
   my ($populations, $snp) = @_;
   
   ## set path information for LD calculations
-  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::BINARY_FILE = $self->species_defs->ENSEMBL_CALC_GENOTYPES_FILE;
-  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::TMP_PATH = $self->species_defs->ENSEMBL_TMP_TMP;
+  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::BINARY_FILE     = $self->species_defs->ENSEMBL_CALC_GENOTYPES_FILE;
+  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::VCF_BINARY_FILE = $self->species_defs->ENSEMBL_LD_VCF_FILE;
+  $Bio::EnsEMBL::Variation::DBSQL::LDFeatureContainerAdaptor::TMP_PATH        = $self->species_defs->ENSEMBL_TMP_TMP;
   
   my %ld_values;
   my $display_zoom = $self->round_bp($self->seq_region_end - $self->seq_region_start);


### PR DESCRIPTION
We have a new, faster method for calculating LD from VCF files.

This involves compiling and installing a new binary; this PR contains the config to point to that and set it up for use when the appropriate method is called.

For 86 e! webservers will need to have this new ld_vcf binary in $PATH (I've copied the current DEFAULTS.ini setup for the existing calc_genotypes binary, which is still required).

Compilation instructions are in the [README](https://github.com/Ensembl/ensembl-variation/blob/master/C_code/README.txt).