### PR TITLE
fix: check if a config exists before dereferencing it

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/GenePhenotypeOrthologue.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GenePhenotypeOrthologue.pm
@@ -58,7 +58,7 @@ sub content {
   my @rows;
 
   foreach my $species (map $hub->species_defs->production_name_mapping($_), sort { ($a =~ /^<.*?>(.+)/ ? $1 : $a) cmp ($b =~ /^<.*?>(.+)/ ? $1 : $b) } keys %orthologue_list) {
-    next unless $hub->species_defs->get_config($species, 'databases')->{'DATABASE_VARIATION'};
+    next unless $hub->species_defs->get_config($species, 'databases') && $hub->species_defs->get_config($species, 'databases')->{'DATABASE_VARIATION'};
 
     my $pfa = $hub->get_adaptor('get_PhenotypeFeatureAdaptor', 'variation', $species);
     my $sp = $species;


### PR DESCRIPTION
Unfortunately for Plants compara, there are other species from other divisions.
But we do not have species defs for those species.

Fixes ENSEMBL-4853.