### PR TITLE
Add external links for OMIM synonym data

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -354,6 +354,15 @@ sub synonyms {
         next unless @urls;
       }
     }
+    elsif ($db =~ /omim/i) {
+      my %url_ids;
+      foreach my $id (@ids) {
+        my $url_id = $id;
+           $url_id =~ s/\./#/;
+        $url_ids{$id} = $url_id;
+      }
+      @urls = map { s/%23/#/; $_ } map $hub->get_ExtURL_link($_, 'OMIM', $url_ids{$_}), @ids;
+    }
     elsif ($db =~ /clinvar/i) {
       @urls = map $hub->get_ExtURL_link($_, 'CLINVAR', $_), @ids;
     }


### PR DESCRIPTION
## Description

Add external links for OMIM synonym data in the Variation summary panel.
The OMIM data has been moved to the variation synonym in release 94.

## Views affected

Variation pages (summary panel)
http://www.ensembl.org/Homo_sapiens/Variation/Explore?;v=rs333
(with the "Synonyms" line expanded)
