### PR TITLE
ENSEMBL-5002 - Oligo probe "View all locations" broken

### DIFF
--- a/modules/EnsEMBL/Web/Factory/Feature.pm
+++ b/modules/EnsEMBL/Web/Factory/Feature.pm
@@ -200,7 +200,7 @@ sub _create_ProbeFeatures_linked_transcripts {
 
     if (!exists $seen{$entry->stable_id}) {
       my $transcript = $transcript_adaptor->fetch_by_stable_id($entry->stable_id);
-      push @transcripts, $transcript;
+      push @transcripts, $transcript if $transcript;
       $seen{$entry->stable_id} = 1;
     }
   }


### PR DESCRIPTION
Some of the transcripts associated with a probe or probeset are not present in transcript table.
See ticket for more info.