### PR TITLE
Make MAX_PROCESS_SIZE configurable

### DIFF
--- a/conf/perl.startup
+++ b/conf/perl.startup
@@ -40,7 +40,7 @@ BEGIN {
   @xs_enabled = @{EnsEMBL::Web::Startup::XS::bootstrap_begin()};
 }
 
-$Apache2::SizeLimit::MAX_PROCESS_SIZE = 1000000; # Kill httpd over 1000Mb
+$Apache2::SizeLimit::MAX_PROCESS_SIZE = $SiteDefs::MAX_PROCESS_SIZE || 1000000; # Kill httpd over 1000Mb
 
 use CGI qw(-compile :cgi); # Load CGI.pm and call its compile method to precompile its autoloaded routines
 use DBI;


### PR DESCRIPTION
This change allows us to set different value for the MAX_PROCESS_SIZE for each division
and make it under source control.

Related to ENSEMBL-4763.