### PR TITLE
Remove htsobj cache once data is fetched from bam/cram

### DIFF
--- a/modules/EnsEMBL/Draw/Role/Bam.pm
+++ b/modules/EnsEMBL/Draw/Role/Bam.pm
@@ -363,13 +363,15 @@ sub reset {
 sub get_data {
 ## get the alignment features
   my $self = shift;
-  my $adaptor = $self->bam_adaptor;
-  if ($self->{'file_error'}) {
-    return [];
-  }
 
-  my $slice = $self->{'container'};
-  if (!exists($self->{_cache}->{data})) {
+  unless ( $self->{_cache}->{data} ) {    
+    my $adaptor = $self->bam_adaptor;
+    if ($self->{'file_error'}) {
+      $self->{_cache}->{_bam_adaptor} = undef;
+      return [];
+    }
+
+    my $slice = $self->{'container'};
     
     ## Allow for seq region synonyms
     my $seq_region_names = [$slice->seq_region_name];
@@ -378,16 +380,13 @@ sub get_data {
     }
 
     my $data;
-
     foreach my $seq_region_name (@$seq_region_names) {
       $data = $adaptor->fetch_alignments_filtered($seq_region_name, $slice->start, $slice->end) || [];
       last if @$data;
     }
 
     $self->{_cache}->{data} = $data;
-
-    ## Explicitly close file, otherwise it can cause errors
-    $adaptor->htsfile_close;
+    $self->{_cache}->{_bam_adaptor} = undef;
   }
 
   ## Return data in standard format expected by other modules
@@ -398,10 +397,12 @@ sub get_data {
 
 sub consensus_features {
   my $self = shift;
+
   unless ($self->{_cache}->{consensus_features}) {
 
     my $adaptor = $self->bam_adaptor;
     if ($self->{'file_error'}) {
+      $self->{_cache}->{_bam_adaptor} = undef;
       return {};
     }
 
@@ -424,6 +425,7 @@ sub consensus_features {
       $cons_lookup->{$_->{'x'}} = $_->{'bp'};
     }
     $self->{_cache}->{consensus_features} = $cons_lookup;
+    $self->{_cache}->{_bam_adaptor} = undef;
   }
   return $self->{_cache}->{consensus_features}; 
 }


### PR DESCRIPTION
For some cram files, the htslib consumes large amount of memory to parse and fetch data
from them. This creates a problem for a location view that has multiple those cram tracks
configured. The memory will quickly exceed the process limit.

This change removes the htsobj cache once the data is fetched for a certain track which
effectively clean up the memory so that all the following tracks could have enough memory
to be processed.

Related to ENSEMBL-5035.