### PR TITLE
Don't delete config if key wasn't renamed

### DIFF
--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -773,7 +773,7 @@ sub _parse {
     ## (and backwards compatibility!)
     $tree->{$url} = $tree->{$prodname};
     push @$datasets, $url;
-    delete $tree->{$prodname};
+    delete $tree->{$prodname} if $prodname ne $url;
   } 
   $tree->{'MULTI'}{'ENSEMBL_DATASETS'} = $datasets;
   #warn ">>> NEW KEYS: ".Dumper($tree);


### PR DESCRIPTION
When renaming keys, allow for the case where production_name and species.url are the same.