### PR TITLE
Removed the option to hide so-called "low-coverage" species

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -235,7 +235,6 @@ sub content {
       push @{$genome_db_ids_by_clade{$clade}}, $genome_db_adaptor->fetch_by_name_assembly($hub->species_defs->get_config($species_name, 'SPECIES_PRODUCTION_NAME'))->dbID;
     }
   }
-  $genome_db_ids_by_clade{LOWCOVERAGE} = $self->hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'SPECIES_SET'}{'LOWCOVERAGE'};
 
   if (@hidden_clades) {
     %hidden_genome_db_ids = ();

--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -1275,17 +1275,6 @@ sub _summarise_compara_db {
   }             
   
   ###################################################################
-  ## Section for colouring and colapsing/hidding genes per species in the GeneTree View
-  
-  # The config for taxon-groups is in DEFAULTS.ini
-  # Here, we only need to add the "special" set of low-coverage species
-  $res_aref = $dbh->selectall_arrayref(q{SELECT genome_db_id FROM genome_db WHERE is_high_coverage = 0});
-  $self->db_tree->{$db_name}{'SPECIES_SET'}{'LOWCOVERAGE'} = [map {$_->[0]} @$res_aref];
-
-  ## End section about colouring and colapsing/hidding gene in the GeneTree View
-  ###################################################################
-
-  ###################################################################
   ## Cache MLSS for quick lookup in ImageConfig
 
   $self->_build_compara_default_aligns($dbh,$self->db_tree->{$db_name});

--- a/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
@@ -172,8 +172,7 @@ sub init_form_non_cacheable {
 
 sub _groups {
   ## @private
-  ## LOWCOVERAGE is a special group, populated in the ConfigPacker, and whose name is also defined in TAXON_LABEL
-  return ('LOWCOVERAGE', @{ $_[0]->species_defs->TAXON_ORDER });
+  return (@{ $_[0]->species_defs->TAXON_ORDER });
 }
 
 1;


### PR DESCRIPTION
The information is not provided any more on recent Vertebrates assemblies. I think it's (almost) never been set in EG either.
:warning: I haven't tested this on my sandbox !

Then you can also remove the line in public-plugins/ensembl/conf/ini-files/DEFAULTS.ini that has "LOWCOVERAGE"