### PR TITLE
Use new Compara methods to get species/clade names

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
@@ -674,12 +674,10 @@ sub features {
     my %genes;
     my %leaves;
 
-    my $species_tree_node_id = $tree->get_tagvalue('species_tree_node_id');
+    my $species_tree_node = $tree->species_tree_node();
     my $node_name;
-    if (defined $species_tree_node_id) {
-        my $speciesTreeNode      = $tree->adaptor->db->get_SpeciesTreeNodeAdaptor->fetch_node_by_node_id($species_tree_node_id);
-        $node_name               = $self->species_defs->multi_hash->{'DATABASE_COMPARA'}{'TAXON_NAME'}->{$speciesTreeNode->taxon_id}
-            || $speciesTreeNode->node_name;
+    if (defined $species_tree_node) {
+        $node_name = $species_tree_node->get_common_name() || $species_tree_node->get_scientific_name;
     }
 
     foreach my $leaf (@{$tree->get_all_leaves}) {

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -204,9 +204,10 @@ sub content {
   # Ideally, this should be stored in $hub->species_defs->multi_hash->{'DATABASE_COMPARA'}
   # or any other centralized place, to avoid recomputing it many times
   my %genome_db_ids_by_clade = map {$_ => []} @{ $self->hub->species_defs->TAXON_ORDER };
+  my $genome_db_adaptor = $tree->adaptor->db->get_GenomeDBAdaptor;
   foreach my $species_name (keys %{$self->hub->get_species_info}) {  
     foreach my $clade (@{ $self->hub->species_defs->get_config($species_name, 'SPECIES_GROUP_HIERARCHY') }) {
-      push @{$genome_db_ids_by_clade{$clade}}, $hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'GENOME_DB'}{lc ($hub->species_defs->get_config($species_name, 'SPECIES_PRODUCTION_NAME'))};
+      push @{$genome_db_ids_by_clade{$clade}}, $genome_db_adaptor->fetch_by_name_assembly($hub->species_defs->get_config($species_name, 'SPECIES_PRODUCTION_NAME'))->dbID;
     }
   }
   $genome_db_ids_by_clade{LOWCOVERAGE} = $self->hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'SPECIES_SET'}{'LOWCOVERAGE'};

--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -1256,16 +1256,7 @@ sub _summarise_compara_db {
   ###################################################################
   ## Section for storing the taxa properties
   
-  # Default name is the name stored in species_tree_node: the glyphset will use it by default
-
-  # But a better name is the ensembl alias
-  $res_aref = $dbh->selectall_arrayref(qq(SELECT taxon_id, name FROM ncbi_taxa_name WHERE name_class='ensembl alias name'));
-  foreach my $row (@$res_aref) {
-    my ($taxon_id, $taxon_name) = @$row;
-    $self->db_tree->{$db_name}{'TAXON_NAME'}{$taxon_id} = $taxon_name;
-  }
-
-  # And we need the age of each ancestor
+  # We need the age of each ancestor
   $res_aref = $dbh->selectall_arrayref(qq(SELECT taxon_id, name FROM ncbi_taxa_name WHERE name_class='ensembl timetree mya'));
   foreach my $row (@$res_aref) {
     my ($taxon_id, $taxon_mya) = @$row;

--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -1238,20 +1238,6 @@ sub _summarise_compara_db {
 
   ##
   ###################################################################
-
-  ###################################################################
-  ## Section for storing the genome_db_ids <=> species_name
-  $res_aref = $dbh->selectall_arrayref('SELECT genome_db_id, name, assembly FROM genome_db');
-  
-  foreach my $row (@$res_aref) {
-    my ($genome_db_id, $species_name) = @$row;
-    
-    $species_name =~ tr/ /_/;
-    
-    $self->db_tree->{$db_name}{'GENOME_DB'}{$species_name} = $genome_db_id;
-    $self->db_tree->{$db_name}{'GENOME_DB'}{$genome_db_id} = $species_name;
-  }
-  ###################################################################
   
   $dbh->disconnect;
 }

--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -1253,19 +1253,6 @@ sub _summarise_compara_db {
   }
   ###################################################################
   
-  ###################################################################
-  ## Section for storing the taxa properties
-  
-  # We need the age of each ancestor
-  $res_aref = $dbh->selectall_arrayref(qq(SELECT taxon_id, name FROM ncbi_taxa_name WHERE name_class='ensembl timetree mya'));
-  foreach my $row (@$res_aref) {
-    my ($taxon_id, $taxon_mya) = @$row;
-    $self->db_tree->{$db_name}{'TAXON_MYA'}{$taxon_id} = $taxon_mya;
-  }
-
-
-  ###################################################################
-  
   $dbh->disconnect;
 }
 

--- a/modules/EnsEMBL/Web/Document/HTML/Compara/MLSS.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara/MLSS.pm
@@ -707,13 +707,16 @@ sub fetch_pairwise_input {
       foreach my $param (split ' ', $pairwise_params) {
         my ($p, $v) = split '=', $param;
         
-        if ($p eq 'Q' && $v =~ /^\/nfs/) {
+        if ($p eq 'Q' && $v =~ /^\$ENSEMBL_CVS_ROOT_DIR/) {
           ## slurp in the matrix file
           my @path  = split '/', $v;
-          my $file  = $path[-1];
-          my $fh    = open IN, $hub->species_defs->ENSEMBL_SERVERROOT . "/public-plugins/ensembl/htdocs/info/genome/compara/$file";
+          my $server_root   = $hub->species_defs->ENSEMBL_SERVERROOT;
+          my ($matrix_name) = ($path[-1] =~ /(.*).matrix/);
+          my $file  = $v;
+             $file  =~ s/^\$ENSEMBL_CVS_ROOT_DIR/$server_root/;
+          my $fh    = open IN, $file;
           
-          $v  = '<pre>';
+          $v  = '<pre>' . ucfirst($matrix_name) . ":\n";
           while (<IN>) {
             $v .= $_;
           }

--- a/modules/EnsEMBL/Web/Document/HTML/Compara/MLSS.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara/MLSS.pm
@@ -536,6 +536,7 @@ sub render_cactus_multiple {
 
   my $hub     = $self->hub;
   my $site    = $hub->species_defs->ENSEMBL_SITETYPE;
+  my $version = $hub->species_defs->ENSEMBL_VERSION;
   my $html;
   my ($species_order, $info) = $self->mlss_species_info($mlss);
 
@@ -548,6 +549,10 @@ sub render_cactus_multiple {
     $html .= qq{<p>This alignment of $count genomes has been imported from UCSC since release $rel.</p>};
     $html .= $self->error_message('API access', sprintf(
         '<p>This alignment set can be accessed using the Compara API via the Bio::EnsEMBL::DBSQL::MethodLinkSpeciesSetAdaptor using the <em>method_link_type</em> "<b>%s</b>" and either the <em>species_set_name</em> "<b>%s</b>".</p>', $mlss->method->type, $mlss->species_set->name), 'info');
+    if ($mlss->method->type =~ /CACTUS_HAL/) {
+        $html .= $self->error_message('HAL configuration', sprintf(
+            '<p>HAL alignments require further configuration. See the instructions in our <a href="https://github.com/Ensembl/ensembl-compara/blob/release/%d/README.md">README</a>.</p>', $version), 'info')
+    }
 
     my $table = EnsEMBL::Web::Document::Table->new([
         { key => 'species', title => 'Species',         width => '50%', align => 'left', sort => 'string' },

--- a/modules/EnsEMBL/Web/Hub.pm
+++ b/modules/EnsEMBL/Web/Hub.pm
@@ -1050,7 +1050,7 @@ sub order_species_by_clade { # TODO - move to EnsEMBL::Web::Document::HTML::Comp
   my $favourites    = $self->get_favourite_species;
   if (scalar @$favourites) {
     my @allowed_production_names = grep {$stn_by_name{$_}} map {$species_defs->get_config($_, 'SPECIES_PRODUCTION_NAME')} @$favourites;
-    push @final_sets, ['Favourite species', [map {encode_entities($stn_by_name{$_})} @allowed_production_names]] if @allowed_production_names;
+    push @final_sets, ['Favourite species', [map {$stn_by_name{$_}} @allowed_production_names]] if @allowed_production_names;
   }
 
   ## Output in taxonomic groups, ordered by common name
@@ -1060,7 +1060,7 @@ sub order_species_by_clade { # TODO - move to EnsEMBL::Web::Document::HTML::Comp
       my $name_to_use = ($group_name eq 'no_group') ? (scalar(@group_order) > 1 ? 'Other species' : 'All species') : encode_entities($group_name);
       my @sorted_by_common = sort { $species_info->{$a}->{'common'} cmp $species_info->{$b}->{'common'} } @$species_list;
       my @allowed_production_names = grep {$stn_by_name{$_}} map {$species_defs->get_config($_, 'SPECIES_PRODUCTION_NAME')} @sorted_by_common;
-      push @final_sets, [$name_to_use, [map {encode_entities($stn_by_name{$_})} @allowed_production_names]] if @allowed_production_names;
+      push @final_sets, [$name_to_use, [map {$stn_by_name{$_}} @allowed_production_names]] if @allowed_production_names;
   }
 
   return \@final_sets;

--- a/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
@@ -69,11 +69,10 @@ sub content {
 
   my $tagvalues       = $node->get_tagvalue_hash;
   my $speciesTreeNode = $node->species_tree_node();
-  my $taxon_id             = $speciesTreeNode->taxon_id;
-     $taxon_id        = $node->genome_db->taxon_id if !$taxon_id && $is_leaf && not $is_supertree;
   my $taxon_name      = $speciesTreeNode->get_scientific_name;
-  my $taxon_mya       = $hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'TAXON_MYA'}->{$taxon_id};
+  my $taxon_mya       = $speciesTreeNode->get_divergence_time;
   my $taxon_alias     = $speciesTreeNode->get_common_name;
+
   my $caption         = 'Taxon: ';
   
   if (defined $taxon_alias) {
@@ -106,7 +105,7 @@ sub content {
        
     $self->add_entry({
       type  => 'Lost taxa',
-      label => join(', ', map { $_->get_common_name } @$lost_taxa ),
+      label => join(', ', map { $_->get_common_name || $_->get_scientific_name } @$lost_taxa ),
       order => 5.6
     });
   }

--- a/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
@@ -75,18 +75,16 @@ sub content {
      $taxon_name      = $node->genome_db->taxon->name if !$taxon_name && $is_leaf && not $is_supertree;
 
   my $taxon_mya       = $hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'TAXON_MYA'}->{$taxon_id};
-  my $taxon_alias     = $hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'TAXON_NAME'}->{$taxon_id};
+  my $taxon_alias     = $speciesTreeNode->get_common_name;
   my $caption         = 'Taxon: ';
   
   if (defined $taxon_alias) {
     $caption .= $taxon_alias;
     $caption .= sprintf ' ~%d MYA', $taxon_mya if defined $taxon_mya;
-    $caption .= " ($taxon_name)" if defined $taxon_name;
-  } elsif (defined $taxon_name) {
+    $caption .= " ($taxon_name)";
+  } else {
     $caption .= $taxon_name;
     $caption .= sprintf ' ~%d MYA', $taxon_mya if defined $taxon_mya;
-  } else {
-    $caption .= 'unknown';
   }
   
   $self->caption($caption);
@@ -110,7 +108,7 @@ sub content {
        
     $self->add_entry({
       type  => 'Lost taxa',
-      label => join(', ', map { $hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'TAXON_NAME'}->{$_->taxon_id} || $_->node_name }  @$lost_taxa ),
+      label => join(', ', map { $_->get_common_name } @$lost_taxa ),
       order => 5.6
     });
   }

--- a/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
@@ -71,9 +71,7 @@ sub content {
   my $speciesTreeNode = $node->species_tree_node();
   my $taxon_id             = $speciesTreeNode->taxon_id;
      $taxon_id        = $node->genome_db->taxon_id if !$taxon_id && $is_leaf && not $is_supertree;
-  my $taxon_name           = $speciesTreeNode->node_name;
-     $taxon_name      = $node->genome_db->taxon->name if !$taxon_name && $is_leaf && not $is_supertree;
-
+  my $taxon_name      = $speciesTreeNode->get_scientific_name;
   my $taxon_mya       = $hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'TAXON_MYA'}->{$taxon_id};
   my $taxon_alias     = $speciesTreeNode->get_common_name;
   my $caption         = 'Taxon: ';

--- a/modules/EnsEMBL/Web/ZMenu/SpeciesTree.pm
+++ b/modules/EnsEMBL/Web/ZMenu/SpeciesTree.pm
@@ -34,8 +34,7 @@ sub content {
   die 'No tree for gene' unless $tree;
   my $node_id  = $hub->param('node')                   || die 'No node value in params';  
   my $node     = $tree->root->find_node_by_node_id($node_id) || die "No node_id $node_id in ProteinTree";
-  my $ta       = $c_db->get_NCBITaxonAdaptor();  
-  my $taxon    = $ta->fetch_node_by_taxon_id($node->{_taxon_id});
+  my $taxon    = $node->taxon;
   
   my $leaf_count      = scalar @{$node->get_all_leaves};
   my $is_leaf         = $node->is_leaf;

--- a/modules/EnsEMBL/Web/ZMenu/SpeciesTree.pm
+++ b/modules/EnsEMBL/Web/ZMenu/SpeciesTree.pm
@@ -42,7 +42,7 @@ sub content {
   my $parent_distance = $node->distance_to_parent || 0;  
   my $taxon_id        = $node->taxon_id;     
   my $scientific_name = $taxon->scientific_name();
-  my $taxon_mya       = $taxon->get_tagvalue('ensembl timetree mya');
+  my $taxon_mya       = $node->get_divergence_time();
   my $taxon_alias     = $node->get_common_name();
  
 

--- a/modules/EnsEMBL/Web/ZMenu/SpeciesTree.pm
+++ b/modules/EnsEMBL/Web/ZMenu/SpeciesTree.pm
@@ -43,7 +43,7 @@ sub content {
   my $taxon_id        = $node->taxon_id;     
   my $scientific_name = $taxon->scientific_name();
   my $taxon_mya       = $taxon->get_tagvalue('ensembl timetree mya');
-  my $taxon_alias     = $taxon->ensembl_alias_name(); 
+  my $taxon_alias     = $node->get_common_name();
  
 
   my $caption   = "Taxon: ";


### PR DESCRIPTION
From e88 we have a number of new methods to get common names (also known as "ensembl alias" or "display name"), scientific names, etc. This simplifies several modules, and removes the need of building lookup tables in the ConfigPacker (which @Zhicheng-Liu should like). 

I don't know how to test the changes at the EBI, so I have used my Sanger sandbox with the e87 databases instead.

Pages affected are:
 /Homo_sapiens/Gene/Compara_Tree?g=ENSG00000139618 : common names on the collapsed nodes, clade names in the zmenus, ability to hide/show some clades (in Configure This Page)
/Homo_sapiens/Gene/Compara_Paralog?g=ENSG00000189167 : the "Ancestral taxonomy" column
/info/genome/compara/prot_tree_stats.html?page=coverage and the other pages in the same section : Species/clade names