### PR TITLE
Add 'sub_type' as a valid config item back to EnsEMBL::Draw::GlyphSet…

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/flat_file.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/flat_file.pm
@@ -42,7 +42,7 @@ sub get_data {
   my $container    = $self->{'container'};
   my $hub          = $self->{'config'}->hub;
   my $species_defs = $self->species_defs;
-  my $type         = $self->my_config('type');
+  my $type         = $self->my_config('type') || $self->my_config('sub_type');
   my $format       = $self->my_config('format');
   my $legend       = {};
 


### PR DESCRIPTION
…::flat_file

Since this change (https://github.com/Ensembl/ensembl-webcode/commit/f2f2654b8520b67fb5bea028406316708f676094),
the 'sub_type' config item has been replaced with 'type'. But there are still places
where 'sub_type' is used instead.

Fixes ENSEMBL-4628.