### PR TITLE
ENSWEB-2158 Replace non-breakable spaces for csv export

### DIFF
--- a/modules/EnsEMBL/Web/Controller/Ajax.pm
+++ b/modules/EnsEMBL/Web/Controller/Ajax.pm
@@ -289,6 +289,7 @@ sub ajax_table_export {
     $str =~ s/^\s+//;
     $str =~ s/\s+$//g;
     $str = $self->strip_HTML(decode_entities($str));
+    $str =~ s/\xA0/ /g;        # Replace non-breakable spaces
     $str =~ s/"/""/g;
     $str =~ s/\0/","/g;
     return $str;


### PR DESCRIPTION
Non-breakable spaces are undesirable in csv, especially for LibreOffice Calc where they show as �.