### PR TITLE
Include file type abbreviations that are in common usage in the export options

### DIFF
--- a/modules/EnsEMBL/Web/Object/Export.pm
+++ b/modules/EnsEMBL/Web/Object/Export.pm
@@ -119,9 +119,9 @@ sub config {
       formats => [
         [ 'csv',  'CSV (Comma separated values)' ],
         [ 'tab',  'Tab separated values' ],
-        [ 'gtf',  'Gene Transfer Format (GTF)' ],
-        [ 'gff',  'Generic Feature Format' ],
-        [ 'gff3', 'Generic Feature Format Version 3' ],
+        [ 'gtf',  'GTF (Gene Transfer Format)' ],
+        [ 'gff',  'GFF (Generic Feature Format)' ],
+        [ 'gff3', 'GFF3 (Generic Feature Format Version 3)' ],
       ],
       params => [
         [ 'similarity', 'Similarity features' ],


### PR DESCRIPTION
This is a proposed fix for https://www.ebi.ac.uk/panda/jira/browse/ENSEMBL-2731. I think users are more familiar with the abbreviations for GTF, GFF and GFF3 than they are with the long forms, so it makes sense to put the filetypes first.