### PR TITLE
Display population structures that only have 2 layers

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/PopulationGenotypes.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/PopulationGenotypes.pm
@@ -253,9 +253,19 @@ sub format_table {
   push @ids, $all if $all;
   my @super_order = sort {$tree->{$a}{'name'} cmp $tree->{$b}{'name'}} keys (%$tree);
   foreach my $super (@super_order) {
-    next if ($all && $super == $all); # Skip the 3 layers structure, which leads to duplicated rows
-    push @ids, $super;
     my $children = $tree->{$super}{'children'} || {};
+    my $next_level_has_children = 0;
+    foreach my $child_id (keys %$children) {
+      if ($tree->{$child_id}{'children'}) {
+        $next_level_has_children = 1;
+      }
+    }
+    next if ($all && $super == $all && $next_level_has_children); # Skip the 3 layers structure, which leads to duplicated rows
+    if ($all) {
+      push @ids, $super if ($super != $all);
+    } else {
+      push @ids, $super;
+    } 
     push @ids, sort {$children->{$a} cmp $children->{$b}} keys (%$children);
   }
 

--- a/modules/EnsEMBL/Web/Component/Variation/PopulationGenotypes.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/PopulationGenotypes.pm
@@ -260,12 +260,11 @@ sub format_table {
         $next_level_has_children = 1;
       }
     }
-    next if ($all && $super == $all && $next_level_has_children); # Skip the 3 layers structure, which leads to duplicated rows
-    if ($all) {
-      push @ids, $super if ($super != $all);
+    if ($all && $super == $all) {
+      next if ($next_level_has_children); # Skip the 3 layers structure, which leads to duplicated rows
     } else {
       push @ids, $super;
-    } 
+    }
     push @ids, sort {$children->{$a} cmp $children->{$b}} keys (%$children);
   }
 

--- a/modules/EnsEMBL/Web/Component/Variation/PopulationGraphs.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/PopulationGraphs.pm
@@ -41,6 +41,7 @@ sub content {
   my $width       = 118;
   my $large_width = 135;
   my $max_width   = 150;
+  my $max_pie_chart_count = 35;
   my (@graphs, $pop_tree, %sub_pops, @alleles);
 
   my $vf         = $hub->param('vf');
@@ -82,7 +83,7 @@ sub content {
   
   # Create graphs
   my $population_count = scalar keys %$pop_freq;
-  my $too_many_populations = ($population_count > 35);
+  my $too_many_populations = ($population_count > $max_pie_chart_count);
   foreach my $pop_name (sort { ($a !~ /ALL/ cmp $b !~ /ALL/) || $a cmp $b } keys %$pop_freq) {
     if ($too_many_populations) {
       next if ($pop_name !~ /ALL/);

--- a/modules/EnsEMBL/Web/Component/Variation/PopulationGraphs.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/PopulationGraphs.pm
@@ -81,7 +81,12 @@ sub content {
   }
   
   # Create graphs
+  my $population_count = scalar keys %$pop_freq;
+  my $too_many_populations = ($population_count > 35);
   foreach my $pop_name (sort { ($a !~ /ALL/ cmp $b !~ /ALL/) || $a cmp $b } keys %$pop_freq) {
+    if ($too_many_populations) {
+      next if ($pop_name !~ /ALL/);
+    }
     my $values     = '';
     my $short_name = $self->get_short_name($pop_name);
     my $pop_desc   = $pop_freq->{$pop_name}{'desc'};


### PR DESCRIPTION
Display populations that only have 2 layers: super_population -> sub_population. At the moment we only deal with 3 layers (1000 genomes project) or 1 layer (everything else). 
I test views for human and sheep and all is working fine. But getting the PR in early would give us more time for testing. Probably @ens-lgil knows the code best and can comment.