### PR TITLE
Fix KEGG_ENZYME URL resolver in DEFAULTS.ini

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -287,7 +287,7 @@ IMGT/GENE_DB                = http://www.imgt.org/IMGT_GENE-DB/GENElect?query=2+
 INTERACTIVEFLY              = http://www.sdbonline.org/fly###ID###
 INTERPRO                    = http://www.ebi.ac.uk/interpro/entry/###ID###
 JAX_STRAINS                 = https://www.jax.org/strain/###ID###
-KEGG_ENZYME                 = http://www.genome.jp/kegg-bin/show_pathway?ec###ID###
+KEGG_ENZYME                 = http://www.kegg.jp/entry/EC###ID###
 MEDAKA                      =
 METACYC                     = http://metacyc.org/META/NEW-IMAGE?type=PATHWAY&object=###ID###
 MGI                         = http://www.informatics.jax.org/marker/###ID###


### PR DESCRIPTION
I believe this link should take you to KEGG directly, rather than the context-free EC page on www.genome.jp. For example, http://www.kegg.jp/entry/EC00983+1.1.1.205, versus http://www.kegg.jp/entry/1.1.1.205, and the original link which now fails to resolve.