### PR TITLE
Fix for broken paralogues region comparison

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaParalogs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaParalogs.pm
@@ -96,6 +96,9 @@ sub content {
       
       my $id_info = qq{<p class="space-below"><a href="$link_url">$stable_id</a></p>} . join '<br />', @external;
 
+      my @seq_region_split_array = split(/:/, $paralogue->{'location'});
+      my $paralogue_seq_region = $seq_region_split_array[0];
+
       my $links = ($availability->{'has_pairwise_alignments'}) ?
         sprintf (
         '<ul class="compact"><li class="first"><a href="%s" class="notext">Region Comparison</a></li>',
@@ -103,7 +106,7 @@ sub content {
           type   => 'Location',
           action => 'Multi',
           g1     => $stable_id,
-          s1     => $spp . '--' . $self->object->seq_region_name,
+          s1     => $spp . '--' . $paralogue_seq_region,
           r      => undef,
           config => 'opt_join_genes_bottom=on',
         })


### PR DESCRIPTION
This pull request is for the JIRA ticket 4427. The link to the sandbox is: http://ves-hx-78.ebi.ac.uk:8310/Homo_sapiens/Location/Multi?db=core;g=ENSG00000116539;g1=ENSG00000109685;r=1:155335268-155562807;r1=4:1871424-1982207:1;s1=Homo_sapiens--4.

However, the problem was in the link itself as Steve pointed out. So the fix had to be made in the gene paralogues table. The code for 'Region Comparison' link had to be changed to append the paralogues sequence region rather than the gene's sequence region at the end of the link. The link to the table is: http://ves-hx-78.ebi.ac.uk:8310/Homo_sapiens/Gene/Compara_Paralog?db=core;g=ENSG00000116539;r=1:155335268-155562807.