### PR TITLE
Only mention "There is a breakpoint in the alignment between chromosome" between real chromosomes

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/alignscalebar.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/alignscalebar.pm
@@ -128,6 +128,7 @@ sub render_align_bar {
   my $pix_per_bp  = $self->scalex;
   my $last_end    = undef;
   my $last_chr    = -1;
+  my $last_slice  = undef;
   my $join_z      = -20;
   my $last_s2s    = -1;
   my $last_s2e    = -1;
@@ -209,10 +210,12 @@ sub render_align_bar {
       $href = '';
       
       if ($last_chr ne $s2t) {
+       if ($s2 && $s2->has_karyotype && $last_slice && $last_slice->has_karyotype) {
         # Different chromosomes
         $colour = 'black';
         $title = "AlignSlice Break; There is a breakpoint in the alignment between chromosome $last_chr and $s2t";
         $legend = "Breakpoint between $other_species_common_name chromosomes";
+       }
       } elsif ($last_s2st ne $s2st) {
         # Same chromosome, different strand (inversion)
         $colour = 'dodgerblue';
@@ -271,6 +274,7 @@ sub render_align_bar {
     $last_s2e = $s2e;
     $last_s2st = $s2st;
     $last_chr = $s2t;
+    $last_slice = $s2;
   }
   
   # alignment legend for multiple alignment (show everything)


### PR DESCRIPTION
When we see a jump between scaffolds / contigs, it may well be there in fact part of the same chromosome.

This is done by checking whether the Slice objects are on the karyotype.

Tested on my sandbox: http://enssand-02.internal.sanger.ac.uk:9073/Homo_sapiens/Location/Compara_Alignments/Image?align=829;db=core;g=ENSG00000139618;r=13:32232872-32482873
Select human and pig from the "EPO LOW COVERAGE"