### PR TITLE
Remove dbSNP links for the non-human species

### DIFF
--- a/modules/EnsEMBL/Web/Component/LD.pm
+++ b/modules/EnsEMBL/Web/Component/LD.pm
@@ -62,7 +62,7 @@ sub focus {
     my $snp       = $builder->object('Variation');
     my $name      = $snp->name;
     my $source    = $snp->source;
-    my $link_name = $hub->get_ExtURL_link($name, 'DBSNP', $name) if $source eq 'dbSNP';
+    my $link_name = $hub->get_ExtURL_link($name, 'DBSNP', $name) if ($source eq 'dbSNP' && $hub->species eq 'Homo_sapiens');
     my $url       = $hub->url({ type => 'Variation', action => 'Explore', v => $v, vf => $hub->param('vf') });
 
     $info = sprintf 'Variant %s (%s %s) <a href="%s">[View variation]</a>', $link_name, $source, $snp->Obj->adaptor->get_source_version($source), $url;
@@ -201,14 +201,17 @@ sub pop_url {
 
   my ($self, $pop_name, $pop_dbSNP) = @_;
 
+  my $hub = $self->hub;
+
   my @composed_name = split(':', $pop_name);
   if (scalar @composed_name > 1) {
     $composed_name[$#composed_name] = '<b>'.$composed_name[$#composed_name].'</b>';
     $pop_name = join(':', @composed_name);
   }
 
+  return $pop_name if ($hub->species ne 'Homo_sapiens');
   return $pop_name unless $pop_dbSNP;
-  return $self->hub->get_ExtURL_link($pop_name, 'DBSNPPOP', $pop_dbSNP->[0]);
+  return $hub->get_ExtURL_link($pop_name, 'DBSNPPOP', $pop_dbSNP->[0]);
 }
 
 #-----------------------------------------------------------------------------

--- a/modules/EnsEMBL/Web/Component/Variation.pm
+++ b/modules/EnsEMBL/Web/Component/Variation.pm
@@ -45,5 +45,64 @@ sub trim_large_allele_string {
   });
 }
 
-1;
+# Population external links
+sub pop_url {
+  ### Arg1        : Population name (to be displayed)
+  ### Arg2        : dbSNP population ID (variable to be linked to)
+  ### Arg3        : Population display label (optional)
+  ### Example     : $self->pop_url($pop_name, $pop_dbSNPID);
+  ### Description : makes pop_name into a URL
+  ### Returns  string
 
+  my ($self, $pop_name, $pop_dbSNP, $pop_label) = @_;
+
+  my $hub = $self->hub;
+
+  my $pop_url;
+
+  $pop_label = $pop_name if (!$pop_label);
+
+  if($pop_name =~ /^1000GENOMES/) {
+    $pop_url = $hub->get_ExtURL('1KG_POP', $pop_label);
+  }
+  elsif ($pop_name =~ /^NextGen/i) {
+    $pop_url = $hub->get_ExtURL('NEXTGEN_POP');
+  }
+  elsif ($pop_name =~ /^ExAC/i) {
+    $pop_url = $hub->get_ExtURL('EXAC_POP');
+  }
+  else {
+    $pop_url = ($pop_dbSNP && $pop_dbSNP->[0] ne '' && $hub->species eq 'Homo_sapiens') ? $hub->get_ExtURL('DBSNPPOP', $pop_dbSNP->[0]) : undef;
+  }
+  return $pop_url;
+}
+
+sub pop_link {
+  ### Arg1        : Population name (to be displayed)
+  ### Arg2        : dbSNP population ID (variable to be linked to)
+  ### Arg3        : Population label (optional)
+  ### Example     : $self->pop_link($pop_name, $pop_dbSNPID, $pop_label);
+  ### Description : makes pop_name into a link
+  ### Returns  string
+
+  my ($self, $pop_name, $pop_dbSNP, $pop_label) = @_;
+
+  my $hub = $self->hub;
+
+  my $pop_link;
+
+  $pop_label = $pop_name if (!$pop_label);
+
+  if($pop_name =~ /^1000GENOMES/) {
+    $pop_link = $hub->get_ExtURL_link($pop_label, '1KG_POP', $pop_name);
+  }
+  elsif ($pop_name =~ /^NextGen/i) {
+    $pop_link = $hub->get_ExtURL_link($pop_label, 'NEXTGEN_POP', $pop_name);
+  }
+  else {
+    $pop_link = ($pop_dbSNP && $hub->species eq 'Homo_sapiens') ? $hub->get_ExtURL_link($pop_label, 'DBSNPPOP', $pop_dbSNP->[0]) : $pop_label;
+  }
+  return $pop_link;
+}
+
+1;

--- a/modules/EnsEMBL/Web/Component/Variation/HighLD.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/HighLD.pm
@@ -149,13 +149,7 @@ sub summary_table {
     }
 
     # Population external links
-    my $pop_url;
-    if ($pop_name =~ /^1000GENOMES/) { 
-      $pop_url = $self->hub->get_ExtURL_link($pop_label, '1KG_POP', $pop_name);
-    }
-    else {
-      $pop_url = $pop_dbSNP ? $self->hub->get_ExtURL_link($pop_label, 'DBSNPPOP', $pop_dbSNP->[0]) : $pop_label;
-    }
+    my $pop_url = $self->pop_link($pop_name, $pop_dbSNP, $pop_label);
     
     my $row = {
       name    => $pop_url,

--- a/modules/EnsEMBL/Web/Component/Variation/PairwiseLD.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/PairwiseLD.pm
@@ -158,13 +158,7 @@ sub content_results {
     }
 
     # Population external links
-    my $pop_url;
-    if ($pop_name =~ /^1000GENOMES/) {
-      $pop_url = $self->hub->get_ExtURL_link($pop_label, '1KG_POP', $pop_name);
-    }
-    else {
-      $pop_url = $pop_dbSNP ? $self->hub->get_ExtURL_link($pop_label, 'DBSNPPOP', $pop_dbSNP->[0]) : $pop_label;
-    }
+    my $pop_url = $self->pop_link($pop_name, $pop_dbSNP, $pop_label);
 
     my @ld_values = @{$ldfca->fetch_by_VariationFeatures(\@vfs, $ld_population)->get_all_ld_values()};  
     foreach my $hash (@ld_values) {

--- a/modules/EnsEMBL/Web/Component/Variation/PopulationGenotypes.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/PopulationGenotypes.pm
@@ -285,9 +285,15 @@ sub format_table {
      
       # SSID + Submitter
       if ($ssid) {
-        $pop_row{'ssid'}      = $hub->get_ExtURL_link($ssid, 'DBSNPSS', $ssid) unless $ssid eq 'ss0';
-        $pop_row{'submitter'} = ($data->{'submitter'}) ? $hub->get_ExtURL_link($data->{'submitter'}, 'DBSNPSSID', $data->{'submitter'}) : '-';
-      }  
+        if ($hub->species eq 'Homo_sapiens') {
+          $pop_row{'ssid'}      = $hub->get_ExtURL_link($ssid, 'DBSNPSS', $ssid) unless $ssid eq 'ss0';
+          $pop_row{'submitter'} = ($data->{'submitter'}) ? $hub->get_ExtURL_link($data->{'submitter'}, 'DBSNPSSID', $data->{'submitter'}) : '-';
+        }
+        else {
+          $pop_row{'ssid'} = $ssid unless $ssid eq 'ss0';
+          $pop_row{'submitter'} = ($data->{'submitter'}) ? $data->{'submitter'} : '-';
+        }
+      }
 
       # Column "Allele: frequency (count)"
       my $allele_content = $self->format_allele_genotype_content($data,'Allele',$ref_allele,$is_somatic);
@@ -422,31 +428,6 @@ sub sort_extra_pops {
   return join '<br />', @pops;
 }
 
-sub pop_url {
-   ### Arg1        : Population name (to be displayed)
-   ### Arg2        : dbSNP population ID (variable to be linked to)
-   ### Example     : $self->pop_url($pop_name, $pop_dbSNPID);
-   ### Description : makes pop_name into a link
-   ### Returns  string
-
-  my ($self, $pop_name, $pop_dbSNP) = @_;
-  
-  my $pop_url;
-
-  if($pop_name =~ /^1000GENOMES/) {
-    $pop_url = $self->hub->get_ExtURL('1KG_POP', $pop_name); 
-  }
-  elsif ($pop_name =~ /^NextGen/i) {
-    $pop_url = $self->hub->get_ExtURL('NEXTGEN_POP');
-  }
-  elsif ($pop_name =~ /^ExAC/i) {
-    $pop_url = $self->hub->get_ExtURL('EXAC_POP');
-  }
-  else {
-    $pop_url = ($pop_dbSNP && $pop_dbSNP->[0] ne '') ? $self->hub->get_ExtURL('DBSNPPOP', $pop_dbSNP->[0]) : undef;
-  }
-  return $pop_url;
-}
 
 sub no_pop_data {
   my ($self, $data) = @_;
@@ -481,8 +462,8 @@ sub no_pop_data {
       }
       
       push @rows, {
-        ssid      => $hub->get_ExtURL_link($ss, 'DBSNPSS', $ss),
-        submitter => $hub->get_ExtURL_link($sub, 'DBSNPSSID', $sub),
+        ssid      => ($hub->species eq 'Homo_sapiens') ? $hub->get_ExtURL_link($ss, 'DBSNPSS', $ss) : $ss,
+        submitter => ($hub->species eq 'Homo_sapiens') ? $hub->get_ExtURL_link($sub, 'DBSNPSSID', $sub) : $sub,
         alleles   =>
           join("/",
             map {defined($alleles{$_}) ? qq{<span style="font-weight:bold">$_</span>} : qq{<span style="color:red">$_</span>}}

--- a/modules/EnsEMBL/Web/Component/Variation/SampleGenotypes.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/SampleGenotypes.pm
@@ -140,7 +140,7 @@ sub content {
     $selected_pop ||= (keys %rows)[0]; # there is only one entry in %rows
 
     my $pop_name = $pop_names{$selected_pop};
-    my $project_url  = $self->pop_url($pop_name,$pop_name);
+    my $project_url  = $self->pop_url($pop_name);
     my $pop_url = ($project_url) ? sprintf('<div style="clear:both"></div><p><a href="%s" rel="external">More information about the <b>%s</b> population</a></p>', $project_url, $pop_name) : ''; 
 
     return $self->toggleable_table(
@@ -285,31 +285,6 @@ sub format_other_samples_table {
 sub format_parent {
   my ($self, $parent_data) = @_;
   return ($parent_data && $parent_data->{'Name'}) ? $parent_data->{'Name'} : '-';
-}
-
-
-sub pop_url {
-   ### Arg1        : Full population name
-   ### Arg2        : Population name/label (to be displayed)
-   ### Arg3        : dbSNP population ID (variable to be linked to)
-   ### Example     : $self->pop_url($pop_name, $pop_label, $pop_dbSNPID);
-   ### Description : makes pop_name into a link
-   ### Returns  string
-
-  my ($self, $pop_name, $pop_label, $pop_dbSNP) = @_;
-
-  my $pop_url;
-
-  if($pop_name =~ /^1000GENOMES/) {
-    $pop_url = $self->hub->get_ExtURL('1KG_POP', $pop_label);
-  }
-  elsif ($pop_name =~ /^NextGen/i) {
-    $pop_url = $self->hub->get_ExtURL('NEXTGEN_POP');
-  }
-  else {
-    $pop_url = $pop_dbSNP ? $self->hub->get_ExtURL('DBSNPPOP', $pop_dbSNP->[0]) : undef;
-  }
-  return $pop_url;
 }
 
 

--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -212,7 +212,7 @@ sub variation_source {
   my $source_prefix = 'View in';
 
   # Source link
-  if ($source =~ /dbSNP/) {
+  if ($source =~ /dbSNP/ && $hub->species eq 'Homo_sapiens') {
     $sname       = 'DBSNP';
     $source_link = $hub->get_ExtURL_link("$source_prefix dbSNP", $sname, $name);
   } elsif ($source =~ /ClinVar/i) {
@@ -242,7 +242,7 @@ sub variation_source {
   }  elsif ($source =~ /PhenCode/) {
      $sname       = 'PHENCODE';
      $source_link = $hub->get_ExtURL_link("$source_prefix PhenCode", $sname, $name);
-} else {
+  } else {
     $source_link = $url ? qq{<a href="$url" class="constant">$source_prefix $source</a>} : "$source $version";
   }
   
@@ -324,18 +324,21 @@ sub synonyms {
 
     next if ($db =~ /(Affy|Illumina|HGVbase|TSC|dbSNP\sHGVS)/i);
 
-    if ($db =~ /dbsnp rs/i) { # Glovar stuff
-      @urls = map $hub->get_ExtURL_link($_, 'DBSNP', $_), @ids;
-    }
-    elsif ($db =~ /dbsnp hgvs/i) {
-      @urls = sort { $a !~ /NM_/ cmp $b !~ /NM_/ || $a cmp $b } @ids;
-    }    
-    elsif ($db =~ /dbsnp/i) {
-      foreach (@ids) {
-        next if /^ss/; # don't display SSIDs - these are useless
-        push @urls, $hub->get_ExtURL_link($_, 'DBSNP', $_);
+    # dbSNP
+    if ($db =~ /dbsnp/i && $hub->species eq 'Homo_sapiens') {
+      if ($db =~ /dbsnp rs/i ) { # Glovar stuff
+        @urls = map $hub->get_ExtURL_link($_, 'DBSNP', $_), @ids;
       }
-      next unless @urls;
+      elsif ($db =~ /dbsnp hgvs/i) {
+        @urls = sort { $a !~ /NM_/ cmp $b !~ /NM_/ || $a cmp $b } @ids;
+      }
+      elsif ($db =~ /dbsnp/i) {
+        foreach (@ids) {
+          next if /^ss/; # don't display SSIDs - these are useless
+          push @urls, $hub->get_ExtURL_link($_, 'DBSNP', $_);
+        }
+        next unless @urls;
+      }
     }
     elsif ($db =~ /clinvar/i) {
       @urls = map $hub->get_ExtURL_link($_, 'CLINVAR', $_), @ids;


### PR DESCRIPTION
dbSNP is no longer supporting non-human variants (will be supported by EVA next year) therefore we need to remove the deprecated links to dbSNP for the non-human species