### PR TITLE
The 'novel' terminology has been deprecated, so remove term from z-menu title

### DIFF
--- a/modules/EnsEMBL/Web/ZMenu/Gene.pm
+++ b/modules/EnsEMBL/Web/ZMenu/Gene.pm
@@ -47,7 +47,7 @@ sub _content {
   my @xref        = $object->display_xref;
   my $gene_desc   = $object->gene_description =~ s/No description//r =~ s/\[.+\]\s*$//r;
   
-  $self->caption($xref[0] ? "$xref[3]: $xref[0]" : 'Novel transcript');
+  $self->caption($xref[0] ? "$xref[3]: $xref[0]" : 'Gene');
   
   if($gene_desc) {
     $self->add_entry({

--- a/modules/EnsEMBL/Web/ZMenu/Transcript.pm
+++ b/modules/EnsEMBL/Web/ZMenu/Transcript.pm
@@ -43,7 +43,7 @@ sub content {
   
   $translation = undef if $transcript->isa('Bio::EnsEMBL::PredictionTranscript'); 
 
-  $self->caption($gene->display_xref ? $gene->display_xref->db_display_name.": ".$gene->display_xref->display_id : !$gene ? $stable_id : 'Novel transcript');
+  $self->caption($gene->display_xref ? $gene->display_xref->db_display_name.": ".$gene->display_xref->display_id : !$gene ? $stable_id : 'Transcript');
     
   if (scalar @click) {
     ## Has user clicked on an exon (or exons)? If yes find out the exon rank to display in zmenu


### PR DESCRIPTION
This is a proposed fix for https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-4174.