### PR TITLE
'Add Feature' modal on chromosome page needs to default to current species

### DIFF
--- a/modules/EnsEMBL/Web/Component/UserData.pm
+++ b/modules/EnsEMBL/Web/Component/UserData.pm
@@ -126,21 +126,20 @@ sub userdata_form {
   $fieldset->add_field({
     'label'         => 'Species',
     'elements'      => [{
-      'type'          => 'speciesdropdown',
-      'name'          => 'species',
-      'values'        => [ map {
-        'value'         => $_->{'value'},
-        'caption'       => $_->{'caption'},
-        'class'         => '_stt',
-        'checked'       => $_->{'value'} eq $current_species ? 1 : 0
-      }, @species ]
-    }, {
       'type'          => 'noedit',
-      'value'         => 'Assembly: '. join('', map { sprintf '<span class="_stt_%s">%s</span>', $_->{'value'}, $_->{'assembly'} } @species),
+      'name'          => 'species_display',
+      'value'         => $sd->species_label($current_species),
+      'no_input'      => 1, 
+    },
+     {
+      'type'          => 'noedit',
+      'value'         => 'Assembly: '. $sd->get_config($current_species, 'ASSEMBLY_VERSION'),
       'no_input'      => 1,
       'is_html'       => 1
     }]
   });
+
+  $fieldset->add_hidden({'name' => 'species', 'value' => $current_species});
 
   $fieldset->add_field({
     'label'         => 'Data',

--- a/modules/EnsEMBL/Web/Component/UserData.pm
+++ b/modules/EnsEMBL/Web/Component/UserData.pm
@@ -119,9 +119,6 @@ sub userdata_form {
 
   $fieldset->add_field({'type' => 'String', 'name' => 'name', 'label' => 'Name for this data (optional)'});
 
-  # Create a data structure for species, with display labels and their current assemblies
-  my @species = sort {$a->{'caption'} cmp $b->{'caption'}} map({'value' => $_, 'caption' => $sd->species_label($_, 1), 'assembly' => $sd->get_config($_, 'ASSEMBLY_VERSION')}, $sd->valid_species);
-
   # Species dropdown list
   $fieldset->add_field({
     'label'         => 'Species',

--- a/modules/EnsEMBL/Web/Component/UserData/FeatureView.pm
+++ b/modules/EnsEMBL/Web/Component/UserData/FeatureView.pm
@@ -48,14 +48,13 @@ sub content {
     <p>If you want to use your own data file, please go to the <a href="$add_track_link" class="modal_link" rel="modal_user_data">Add custom track</a> page instead.</p>
   }});
 
-  my @species = sort {$a->{'caption'} cmp $b->{'caption'}} map {'value' => $_, 'caption' => $species_defs->species_label($_, 1)}, $species_defs->valid_species;
   $form->add_field({
-    'type'    => 'dropdown',
-    'name'    => 'species',
+    'type'    => 'noedit',
+    'name'    => 'species_display',
     'label'   => 'Species',
-    'values'  => \@species,
-    'value'   => $current_species  # Species is set automatically for the page you are on
+    'value'   => $species_defs->species_label($current_species)  # Species is set automatically for the page you are on
   });
+  $form->add_hidden({'name' => 'species', 'value' => $current_species});
 
   my @types = (
     {'value'  => 'Gene',                'caption' => 'Gene'},


### PR DESCRIPTION
As discussed with Steve, users should be uploading only on the species they are viewing.