### PR TITLE
Fix for #637

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/_alignment_multiple.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/_alignment_multiple.pm
@@ -258,8 +258,8 @@ sub element_features {
     my $is_low_coverage_species = 0;
     unless ($constrained_element) {
         # The species is not low-coverage if it's been used in one of the EPO alignments
-        $is_low_coverage_species = !scalar( grep {($_->{type} eq 'EPO') && $_->{species}->{$object->species}}
-                                            values %{$self->{'config'}->hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'ALIGNMENTS'}}
+        $is_low_coverage_species = !scalar( grep {($_->{type} eq 'EPO') && $_->{species}->{$self->species}}
+                                            values %{$sd->multi_hash->{'DATABASE_COMPARA'}{'ALIGNMENTS'}}
                                           );
     }
 


### PR DESCRIPTION
As highlighted by @ens-ap5 , `$object` doesn't exist.
Is it ok to use `$slice->{'web_species'}` (`$slice` is the container) ? It seems I can also do `$self->species`

Tested on my sandbox (human and armadillo) and I could see this in my debug log
```
homo_sapiens is_low_coverage_species= at /net/vnas_homes/ens_adm30/workspace/src/sandbox_staging/ensembl-webcode/modules/EnsEMBL/Draw/GlyphSet/_alignment_multiple.pm line 264.
homo_sapiens is_low_coverage_species= at /net/vnas_homes/ens_adm30/workspace/src/sandbox_staging/ensembl-webcode/modules/EnsEMBL/Draw/GlyphSet/_alignment_multiple.pm line 264.
homo_sapiens is_low_coverage_species= at /net/vnas_homes/ens_adm30/workspace/src/sandbox_staging/ensembl-webcode/modules/EnsEMBL/Draw/GlyphSet/_alignment_multiple.pm line 264.
dasypus_novemcinctus is_low_coverage_species=1 at /net/vnas_homes/ens_adm30/workspace/src/sandbox_staging/ensembl-webcode/modules/EnsEMBL/Draw/GlyphSet/_alignment_multiple.pm line 264.
dasypus_novemcinctus is_low_coverage_species=1 at /net/vnas_homes/ens_adm30/workspace/src/sandbox_staging/ensembl-webcode/modules/EnsEMBL/Draw/GlyphSet/_alignment_multiple.pm line 264.
```