### PR TITLE
Avoid loop when querying for ontology availability

### DIFF
--- a/modules/EnsEMBL/Web/Query/Availability/Gene.pm
+++ b/modules/EnsEMBL/Web/Query/Availability/Gene.pm
@@ -45,9 +45,8 @@ sub fixup {
 }
 
 sub _count_go {
-  my ($self,$args,$goid) = @_;
+  my ($self,$args,$out) = @_;
 
-  my $counts = 0;
   my $go_name;
   foreach my $transcript (@{$args->{'gene'}->get_all_Transcripts}) {
     next unless $transcript->translation;
@@ -77,7 +76,7 @@ sub _count_go {
       }
     }
   }
-  return 0 unless $go_name;
+  return unless $go_name;
   $go_name =~ s/,$//g;
 
   my $goadaptor = $self->database_dbc($args->{'species'},'go');
@@ -87,10 +86,15 @@ sub _count_go {
   my $sth = $goadaptor->prepare($go_sql);
   $sth->execute();
 
+  my %clusters = $self->multiX('ONTOLOGIES');
+  $out->{"has_go_$_"} = 0 for(keys %clusters);
+
   foreach (@{$sth->fetchall_arrayref}) {
-    $counts = $_->[1] if($_->[0] eq "$goid");
+    my $goid = $_->[0];
+    if ( exists $clusters{$goid} ) {
+      $out->{"has_go_$goid"} = $_->[1];
+    }
   }
-  return $counts;
 }
 
 sub _count_xrefs {
@@ -235,7 +239,6 @@ sub get {
   my $member = $self->compara_member($args) if $out->{'database:compara'};
   my $panmember = $self->pancompara_member($args) if $out->{'database:compara_pan_ensembl'};
   my $counts = $self->_counts($args,$member,$panmember);
-  my %clusters = $self->multiX('ONTOLOGIES');
 
   $out->{'counts'} = $counts;
   $out->{'history'} =
@@ -279,7 +282,8 @@ sub get {
   )) {
     $out->{"has_$_"} = $counts->{$_};
   }
-  $out->{"has_go_$_"} = $self->_count_go($args,$_) for(keys %clusters);
+
+  $self->_count_go($args, $out);
   $out->{'multiple_transcripts'} = ($counts->{'transcripts'}>1);
   $out->{'not_patch'} = 0+!($args->{'gene'}->stable_id =~ /^ASMPATCH/);
   $out->{'has_alt_alleles'} = 0+!!(@{$self->_get_alt_alleles($args)});


### PR DESCRIPTION
With current implementation, in order to decide whether to enable ontology related menu items
on the left hand side of a page (e.g. gene summary), it needs to fetch from ontology database
for related ontologies.

The lookup of ontology adaptor takes long time for Bacteria because the underlying implementaion
requires an exhaustive iteration through the whole registry:
https://github.com/Ensembl/ensembl/blob/release/88/modules/Bio/EnsEMBL/Registry.pm#L705-L714

Furthermore, the current implementation repeatly fetches from the database for the same query:
https://github.com/Ensembl/ensembl-webcode/blob/release/88/modules/EnsEMBL/Web/Query/Availability/Gene.pm#L282

This change tries to fetch from the ontology database for only once.