### PR TITLE
Check $path_seg->[0] is defined

### DIFF
--- a/modules/EnsEMBL/Web/Apache/Handlers.pm
+++ b/modules/EnsEMBL/Web/Apache/Handlers.pm
@@ -1,3 +1,4 @@
+
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
@@ -376,7 +377,7 @@ sub handler {
   my $path_seg  = [ grep { $_ ne '' } split '/', $path ];
 
   # other species-like path segments
-  if (!$species && grep /$path_seg->[0]/, qw(Multi common)) {
+  if (!$species && $path_seg->[0] && grep /$path_seg->[0]/, qw(Multi common)) {
     $species = shift @$path_seg;
   }
 


### PR DESCRIPTION
In the event that $path_seg->[0] is not defined, this line creates a warning in the logs