### PR TITLE
Don't delete config if key wasn't renamed

### DIFF
--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -771,9 +771,12 @@ sub _parse {
     
     ## Rename the tree keys for easy data access via URLs
     ## (and backwards compatibility!)
-    $tree->{$url} = $tree->{$prodname};
+    if ($url ne $prodname) {
+      $tree->{$url} = $tree->{$prodname};
+      delete $tree->{$prodname};
+    }
     push @$datasets, $url;
-    delete $tree->{$prodname};
+    
   } 
   $tree->{'MULTI'}{'ENSEMBL_DATASETS'} = $datasets;
   #warn ">>> NEW KEYS: ".Dumper($tree);


### PR DESCRIPTION
When renaming keys, allow for the case where production_name and species.url are the same.