### PR TITLE
For HGVS fix MT links and restrict transcript links

### DIFF
--- a/modules/EnsEMBL/Web/Object/Variation.pm
+++ b/modules/EnsEMBL/Web/Object/Variation.pm
@@ -1623,10 +1623,16 @@ sub hgvs_url {
       $p->{'type'}   = 'Transcript';
       $p->{'action'} = 'ProtVariations';
       $p->{'t'}      = $refseq.$version;
-    } else { # $type eq c: cDNA position, no $type: special cases where the variation falls in e.g. a pseudogene. Default to transcript
+    } elsif (($type eq 'n') || ($type eq 'c')) {
+      # transcript links only set for type 'n' or 'c'
+      # $type eq c: cDNA position 
+      # $type eq n: non-coding e.g. special cases where the variation falls in e.g. a pseudogene
       $p->{'type'}   = 'Transcript';
       $p->{'action'} = ($hub->species_defs->databases->{'DATABASE_VARIATION'} && $hub->species_defs->databases->{'DATABASE_VARIATION'}->{'#STRAINS'} > 0 ? 'Population' : 'Summary');
       $p->{'t'}      = $refseq.$version;
+    } else {
+      # Do not assign an url
+      return undef;
     }
   }
   

--- a/modules/EnsEMBL/Web/Object/Variation.pm
+++ b/modules/EnsEMBL/Web/Object/Variation.pm
@@ -1615,7 +1615,7 @@ sub hgvs_url {
       $p->{'lrgt'} = "${id}t$tr_pr_id";
     }
   } else {
-    if ($type eq 'g') { # genomic position
+    if (($type eq 'g') || ($type eq 'm')) { # genomic position
       $p->{'type'}             = 'Location';
       $p->{'action'}           = 'View';
       $p->{'contigviewbottom'} = $config_param;


### PR DESCRIPTION
The MT link is fixed to link to a genomic location. Previously linked to a transcript location causing an error (ENSVAR-1424)

Transcript links now only set for  'c' or 'n' 

For other types and url is not assigned