### PR TITLE
bugfix/improvement: cleaner way of checking if the species is "low-coverage" or not

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/_alignment_multiple.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/_alignment_multiple.pm
@@ -257,7 +257,10 @@ sub element_features {
 
     my $is_low_coverage_species = 0;
     unless ($constrained_element) {
-        $is_low_coverage_species = $feature->reference_genomic_align->genome_db->has_karyotype ? 0 : 1;
+        # The species is not low-coverage if it's been used in one of the EPO alignments
+        $is_low_coverage_species = !scalar( grep {($_->{type} eq 'EPO') && $_->{species}->{$object->species}}
+                                            values %{$self->{'config'}->hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'ALIGNMENTS'}}
+                                          );
     }
 
     


### PR DESCRIPTION
This is a follow-up to 0d885cf7767bc7c85f0f8b61581511d6c832d0ed