### PR TITLE
Skip error messages that we don't care about while attaching trackhubs

### DIFF
--- a/modules/EnsEMBL/Web/File/AttachedFormat/TRACKHUB.pm
+++ b/modules/EnsEMBL/Web/File/AttachedFormat/TRACKHUB.pm
@@ -50,13 +50,13 @@ sub check_data {
   my $hubCheck = $self->{'hub'}->species_defs->HUBCHECK_BIN;
   if ($hubCheck && !$self->{'registry'}) {
     my $url = $self->{'url'};
-    my $hc_error = system("$hubCheck $url -checkSettings -noTracks");
+    my $hc_error = `$hubCheck $url -checkSettings -noTracks`;	
     if ($hc_error) {
       ## Parse and ignore issues we don't care about
       my @lines = split /\n/, $hc_error;
       my $problematic = 0;
       for my $line (@lines) {
-        next if $line =~ /deprecated|cram/;
+        next if $line =~ m/deprecated|cram|^Found\s[0-9]*\sproblems?:$/;
         $problematic = 1;
       }
       $error = qq(<p>The trackhub at $url failed to validate with <a href="https://genome.ucsc.edu/goldenpath/help/hgTrackHubHelp.html#Debug">hubCheck</a>. Please contact the creator of this hub if you wish to use it with Ensembl.</p>) if $problematic;


### PR DESCRIPTION
This is an extension to the commit by Anne
https://github.com/Ensembl/ensembl-webcode/commit/5641ad73378129ec6c5e91578c3c9b5f511709f7

Takes care of error messages like the following:
Found 1 problem:
Unsupported type 'cram' in hub ftp://ftp.ensemblgenomes.org/pub/misc_data/Track_Hubs/SRP033660/hub.txt genome TAIR10 track SRR1046889

Also changed the way we run the hubcheck command. system() is returning exit status information rather than the command output. So, using Backticks.