### PR TITLE
Link to pathway diagram for InterPro-derived KEGG xrefs

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -287,7 +287,7 @@ IMGT/GENE_DB                = http://www.imgt.org/IMGT_GENE-DB/GENElect?query=2+
 INTERACTIVEFLY              = http://www.sdbonline.org/fly###ID###
 INTERPRO                    = http://www.ebi.ac.uk/interpro/entry/###ID###
 JAX_STRAINS                 = https://www.jax.org/strain/###ID###
-KEGG_ENZYME                 = http://www.kegg.jp/entry/EC###ID###
+KEGG_ENZYME                 = http://www.genome.jp/kegg-bin/show_pathway?map=map###ID###
 MEDAKA                      =
 METACYC                     = http://metacyc.org/META/NEW-IMAGE?type=PATHWAY&object=###ID###
 MGI                         = http://www.informatics.jax.org/marker/###ID###

--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -1073,6 +1073,10 @@ sub _sort_similarity_links {
       $word .= " ($primary_id)" if $A eq 'MARKERSYMBOL';
 
       if ($link) {
+        ## KEGG Enzyme xrefs are compound, consisting of pathway and enzyme ids.
+        ## Need to modify the xref for linkouts to work.
+        $link =~ s/%2B/&multi_query=/ if $externalDB eq 'KEGG_Enzyme';
+        
         $text = qq{<a href="$link" class="constant">$word</a>};
       } else {
         $text = $word;


### PR DESCRIPTION
This is the configuration that EG have had for some time. The xref here is actually a compound of two (or more...) things. Firstly a pathway, and then a set of enzymes (EC IDs) - usually it's just one enzyme, but not always. So, rather than linking to a single enzyme page, we can link to a pathway page, with all the enzymes highlighted in red.
