### PR TITLE
Prevent spamming the logs with uninitialised warnings

### DIFF
--- a/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
@@ -53,8 +53,8 @@ sub init_cacheable {
   my @bg_col = @{ $species_defs->TAXON_GENETREE_BGCOLOUR };
   my @fg_col = @{ $species_defs->TAXON_GENETREE_FGCOLOUR };
   foreach my $name ( @{ $species_defs->TAXON_ORDER } ) {
-    my $this_bg_col = shift @bg_col;
-    my $this_fg_col = shift @fg_col;
+    my $this_bg_col = shift @bg_col || 0;
+    my $this_fg_col = shift @fg_col || 0;
     $defaults->{"group_${name}_bgcolour"} = $this_bg_col if $this_bg_col ne '0';
     $defaults->{"group_${name}_fgcolour"} = $this_fg_col if $this_fg_col ne '0';
     $defaults->{"group_${name}_display"} = 'default';


### PR DESCRIPTION
If TAXON_GENETREE_BGCOLOUR or TAXON_GENETREE_FGCOLOUR contain less entries than TAXON_ORDER (which may be the case if these colours are not being used - as in case of e!g) previously this caused 'uninitialised' warnings.