### PR TITLE
Fix datatables nested form issue

### DIFF
--- a/htdocs/components/05_DataTable.js
+++ b/htdocs/components/05_DataTable.js
@@ -185,7 +185,7 @@ Ensembl.DataTable = {
     options.aLengthMenu = menu;
     
     // Extend options from config defined in the html
-    $('input', table.siblings('form.data_table_config')).each(function () {
+    $('input', table.siblings('div.data_table_config')).each(function () {
       if (this.name === 'code') {
         table.data('code', this.value);
         

--- a/htdocs/components/22_dynamic_content.css
+++ b/htdocs/components/22_dynamic_content.css
@@ -110,8 +110,8 @@ body.mac div.reorder_species ul li { cursor: ns-resize; }
 div.toggleable_table             { clear: both; }
 div.toggleable_table h2 a.toggle { background-position: right 50%; }
 
-form.data_table_config,
-form.data_table_export { display: none; }
+div.data_table_config,
+div.data_table_export { display: none; }
 
 
 /***********************************

--- a/modules/EnsEMBL/Web/Document/Table.pm
+++ b/modules/EnsEMBL/Web/Document/Table.pm
@@ -226,11 +226,11 @@ sub render {
     my $options  = sprintf '<input type="hidden" name="expopts" value="%s" />', encode_entities($self->export_options);
     
     $table .= qq{
-      <form class="data_table_export" action="/Ajax/table_export" method="post">
+      <div class="data_table_export" action="/Ajax/table_export" method="post">
         <input type="hidden" name="filename" value="$filename" />
         <input type="hidden" class="data" name="data" value="" />
         $options
-      </form>
+      </div>
     };
   }
    
@@ -355,7 +355,7 @@ sub data_table_config {
   
   $config .= sprintf '<input type="hidden" name="expopts" value="%s" />', encode_entities($self->export_options);
  
-  return qq{<form class="data_table_config" action="#">$config</form>};
+  return qq{<div class="data_table_config">$config</div>};
 }
 
 sub process {


### PR DESCRIPTION
Update the datatables code to use div elements instead of form elements for storing configuration params. Form elements cannot be nested and so previously it was not possible to use a datatable inside a form.
See also ENSWEB-2231
Based on the VectorBase modification here https://github.com/EnsemblGenomes/eg-web-vectorbase/commit/28acd78ce41f2110564e5c7efbb9bca7c53336fa