### PR TITLE
Space delimiter to paralogues table export field

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaParalogs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaParalogs.pm
@@ -94,7 +94,8 @@ sub content {
         g      => $stable_id
       });
       
-      my $id_info = qq{<p class="space-below"><a href="$link_url">$stable_id</a></p>} . join '<br />', @external;
+      # Need to have one white space character after the anchor tag to make sure there will be a space between the stable ID and gene symbol in the generated CSV file (for download)
+      my $id_info = qq{<p class="space-below"><a href="$link_url">$stable_id</a>&nbsp;</p>} . join '<br />', @external;
 
       my @seq_region_split_array = split(/:/, $paralogue->{'location'});
       my $paralogue_seq_region = $seq_region_split_array[0];


### PR DESCRIPTION
This pull request is for JIRA ticket ENSWEB-4474. A whitespace character is added using the HTML special character 'nbsp' to separate the stable ID and the gene symbol in the generated CSV file for download. The link to the sandbox is: http://ves-hx-78.ebi.ac.uk:8310/Homo_sapiens/Gene/Compara_Paralog?db=core;g=ENSG00000147044;r=X:41514934-41923645.