### PR TITLE
Remove duplicates from valid_species in case of collection species

### DIFF
--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -199,22 +199,23 @@ sub valid_species {
   ### Filters the list of species to those configured in the object.
   ### If an empty list is passes, returns a list of all configured species
   ### Returns: array of configured species names
-  
+
   my $self          = shift;
   my %test_species  = map { $_ => 1 } @_;
   my @valid_species = @{$self->{'_valid_species'} || []};
-  
-  if (!@valid_species) {
-    foreach my $sp (@{$self->multi_hash->{'ENSEMBL_DATASETS'}}) {
+  my %uniq_valid_species;
+
+   if (!@valid_species) {
+    foreach my $sp (@{$self->multi_hash->{'ENSEMBL_DATASETS'}}) { 
       my $config = $self->get_config($sp, 'DB_SPECIES');
-      
+
       if ($config->[0]) {
-        push @valid_species, @{$config};
+        $uniq_valid_species{$_} = 1 foreach @{$config};
       } else {
         warn "Species $sp is misconfigured: please check generation of packed file";
       }
     }
-    
+    @valid_species = keys %uniq_valid_species;    
     $self->{'_valid_species'} = [ @valid_species ]; # cache the result
   }
 
@@ -395,12 +396,12 @@ sub parse {
     }
     warn " conf was not generated here, regenerating\n";
   }
-  
+ 
 #  $self->_get_valid_urls; # under development
   $self->_parse;
   $self->store;
   $reg_conf->configure;
-  
+
   EnsEMBL::Web::Tools::RobotsTxt::create($self->multi_hash->{'ENSEMBL_DATASETS'}, $self);
   EnsEMBL::Web::Tools::OpenSearchDescription::create($self);
   


### PR DESCRIPTION
Every species of a collection has reference to same DB_SPECIES array. 
And hence this will cause duplicate entries if pushed into an array.