### PR TITLE
Fix the hide/show tutorial button overlapping the configuration input box

### DIFF
--- a/htdocs/components/91_config_matrix.css
+++ b/htdocs/components/91_config_matrix.css
@@ -135,7 +135,7 @@ div.config div.config_matrix div.subtracks div.select_all .current  { font-weigh
 
 /* tutorial */
 
-div.config div.config_matrix .toggle_tutorial           { position: absolute; top: 8px; left: 800px; width: 110px; height: 25px; background: url(/i/tutorial.png) 0 top no-repeat; cursor: pointer; }
+div.config div.config_matrix .toggle_tutorial           { position: absolute; top: 55px; left: 630px; width: 110px; height: 25px; background: url(/i/tutorial.png) 0 top no-repeat; cursor: pointer; }
 div.config div.config_matrix .toggle_tutorial.on        { background-position: 0 bottom; }
 div.config div.config_matrix .tutorial                  { position: absolute; display: none; padding: 8px; background: [[V_DARK_GREY]]; color: [[WHITE]]; text-align: center; z-index: 10000; white-space: normal; line-height: 16px; border-radius: 10px; }
 div.config div.config_matrix .tutorial:before, 

--- a/htdocs/components/91_config_matrix.css
+++ b/htdocs/components/91_config_matrix.css
@@ -158,7 +158,7 @@ div.config div.config_matrix .tutorial.col:after        { border-width: 0 25px 8
 div.config div.config_matrix .tutorial.fil              { width: 180px; top: 3px; left: 300px; padding: 4px; border-radius: 0; }
 div.config div.config_matrix .tutorial.fil:before       { border-width: 30px 30px 0 0; bottom: 50%; left: -30px; }
 div.config div.config_matrix .tutorial.fil:after        { border-width: 0 30px 30px 0; top:    50%; left: -30px; }
-div.config div.config_matrix .tutorial.video            { top: 45px; left: 800px; }
+div.config div.config_matrix .tutorial.video            { top: 50px; left: 760px; }
 div.config div.config_matrix .tutorial.video a          { color: [[WHITE]]!important; }
 div.config div.config_matrix .tutorial.video:before,    
 div.config div.config_matrix .tutorial.video:after      { display: none; }

--- a/htdocs/components/91_config_matrix.css
+++ b/htdocs/components/91_config_matrix.css
@@ -135,7 +135,8 @@ div.config div.config_matrix div.subtracks div.select_all .current  { font-weigh
 
 /* tutorial */
 
-div.config div.config_matrix .toggle_tutorial           { position: absolute; top: 55px; left: 630px; width: 110px; height: 25px; background: url(/i/tutorial.png) 0 top no-repeat; cursor: pointer; }
+div.config div.config_matrix .header_tutorial_wrapper   { position: relative; }
+div.config div.config_matrix .toggle_tutorial           { position: absolute; top: 2px; left: 300px; width: 110px; height: 25px; background: url(/i/tutorial.png) 0 top no-repeat; cursor: pointer; }
 div.config div.config_matrix .toggle_tutorial.on        { background-position: 0 bottom; }
 div.config div.config_matrix .tutorial                  { position: absolute; display: none; padding: 8px; background: [[V_DARK_GREY]]; color: [[WHITE]]; text-align: center; z-index: 10000; white-space: normal; line-height: 16px; border-radius: 10px; }
 div.config div.config_matrix .tutorial:before, 
@@ -158,7 +159,7 @@ div.config div.config_matrix .tutorial.col:after        { border-width: 0 25px 8
 div.config div.config_matrix .tutorial.fil              { width: 180px; top: 3px; left: 300px; padding: 4px; border-radius: 0; }
 div.config div.config_matrix .tutorial.fil:before       { border-width: 30px 30px 0 0; bottom: 50%; left: -30px; }
 div.config div.config_matrix .tutorial.fil:after        { border-width: 0 30px 30px 0; top:    50%; left: -30px; }
-div.config div.config_matrix .tutorial.video            { top: 50px; left: 760px; }
+div.config div.config_matrix .tutorial.video            { top: -2px; left: 430px; }
 div.config div.config_matrix .tutorial.video a          { color: [[WHITE]]!important; }
 div.config div.config_matrix .tutorial.video:before,    
 div.config div.config_matrix .tutorial.video:after      { display: none; }

--- a/modules/EnsEMBL/Web/Form/ViewConfigMatrix.pm
+++ b/modules/EnsEMBL/Web/Form/ViewConfigMatrix.pm
@@ -300,9 +300,11 @@ sub build {
   }
 
   my $html = sprintf(qq(
-    <h1>$matrix_data->{'section'}</h1>
-    <div class="toggle_tutorial"></div>
-    $tutorials{'video'}
+    <div class="header_tutorial_wrapper">
+      <h1>$matrix_data->{'section'}</h1>
+      <div class="toggle_tutorial"></div>
+      $tutorials{'video'}
+    </div>
     <div class="header_wrapper">
       <h2>%s</h2>
       %s


### PR DESCRIPTION
This is a fix for ENSWEB-4344. With this fix show/hide tutorial button will be displayed next to the configuration modal title.