### PR TITLE
Fix for LDPlot redirecting to LD after selecting populations

### DIFF
--- a/modules/EnsEMBL/Web/Component/PopulationSelector.pm
+++ b/modules/EnsEMBL/Web/Component/PopulationSelector.pm
@@ -25,15 +25,27 @@ use base qw(EnsEMBL::Web::Component::MultiSelector);
 
 sub _init {
   my $self = shift;
- 
+  my $action = '';
+
   $self->SUPER::_init;
- 
+
   $self->{'link_text'}       = 'Select populations';
   $self->{'included_header'} = 'Selected Populations';
   $self->{'excluded_header'} = 'Unselected Populations';
   $self->{'url_param'}       = 'pop';
   $self->{'rel'}             = 'modal_select_populations';
-  $self->{'url'}             = $self->hub->url({action => 'LDPlot'}, 1);
+
+  foreach my $component_array (@{$self->hub->components}) {
+    foreach my $component (@{$component_array}) {
+      if ($component eq 'LDPlot') {
+        $action = 'LDPlot';
+      } elsif ($component eq 'LDImage') {
+        $action = 'LD';
+      }
+    }
+  }
+
+  $self->{'url'} = $self->hub->url({action => $action}, 1);
 }
 
 sub content_ajax {

--- a/modules/EnsEMBL/Web/Component/PopulationSelector.pm
+++ b/modules/EnsEMBL/Web/Component/PopulationSelector.pm
@@ -35,17 +35,7 @@ sub _init {
   $self->{'url_param'}       = 'pop';
   $self->{'rel'}             = 'modal_select_populations';
 
-  foreach my $component_array (@{$self->hub->components}) {
-    foreach my $component (@{$component_array}) {
-      if ($component eq 'LDPlot') {
-        $action = 'LDPlot';
-      } elsif ($component eq 'LDImage') {
-        $action = 'LD';
-      }
-    }
-  }
-
-  $self->{'url'} = $self->hub->url({action => $action}, 1);
+  $self->{'url'} = $self->hub->url({action => $self->hub->action}, 1);
 }
 
 sub content_ajax {

--- a/modules/EnsEMBL/Web/Component/PopulationSelector.pm
+++ b/modules/EnsEMBL/Web/Component/PopulationSelector.pm
@@ -25,6 +25,7 @@ use base qw(EnsEMBL::Web::Component::MultiSelector);
 
 sub _init {
   my $self = shift;
+  my $hub = $self->hub;
 
   $self->SUPER::_init;
 
@@ -34,7 +35,9 @@ sub _init {
   $self->{'url_param'}       = 'pop';
   $self->{'rel'}             = 'modal_select_populations';
 
-  $self->{'url'} = $self->hub->url({action => $self->hub->action}, 1);
+  # if referer_action param exists then get action from it else get it from hub itself
+  # referer_action will be used by the view configs while action itself is usually used if a user selects select population directly from the sidebar
+  $self->{'url'} = $hub->url({ action => ($hub->param('referer_action') || $hub->action) }, 1);
 }
 
 sub content_ajax {

--- a/modules/EnsEMBL/Web/Component/PopulationSelector.pm
+++ b/modules/EnsEMBL/Web/Component/PopulationSelector.pm
@@ -33,7 +33,7 @@ sub _init {
   $self->{'excluded_header'} = 'Unselected Populations';
   $self->{'url_param'}       = 'pop';
   $self->{'rel'}             = 'modal_select_populations';
-  $self->{'url'}             = $self->hub->url({action => 'LD'}, 1);
+  $self->{'url'}             = $self->hub->url({action => 'LDPlot'}, 1);
 }
 
 sub content_ajax {

--- a/modules/EnsEMBL/Web/Component/PopulationSelector.pm
+++ b/modules/EnsEMBL/Web/Component/PopulationSelector.pm
@@ -25,7 +25,6 @@ use base qw(EnsEMBL::Web::Component::MultiSelector);
 
 sub _init {
   my $self = shift;
-  my $action = '';
 
   $self->SUPER::_init;
 

--- a/modules/EnsEMBL/Web/ViewConfig/Location/LDImage.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Location/LDImage.pm
@@ -50,10 +50,12 @@ sub extra_tabs {
   my $self = shift;
   my $hub  = $self->hub;
 
+  # referer_action is added to ensure the correct action can be used by PopulationSelector when the OK icon is clicked
   return [
     'Select populations',
     $hub->url('MultiSelector', {
       action   => 'SelectPopulation',
+      referer_action => $hub->action,
       %{$hub->multi_params}
     })
   ];

--- a/modules/EnsEMBL/Web/ViewConfig/Variation/LDPlot.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Variation/LDPlot.pm
@@ -52,10 +52,12 @@ sub extra_tabs { # TODO - fix the old style component link
   my $self = shift;
   my $hub  = $self->hub;
 
+  # referer_action is added to ensure the correct action can be used by PopulationSelector when the OK icon is clicked
   return [
     'Select populations',
     $hub->url('MultiSelector', {
       action   => 'SelectPopulation',
+      referer_action => $hub->action,
       %{$hub->multi_params}
     })
   ];


### PR DESCRIPTION
This fix is for ENSWEB-4360. The sandbox link is: http://ves-hx-78.ebi.ac.uk:8300/Homo_sapiens/Variation/LDPlot?db=core;pop1=373508;r=9:22125004-22126004;v=rs1333049;vdb=variation;vf=906984.