### PR TITLE
Feature/sample genotype pop url

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation.pm
+++ b/modules/EnsEMBL/Web/Component/Variation.pm
@@ -72,7 +72,7 @@ sub pop_url {
     $pop_url = $hub->get_ExtURL('EXAC_POP');
   }
   elsif ($pop_name =~ /PRJEB/i) {
-    $pop_url = $hub->get_ExtURL('EVA_STUDY');
+    $pop_url = $hub->get_ExtURL('EVA_STUDY').$pop_name;
   }
   else {
     $pop_url = ($pop_dbSNP && $pop_dbSNP->[0] ne '' && $hub->species eq 'Homo_sapiens') ? $hub->get_ExtURL('DBSNPPOP', $pop_dbSNP->[0]) : undef;

--- a/modules/EnsEMBL/Web/Component/Variation/PopulationGenotypes.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/PopulationGenotypes.pm
@@ -227,8 +227,7 @@ sub format_table {
     ## Get URL
     my $url = $self->pop_url($name, $freq_data->{$pop_id}{'pop_info'}{'PopLink'});
     if ($url) {
-      $pop_urls{$pop_id}  = $url;
-      $pop_urls{$pop_id} .= $name if ($url eq $hub->get_ExtURL('EVA_STUDY'));
+      $pop_urls{$pop_id} = $url;
       $urls_seen{$url}++;
     }
 


### PR DESCRIPTION
## Description

The EVA study was missing in the external link of the `SampleGenotypes.pm` module.
This PR adds it by default in the `pop_url` method.
At the same time, we remove the manual addition of the EVA name in the url in the `PopulationGenotypes.pm` module.

This would be nice if this code changes could be copied to the live site.

## Views affected

- Variation -> Population genetics
- Variation -> Sample genotypes