### PR TITLE
Default to NULL instead of empty string when no species code

### DIFF
--- a/utils/static_content/update_webdb.pl
+++ b/utils/static_content/update_webdb.pl
@@ -119,7 +119,7 @@ SPECIES: foreach my $sp (sort @species) {
   # check if this species is in the database yet
   if (!$lookup{$sp}) {
     $sql = sprintf ('INSERT INTO species SET code = "%s", name = "%s", common_name = "%s", vega = "%s", online = "%s";',
-            $sd->get_config($sp, 'SPECIES_CODE') || '', $sd->get_config($sp, 'SPECIES_URL'),
+            $sd->get_config($sp, 'SPECIES_CODE') || 'NULL', $sd->get_config($sp, 'SPECIES_URL'),
             $sd->get_config($sp, 'SPECIES_COMMON_NAME'), 'N', 'Y');
     print "$sql\n\n" unless $DEBUG;
 


### PR DESCRIPTION
Species code is not compulsory, but the unique constraint on the species db table will not allow duplicate rows with empty string for this field.