### PR TITLE
New way of listing alignments

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/Compara.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara.pm
@@ -42,6 +42,14 @@ sub common_name {
   return $self->hub->species_defs->get_config($name, 'SPECIES_COMMON_NAME');
 }
 
+sub combine_names {
+  my ($self, $common_name, $sci_name) = @_;
+  if ($sci_name eq $common_name) {
+      return "<em>$sci_name</em>";
+  } else {
+      return "$common_name (<em>$sci_name</em>)";
+  }
+}
 
 sub error_message {
   my ($self, $title, $message, $type) = @_;
@@ -157,7 +165,7 @@ sub print_wga_stats {
           my $cgc = $colors[int($gc/25)];
           my $cec = $colors[int($ec/25)];
           $table->add_row({
-            'species' => sprintf('%s (<em>%s</em>)', $info->{$sp}{'common_name'}, $info->{$sp}{'long_name'}),
+            'species' => $self->combine_names($info->{$sp}{'common_name'}, $info->{$sp}{'long_name'}),
             'asm'     => $info->{$sp}{'assembly'},
             'gl'      => $self->thousandify($info->{$sp}{'genome_length'}),
             'gc'      => $self->thousandify($info->{$sp}{'genome_coverage'}),

--- a/modules/EnsEMBL/Web/Document/HTML/Compara.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara.pm
@@ -207,6 +207,41 @@ sub list_mlss_by_method {
 }
 
 
+sub pairwise_mlss_data {
+  my ($self, $methods) = @_;
+
+  my $compara_db = $self->hub->database('compara');
+  return unless $compara_db;
+
+  my $mlss_adaptor    = $compara_db->get_adaptor('MethodLinkSpeciesSet');
+
+  my %data;
+  my %synt_methods;
+
+  ## Munge all the necessary information
+  foreach my $method (@{$methods||[]}) {
+    my $mlss_sets  = $mlss_adaptor->fetch_all_by_method_link_type($method);
+    if (@$mlss_sets and ($mlss_sets->[0]->method->class =~ /SyntenyRegion.synteny/)) {
+      $synt_methods{$method} = 1;
+    }
+
+    foreach my $mlss (@$mlss_sets) {
+      my ($gdb1, $gdb2) = @{$mlss->species_set->genome_dbs};
+      my $name1 = $self->hub->species_defs->production_name_mapping($gdb1->name);
+      if ($gdb2) {
+        my $name2 = $self->hub->species_defs->production_name_mapping($gdb2->name);
+        push @{$data{$name1}->{$name2}}, [$method, $mlss->dbID];
+        push @{$data{$name2}->{$name1}}, [$method, $mlss->dbID];
+      } else {
+        # Self alignment
+        push @{$data{$name1}->{$name1}}, [$method, $mlss->dbID];
+      }
+    }
+  }
+  return (\%data, \%synt_methods);
+}
+
+
 sub mlss_data {
   my ($self, $methods) = @_;
 
@@ -309,6 +344,7 @@ sub get_species_info {
     $info->{$sp}{'short_name'}     = $short_name;
     $info->{$sp}{'formatted_name'} = $formatted_name; 
     $info->{$sp}{'common_name'}    = $hub->species_defs->get_config($sp, 'SPECIES_COMMON_NAME');
+    $info->{$sp}{'sample_loc'}     = ($hub->species_defs->get_config($sp, 'SAMPLE_DATA') || {})->{'LOCATION_PARAM'};
 
     if ($mlss) {
       my $prod_name = $hub->species_defs->get_config($sp, 'SPECIES_PRODUCTION_NAME');
@@ -376,6 +412,112 @@ sub draw_stepped_table {
   $html .= "</table>\n";
 
   return $html;
+}
+
+
+sub draw_pairwise_alignment_list {
+    my ($self, $species) = @_;
+
+    my $hub  = $self->hub;
+    my ($data, $synt_methods) = $self->pairwise_mlss_data( ['TRANSLATED_BLAT_NET','BLASTZ_NET', 'LASTZ_NET', 'ATAC', 'SYNTENY'] );
+
+    ## Do some munging
+    my ($species_order, $info) = $self->get_species_info([keys %$data], 1);
+
+    ## Output HTML
+    # Outer table has 1 row per query species
+    my $thtml = qq{<table id="genomic_align_table" class="no_col_toggle ss autocenter" style="width: 100%" cellpadding="0" cellspacing="0">};
+
+    my ($i, $j) = (0, 0);
+    foreach my $sp (@$species_order) {
+        next unless $data->{$sp};
+
+	my $ybg = $i++ % 2 ? 'bg1' : 'bg2';
+
+        # Intermediate table has 1 row per target species
+        my $ghtml = sprintf q{
+        <table id="%s_aligns" class="no_col_toggle ss toggle_table hide toggleable autocenter all_species_tables" style="width: 100%;" cellpadding="0" cellspacing="0">
+        }, $sp;
+
+	$j = $i;
+        my $genomic_count = 0;
+        my $synteny_count = 0;
+        foreach my $other (@$species_order) {
+            my $alignments = $data->{$sp}{$other};
+            next unless $alignments;
+            my $xbg = $j++ % 2 ? 'bg1' : 'bg2';
+
+            # Inner table has 1 row per alignment method
+            my $astr = qq{<table cellpadding="0" cellspacing="2" style="width:100%">};
+            foreach my $aln (@$alignments) {
+                my $method = $aln->[0];
+                my $mlss_id = $aln->[1];
+
+                if ($synt_methods->{$method}) {
+                    $synteny_count++;
+                } else {
+                    $genomic_count++;
+                }
+
+		my $sample_location = '&nbsp;';
+		if ($info->{$sp}->{'sample_loc'}) {
+                    if ($synt_methods->{$method}) {
+			$sample_location = sprintf qq{<a href="/%s/Location/Synteny?r=%s;otherspecies=%s">example</a>}, $sp, $info->{$sp}->{'sample_loc'}, $other;
+		    } else {
+			$sample_location = sprintf qq{<a href="/%s/Location/Compara_Alignments/Image?align=%s;r=%s">example</a>}, $sp, $mlss_id, $info->{$sp}->{'sample_loc'};
+		    }
+		}
+                if ($Bio::EnsEMBL::Compara::Method::PLAIN_TEXT_DESCRIPTIONS{$method}) {
+                    $method = $Bio::EnsEMBL::Compara::Method::PLAIN_TEXT_DESCRIPTIONS{$method};
+                }
+                $astr .= qq{<tr>
+<td style="padding:0px 10px 0px 0px;text-align:right;">&nbsp;</td>
+<td style="padding:0px 10px 0px 0px;text-align:right;widht:20px">$method |</td>
+<td style="padding:0px 10px 0px 0px;text-align:left;width:60px;">$sample_location</td>
+<td style="padding:0px 10px 0px 0px;text-align:left;width:40px;"><a href="/mlss.html?mlss=$mlss_id">stats</a></td><tr>};
+            }
+            $astr .= qq{</table>};
+            my $self_desc = $sp eq $other ? ' [self-alignment]' : '';
+            $ghtml .= sprintf qq{<tr class="%s"><td>%s%s</td><td>%s</td></tr>}, $xbg, $self->combine_names($info->{$other}->{'common_name'}, $info->{$other}->{'long_name'}), $self_desc, $astr;
+        }
+        $ghtml .= qq{</table>};
+
+	my $synteny_str = $synteny_count > 1 ? 'syntenies' : 'synteny';
+	my $chtml = sprintf qq {
+<span style="text-align:left">%s</span> &nbsp; <span style="text-align:left">%s</span>}, $genomic_count ? ("$genomic_count alignment".($genomic_count > 1 ? 's':'')): "&nbsp;", $synteny_count ? "$synteny_count $synteny_str" : "&nbsp;";
+
+	my $sphtml = sprintf qq{
+<tr class="%s">
+  <td>
+    <a title="Click to show/hide" rel="%s_aligns" class="toggle no_img closed" href="#">
+      <span class="open closed" style="width:50%;float:left;">
+        <strong>%s</strong>
+      </span>
+    </a>
+    %s
+    %s
+  </td>
+</tr>}, $ybg, $sp, $self->combine_names($info->{$sp}->{'common_name'}, $info->{$sp}->{'long_name'}), $chtml, $ghtml;
+	$thtml .= $sphtml;
+    }
+    $thtml .= qq{</table>};
+
+    my $html = sprintf qq{
+<div id="GenomicAlignmentsTab" class="js_panel">
+<input type="hidden" class="panel_type" value="Content"/>
+<div class="info-box">
+  <p>
+    <a rel="all_species_tables" href="#" class="closed toggle" title="Expand all tables">
+       <span class="closed">Toggle All</span>
+       <span class="open">Toggle All</span>
+    </a> or click a species names to expand/collapse its alignment list
+  </p>
+  %s
+</div>
+</div>
+}, $thtml;
+
+    return $html;
 }
 
 1;

--- a/modules/EnsEMBL/Web/Document/HTML/Compara/BlastZ.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara/BlastZ.pm
@@ -46,7 +46,7 @@ sub render {
         
           my $mlss_id = $values->[1];
           my $url = '/info/genome/compara/mlss.html?mlss='.$mlss_id;
-          my $txt = sprintf '<a href="%s">%s (<em>%s</em>)</a>', $url, $info->{$other}{'common_name'}, $info->{$other}{'long_name'};
+          my $txt = sprintf '<a href="%s">%s</a>', $url, $self->combine_names($info->{$other}{'common_name'}, $info->{$other}{'long_name'});
           if ($sp eq $other) {
               $txt .= ' [self-alignment]';
           } elsif ($data_synt->{$sp}{$other}) {

--- a/modules/EnsEMBL/Web/Document/HTML/Compara/MLSS.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara/MLSS.pm
@@ -546,7 +546,7 @@ sub render_cactus_multiple {
       ], [], {data_table => 1, exportable => 1, id => sprintf('%s_%s', $mlss->method->type, $mlss->species_set->name), sorting => ['species asc']});
     foreach my $sp (@$species_order) {
       $table->add_row({
-          'species' => sprintf('%s (<em>%s</em>)', $info->{$sp}{'common_name'}, $info->{$sp}{'long_name'}),
+          'species' => $self->combine_names($info->{$sp}{'common_name'}, $info->{$sp}{'long_name'}),
           'asm'     => $info->{$sp}{'assembly'},
         });
     }


### PR DESCRIPTION
[ cc @ens-emily ]

I have copied the [EG way](http://fungi.ensembl.org/compara_analyses.html) of [listing the pairwise alignments](http://staging.ensembl.org/info/genome/compara/analyses.html) (see [my sandbox](http://ves-hx2-76.ebi.ac.uk:5080/info/genome/compara/analyses.html)) with two changes:
 - added the common names of species
 - replaced the capital letter codes LASTZ_NET, SYNTENY, etc with capitalized text 

There is still an open question. In Ensembl we were sorting the species according to the phylogeny, orienting the tree with the favourite species (by default: human, mouse, zebrafish). Other options are sorting by common name or by scientific name.
