### PR TITLE
fix: check if a key is defined before dereferencing it

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/RegulationImage.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/RegulationImage.pm
@@ -46,7 +46,9 @@ sub content {
   my $key = $wuc->get_track_key( 'transcript', $object );
   $wuc->modify_configs( [$key], {qw(display collapsed_label)} );
 
-  $wuc->{'data_by_cell_line'} = $self->new_object('Slice', $extended_slice, $object->__data)->get_cell_line_data($wuc) if keys %{$self->hub->species_defs->databases->{'DATABASE_FUNCGEN'}{'tables'}{'cell_type'}{'ids'}};
+  if ( $self->hub->species_defs->databases->{'DATABASE_FUNCGEN'} ) {
+    $wuc->{'data_by_cell_line'} = $self->new_object('Slice', $extended_slice, $object->__data)->get_cell_line_data($wuc) if keys %{$self->hub->species_defs->databases->{'DATABASE_FUNCGEN'}{'tables'}{'cell_type'}{'ids'}};
+  }
 
   my $image    = $self->new_image( $extended_slice, $wuc, [] );
   $image->imagemap           = 'yes';

--- a/modules/EnsEMBL/Web/Component/Gene/TranscriptsImage.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/TranscriptsImage.pm
@@ -56,7 +56,9 @@ sub content {
   
   $node->set('display', 'transcript_label') if $node && $node->get('display') eq 'off';
 
-  $image_config->{'data_by_cell_line'} = $self->new_object('Slice', $gene_slice, $object->__data)->get_cell_line_data_closure($image_config) if keys %{$self->hub->species_defs->databases->{'DATABASE_FUNCGEN'}{'tables'}{'cell_type'}{'ids'}};
+  if ( $self->hub->species_defs->databases->{'DATABASE_FUNCGEN'} ) {
+    $image_config->{'data_by_cell_line'} = $self->new_object('Slice', $gene_slice, $object->__data)->get_cell_line_data_closure($image_config) if keys %{$self->hub->species_defs->databases->{'DATABASE_FUNCGEN'}{'tables'}{'cell_type'}{'ids'}};
+  }
 
   my $image = $self->new_image($gene_slice, $image_config, [ $gene->stable_id ]);
   

--- a/modules/EnsEMBL/Web/Component/Location/ViewBottom.pm
+++ b/modules/EnsEMBL/Web/Component/Location/ViewBottom.pm
@@ -57,11 +57,13 @@ sub content {
       { marker_id => $marker_id }
     );
   }
-  
+
   # Add multicell configuration
-  $image_config->{'data_by_cell_line'} = $self->new_object('Slice', $slice, $object->__data)->get_cell_line_data_closure($image_config) if keys %{$hub->species_defs->databases->{'DATABASE_FUNCGEN'}{'tables'}{'cell_type'}{'ids'}};
+  if ( $hub->species_defs->databases->{'DATABASE_FUNCGEN'} ) {
+    $image_config->{'data_by_cell_line'} = $self->new_object('Slice', $slice, $object->__data)->get_cell_line_data_closure($image_config) if keys %{$hub->species_defs->databases->{'DATABASE_FUNCGEN'}{'tables'}{'cell_type'}{'ids'}};
+  }
   $image_config->_update_missing($object);
-  
+
   my $info  = $self->_add_object_track($image_config);
   my $image = $self->new_image($slice, $image_config, $object->highlights);
   

--- a/modules/EnsEMBL/Web/Component/Regulation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Regulation/Summary.pm
@@ -72,7 +72,10 @@ sub content {
   my $show        = $self->hub->get_cookie_value('toggle_epigenomes_list') eq 'open';
   my @class = ($object->feature_type->name);
 
-  my $epigenome_count = grep { $_ > 0 } values %{$self->hub->species_defs->databases->{'DATABASE_FUNCGEN'}->{'tables'}{'cell_type'}{'ids'}}; 
+  my $epigenome_count = 0;
+  if ( $self->hub->species_defs->databases->{'DATABASE_FUNCGEN'} ) {
+    $epigenome_count = grep { $_ > 0 } values %{$self->hub->species_defs->databases->{'DATABASE_FUNCGEN'}->{'tables'}{'cell_type'}{'ids'}};
+  }
 
   $summary->add_row('Classification',join(', ',@class));
   $summary->add_row('Location', $location_html);

--- a/modules/EnsEMBL/Web/Component/Transcript/ProteinVariations.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/ProteinVariations.pm
@@ -101,7 +101,8 @@ sub content {
   ];
  
   # add SIFT for supported species
-  if ( $hub->species_defs->databases->{'DATABASE_VARIATION'}->{'SIFT'}){
+  if ( $hub->species_defs->databases->{'DATABASE_VARIATION'} &&
+       $hub->species_defs->databases->{'DATABASE_VARIATION'}->{'SIFT'}){
     push @$columns, ({ key => 'sift', title => 'SIFT', width => '8%', align => 'center', sort => 'position_html', help => $glossary->{'SIFT'} });
   }
   if ($hub->species =~ /homo_sapiens/i) {

--- a/modules/EnsEMBL/Web/Component/Variation/HighLD.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/HighLD.pm
@@ -44,7 +44,7 @@ sub content {
   my $species_defs = $hub->species_defs;
   
   # check we have a location and LD populations are defined
-  return unless $self->builder->object('Location') && $species_defs->databases->{'DATABASE_VARIATION'}{'DEFAULT_LD_POP'};
+  return unless $self->builder->object('Location') && $species_defs->databases->{'DATABASE_VARIATION'} && $species_defs->databases->{'DATABASE_VARIATION'}{'DEFAULT_LD_POP'};
   
   my $selected_pop = $hub->param('pop_id');
   

--- a/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
@@ -433,7 +433,7 @@ sub table_columns {
   );  
 
   push @columns, ({ key => 'sift',     title => 'SIFT',     sort => 'position_html', align => 'center', help => $glossary->{'SIFT'} })
-      if defined $self->hub->species_defs->databases->{'DATABASE_VARIATION'}->{'SIFT'};
+      if $self->hub->species_defs->databases->{'DATABASE_VARIATION'} && defined $self->hub->species_defs->databases->{'DATABASE_VARIATION'}->{'SIFT'};
 
   push @columns, ({ key => 'polyphen', title => 'PolyPhen', sort => 'position_html', align => 'center', help => $glossary->{'PolyPhen'} })
       if $self->hub->species eq 'Homo_sapiens';

--- a/modules/EnsEMBL/Web/DBSQL/DBConnection.pm
+++ b/modules/EnsEMBL/Web/DBSQL/DBConnection.pm
@@ -135,7 +135,9 @@ sub get_DBAdaptor {
   # warn "$species - $database - $dba";
 
   # Funcgen Database Files Overwrite
-  if ($database eq 'funcgen' && $self->{'species_defs'}->databases->{'DATABASE_FUNCGEN'}{'NAME'}) {
+  if ($database eq 'funcgen' &&
+      $self->{'species_defs'}->databases->{'DATABASE_FUNCGEN'} &&
+      $self->{'species_defs'}->databases->{'DATABASE_FUNCGEN'}{'NAME'}) {
     my $file_path = join '/', $self->{'species_defs'}->DATAFILE_BASE_PATH, lc $species, $self->{'species_defs'}->ASSEMBLY_VERSION;
     $dba->get_ResultSetAdaptor->dbfile_data_root($file_path) if ($dba && -e $file_path && -d $file_path);
   }  

--- a/modules/EnsEMBL/Web/Factory/StructuralVariation.pm
+++ b/modules/EnsEMBL/Web/Factory/StructuralVariation.pm
@@ -61,7 +61,7 @@ sub createObjects {
     $self->param('vdb', 'variation');
     $self->param('sv', $structural_variation->variation_name) unless $self->param('sv'); # For same reason as svf check above;
   } else {
-    my $db_version = $self->species_defs->databases->{'DATABASE_VARIATION'}{'dbSNP_VERSION'};
+    my $db_version = $self->species_defs->databases->{'DATABASE_VARIATION'} && $self->species_defs->databases->{'DATABASE_VARIATION'}{'dbSNP_VERSION'};
     
     return $self->problem('fatal', "Could not find structural variation $identifier", $self->_help(sprintf(
       'Either %s does not exist in the current Ensembl database, %sor there was a problem retrieving it.',

--- a/modules/EnsEMBL/Web/ImageConfig/contigviewbottom.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/contigviewbottom.pm
@@ -314,7 +314,8 @@ sub init_cacheable {
   }
   elsif ($self->hub->database('variation')) {
     my $tracks = [qw(variation_feature_variation)];
-    if ($self->species_defs->databases->{'DATABASE_VARIATION'}{'STRUCTURAL_VARIANT_COUNT'}) {
+    if ($self->species_defs->databases->{'DATABASE_VARIATION'} &&
+        $self->species_defs->databases->{'DATABASE_VARIATION'}{'STRUCTURAL_VARIANT_COUNT'}) {
       push @$tracks, 'variation_feature_structural_smaller';
     }
     $self->modify_configs($tracks, {display => 'compact'});

--- a/modules/EnsEMBL/Web/ImageConfig/regulation_view.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/regulation_view.pm
@@ -36,7 +36,10 @@ sub init_cacheable {
   $self->SUPER::init_cacheable(@_);
 
   my @feature_sets  = ('cisRED', 'VISTA', 'miRanda', 'NestedMICA', 'REDfly CRM', 'REDfly TFBS', 'search');
-  my $cell_info     = $self->species_defs->databases->{'DATABASE_FUNCGEN'}{'tables'}{'cell_type'}{'ids'};
+  my $cell_info     = {};
+  if ( $self->species_defs->databases->{'DATABASE_FUNCGEN'} ) {
+    $cell_info      = $self->species_defs->databases->{'DATABASE_FUNCGEN'}{'tables'}{'cell_type'}{'ids'};
+  }
   my @cell_lines    = grep { $cell_info->{$_} > 0 } sort keys %$cell_info;
 
   s/\:\d*$// for @cell_lines;

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -993,7 +993,10 @@ sub add_regulation_features {
 
   # Add other bigBed-based tracks
   my $methylation_menu  = $reg_regions->before($self->create_menu_node('functional_dna_methylation', 'DNA Methylation'));
-  my $db_tables         = $self->databases->{'DATABASE_FUNCGEN'}{'tables'};
+  my $db_tables         = {};
+  if ( $self->databases->{'DATABASE_FUNCGEN'} ) {
+    $db_tables          = $self->databases->{'DATABASE_FUNCGEN'}{'tables'};
+  }
   my %file_tracks = ( 'methylation' => {'menu'      => $methylation_menu,
                                         'renderers' => [ qw(off Off compact On) ],
                                         'default'   => 'compact',
@@ -1060,7 +1063,10 @@ sub add_regulation_builds {
     caption     => 'Regulatory Build',
   }));
 
-  my $db_tables     = $self->databases->{'DATABASE_FUNCGEN'}{'tables'};
+  my $db_tables     = {};
+  if ( defined $self->database->{'DATABASE_FUNCGEN'} ) {
+    $db_tables      = $self->databases->{'DATABASE_FUNCGEN'}{'tables'};
+  }
   my $reg_feats     = $menu->append_child($self->create_menu_node('reg_features', 'Epigenomic activity'));
   my $reg_segs      = $menu->append_child($self->create_menu_node('seg_features', 'Segmentation features'));
   my $adaptor       = $db->get_FeatureTypeAdaptor;
@@ -1804,7 +1810,7 @@ sub add_somatic_mutations {
 
 
   # Mixed source(s)
-  foreach my $key_1 (keys(%{$self->species_defs->databases->{'DATABASE_VARIATION'}{'SOMATIC_MUTATIONS'}})) {
+  foreach my $key_1 ( ($self->species_defs->databases->{'DATABASE_VARIATION'} && keys(%{$self->species_defs->databases->{'DATABASE_VARIATION'}{'SOMATIC_MUTATIONS'}})) || [] ) {
     if ($self->species_defs->databases->{'DATABASE_VARIATION'}{'SOMATIC_MUTATIONS'}{$key_1}{'none'}) {
       (my $k = $key_1) =~ s/\W/_/g;
       $somatic->append_child($self->create_track_node("somatic_mutation_$k", "$key_1 somatic variants", {
@@ -1830,7 +1836,7 @@ sub add_somatic_mutations {
     my $tissue_menu = $self->create_menu_node('somatic_mutation_by_tissue', 'Somatic variants by tissue');
 
     ## Add tracks for each tumour site
-    my %tumour_sites = %{$self->species_defs->databases->{'DATABASE_VARIATION'}{'SOMATIC_MUTATIONS'}{$key_2} || {}};
+    my %tumour_sites = ($self->species_defs->databases->{'DATABASE_VARIATION'} && %{$self->species_defs->databases->{'DATABASE_VARIATION'}{'SOMATIC_MUTATIONS'}{$key_2} || {}}) || {};
 
     foreach my $description (sort  keys %tumour_sites) {
       next if $description eq 'none';

--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -1622,7 +1622,10 @@ sub get_extended_reg_region_slice {
 sub feature_sets {
   my $self = shift;
 
-  my $available_sets = $self->species_defs->databases->{'DATABASE_FUNCGEN'}->{'FEATURE_SETS'};
+  my $available_sets = [];
+  if ( $self->species_defs->databases->{'DATABASE_FUNCGEN'} ) {
+    $available_sets = $self->species_defs->databases->{'DATABASE_FUNCGEN'}->{'FEATURE_SETS'};
+  }
   my $fg_db = $self->get_fg_db; 
   my $feature_set_adaptor = $fg_db->get_FeatureSetAdaptor;
   my @fsets;

--- a/modules/EnsEMBL/Web/Object/LRG.pm
+++ b/modules/EnsEMBL/Web/Object/LRG.pm
@@ -1036,7 +1036,10 @@ return $fg_db;
 sub feature_sets {
   my $self = shift;
 
-  my $available_sets = $self->species_defs->databases->{'DATABASE_FUNCGEN'}->{'FEATURE_SETS'};
+  my $available_sets = [];
+  if ( $self->species_defs->databases->{'DATABASE_FUNCGEN'} ) {
+    $available_sets = $self->species_defs->databases->{'DATABASE_FUNCGEN'}->{'FEATURE_SETS'};
+  }
   my $fg_db = $self->get_fg_db; 
   my $feature_set_adaptor = $fg_db->get_FeatureSetAdaptor;
   my @fsets;

--- a/modules/EnsEMBL/Web/Object/Regulation.pm
+++ b/modules/EnsEMBL/Web/Object/Regulation.pm
@@ -335,12 +335,22 @@ sub get_evidence_data {
 
 sub all_epigenomes {
   my ($self) = @_;
-  return [sort keys %{$self->hub->species_defs->databases->{'DATABASE_FUNCGEN'}->{'tables'}{'cell_type'}{'names'}}];
+  
+  if ( $self->hub->species_defs->databases->{'DATABASE_FUNCGEN'} ) {
+    return [sort keys %{$self->hub->species_defs->databases->{'DATABASE_FUNCGEN'}->{'tables'}{'cell_type'}{'names'}}];
+  }
+
+  return [];
 }
 
 sub regbuild_epigenomes {
   my ($self) = @_;
-  return [sort keys %{$self->hub->species_defs->databases->{'DATABASE_FUNCGEN'}->{'tables'}{'cell_type'}{'regbuild_names'}}];
+
+  if ( $self->hub->species_defs->databases->{'DATABASE_FUNCGEN'} ) {
+    return [sort keys %{$self->hub->species_defs->databases->{'DATABASE_FUNCGEN'}->{'tables'}{'cell_type'}{'regbuild_names'}}];
+  }
+
+  return [];
 }
 
 ################ Calls for Feature in Detail view ###########################

--- a/modules/EnsEMBL/Web/Object/Slice.pm
+++ b/modules/EnsEMBL/Web/Object/Slice.pm
@@ -346,7 +346,10 @@ sub get_cell_line_data {
   my ($self, $image_config, $filter) = @_;
   
   # First work out which tracks have been turned on in image_config
-  my %cell_lines = %{$self->species_defs->databases->{'DATABASE_FUNCGEN'}->{'tables'}{'cell_type'}{'ids'}};
+  my %cell_lines = ();
+  if ( $self->species_defs->databases->{'DATABASE_FUNCGEN'} ) {
+    %cell_lines = %{$self->species_defs->databases->{'DATABASE_FUNCGEN'}->{'tables'}{'cell_type'}{'ids'}};
+  }
   my @sets       = qw(core non_core);  
   my $data;
 

--- a/modules/EnsEMBL/Web/Object/Variation.pm
+++ b/modules/EnsEMBL/Web/Object/Variation.pm
@@ -1674,7 +1674,7 @@ sub hgvs_url {
       $p->{'t'}      = $refseq.$version;
     } else { # $type eq c: cDNA position, no $type: special cases where the variation falls in e.g. a pseudogene. Default to transcript
       $p->{'type'}   = 'Transcript';
-      $p->{'action'} = ($hub->species_defs->databases->{'DATABASE_VARIATION'}->{'#STRAINS'} > 0 ? 'Population' : 'Summary');
+      $p->{'action'} = ($hub->species_defs->databases->{'DATABASE_VARIATION'} && $hub->species_defs->databases->{'DATABASE_VARIATION'}->{'#STRAINS'} > 0 ? 'Population' : 'Summary');
       $p->{'t'}      = $refseq.$version;
     }
   }

--- a/modules/EnsEMBL/Web/ViewConfig/Regulation/FeatureDetails.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Regulation/FeatureDetails.pm
@@ -27,7 +27,10 @@ use parent qw(EnsEMBL::Web::ViewConfig::RegulationPage);
 sub init_cacheable {
   ## Abstract method implementation
   my $self     = shift;
-  my $analyses = $self->species_defs->databases->{'DATABASE_FUNCGEN'}{'tables'}{'feature_type'}{'analyses'} || {};
+  my $analyses = {};
+  if ( $self->species_defs->databases->{'DATABASE_FUNCGEN'} ) {
+    $analyses = $self->species_defs->databases->{'DATABASE_FUNCGEN'}{'tables'}{'feature_type'}{'analyses'} || {};
+  }
 
   $self->set_default_options({
     'context'   => 200,


### PR DESCRIPTION
Due to Perl's autovivification feature, if a key is not defined, dereferencing
it will automaticaly create an empty hash as value for that key. This will be
an issue when checking if the key is defined elsewhere.

This change remove this potential problem for 'DATABASE_FUNCGEN' and 'DATABASE
_VARIATION' keys in species_defs->databases.

Related to ENSEMBL-4611.