### PR TITLE
Make scripts work better with collection core databases

### DIFF
--- a/utils/google_sitemaps/make_google_sitemap_by_species.pl
+++ b/utils/google_sitemaps/make_google_sitemap_by_species.pl
@@ -102,7 +102,7 @@ push @sitemaps, "sitemap-common.xml";
 my @skip = split /,/, $skip_list;
 
 # create the sitemaps for each dataset
-foreach my $dataset (@ARGV ? @ARGV : @{$sd->multi_hash->{'ENSEMBL_DATASETS'}}) {
+foreach my $dataset (@ARGV ? @ARGV : @$SiteDefs::PRODUCTION_NAMES) {
   next if grep { $_ eq $dataset } @skip;
   
   print "$dataset\n";

--- a/utils/make_gene_autocomplete.pl
+++ b/utils/make_gene_autocomplete.pl
@@ -64,7 +64,7 @@ if (!@ARGV and !$nodelete) {
   }
 }
 
-foreach my $dataset (@ARGV ? @ARGV : @{$sd->multi_hash->{'ENSEMBL_DATASETS'}}) {
+foreach my $dataset (@ARGV ? @ARGV : @$SiteDefs::PRODUCTION_NAMES) {
   warn "$dataset\n";
   
   my $dbs = $sd->get_config($dataset, 'databases');


### PR DESCRIPTION
Use SiteDefs PRODUCTION_NAMES as it contains db names (including collections), instead of SpeciesDefs ENSEMBL_DATASETS which contains individual genome names. This wy we can process in bulk instead of every individual genome.