### PR TITLE
Multiple-alignment stats

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/Compara.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara.pm
@@ -334,6 +334,8 @@ sub get_species_info {
       $genome_db_name_hash->{$species_tree_name} = $genome_db;
     }
   }
+  my $genome_db_id_2_node_hash = $mlss && $mlss->species_tree && $mlss->species_tree->get_genome_db_id_2_node_hash;
+
   ## Now munge information for selected species
   foreach my $sp (@$species_order) {
     my $display_name = $hub->species_defs->get_config($sp, 'SPECIES_SCIENTIFIC_NAME');
@@ -354,7 +356,7 @@ sub get_species_info {
       my $id = $gdb->dbID;
       my @stats = qw(genome_coverage genome_length coding_exon_coverage coding_exon_length);
       foreach (@stats) {
-        $info->{$sp}{$_} = $mlss->get_value_for_tag($_.'_'.$id);
+        $info->{$sp}{$_} = $genome_db_id_2_node_hash ? $genome_db_id_2_node_hash->{$id}->get_value_for_tag($_) : $mlss->get_value_for_tag($_.'_'.$id);
       }
     }
   }

--- a/modules/EnsEMBL/Web/Document/HTML/Compara.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara.pm
@@ -300,7 +300,7 @@ sub get_species_info {
     return [] unless $compara_db;
     my $lookup = {};
 
-    my $tree = Bio::EnsEMBL::Compara::Utils::SpeciesTree->create_species_tree( -compara_dba => $compara_db, -ALLOW_SUBTAXA => 1);
+    my $tree = $mlss ? $mlss->species_tree->root : Bio::EnsEMBL::Compara::Utils::SpeciesTree->create_species_tree( -compara_dba => $compara_db, -ALLOW_SUBTAXA => 1);
     ## Compara now uses full trinomials for all species
     foreach (@$species_order) {
       my $prod_name = $hub->species_defs->get_config($_, 'SPECIES_PRODUCTION_NAME');


### PR DESCRIPTION
The most important change is that we store the alignment statistics in a different object. This fixes the stats page: http://staging.ensembl.org/info/genome/compara/mlss.html?mlss=1142
See: http://http://ves-hx2-77.ebi.ac.uk:5083/info/genome/compara/mlss.html?mlss=1142

The other change is to use the pre-built species-tree rather than creating a new one