### PR TITLE
Add missing documentation links in Tools page

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/ToolsTable.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/ToolsTable.pm
@@ -98,7 +98,7 @@ sub render {
       'tool'  => sprintf('<a href="%s" class="nodeco"><img src="%s16/tool.png" alt="Tool" title="Go to online tool" /></a>', $link, $img_url),
       'limit' => $tools_limit,
       'code'  => '',
-      'docs'  => '',
+      'docs'  =>  sprintf('<a href="/%s" class="popup"><img src="%s16/info.png" alt="Documentation" /></a>', $hub->url({'species' => '', 'type' => 'Help', 'action' => 'View', 'id' => { $sd->multiX('ENSEMBL_HELP') }->{'Tools/AssemblyConverter'}}), $img_url),
     });
   }
 
@@ -111,7 +111,7 @@ sub render {
       'tool'  => sprintf('<a href="%s" class="nodeco"><img src="%s16/tool.png" alt="Tool" title="Go to online tool" /></a>', $link, $img_url),
       'limit' => $tools_limit,
       'code'  => sprintf('<a href="https://github.com/Ensembl/ensembl-tools/tree/release/%s/scripts/id_history_converter" rel="external" class="nodeco"><img src="%s16/download.png" alt="Download" title="Download Perl script" /></a>', $sd->ENSEMBL_VERSION, $img_url),
-      'docs'  => '',
+      'docs'  =>  sprintf('<a href="/%s" class="popup"><img src="%s16/info.png" alt="Documentation" /></a>', $hub->url({'species' => '', 'type' => 'Help', 'action' => 'View', 'id' => { $sd->multiX('ENSEMBL_HELP') }->{'Tools/IDMapper'}}), $img_url),
     });
   }
 


### PR DESCRIPTION
This pull request is for ENSWEB-4391. The documentation links for Assembly Converter and ID History Converter have been added. The sandbox link is: http://ves-hx-78.ebi.ac.uk:8320/info/docs/tools/index.html.