### PR TITLE
show mutation_assessor only for human

### DIFF
--- a/modules/EnsEMBL/Web/Component/Transcript/ProteinVariations.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/ProteinVariations.pm
@@ -158,7 +158,7 @@ sub make_table {
   my @exclude;
   push @exclude,'sift_sort','sift_class','sift_value' unless $sd->{'SIFT'};
   unless($hub->species eq 'Homo_sapiens') {
-    push @exclude,'polyphen_sort','polyphen_class','polyphen_value', 'cadd_sort', 'cadd_class', 'cadd_value', 'revel_sort', 'revel_class', 'revel_value', 'meta_lr_sort', 'meta_lr_class', 'meta_lr_value';
+    push @exclude,'polyphen_sort','polyphen_class','polyphen_value', 'cadd_sort', 'cadd_class', 'cadd_value', 'revel_sort', 'revel_class', 'revel_value', 'meta_lr_sort', 'meta_lr_class', 'meta_lr_value', 'mutation_assessor_sort', 'mutation_assessor_class', 'mutation_assessor_value';
   }
 
   my @columns = ({

--- a/modules/EnsEMBL/Web/Component/VariationTable.pm
+++ b/modules/EnsEMBL/Web/Component/VariationTable.pm
@@ -351,7 +351,7 @@ sub make_table {
   }
   push @exclude,'sift_sort','sift_class','sift_value' unless $sd->{'SIFT'};
   unless($hub->species eq 'Homo_sapiens') {
-    push @exclude,'polyphen_sort','polyphen_class','polyphen_value', 'cadd_sort', 'cadd_class', 'cadd_value', 'revel_sort', 'revel_class', 'revel_value', 'meta_lr_sort', 'meta_lr_class', 'meta_lr_value';
+    push @exclude,'polyphen_sort','polyphen_class','polyphen_value', 'cadd_sort', 'cadd_class', 'cadd_value', 'revel_sort', 'revel_class', 'revel_value', 'meta_lr_sort', 'meta_lr_class', 'meta_lr_value', 'mutation_assessor_sort', 'mutation_assessor_class', 'mutation_assessor_value';
   }
   push @exclude,'Transcript' if $hub->type eq 'Transcript';
 


### PR DESCRIPTION
## Description

When adding the new protein function predictors for release/94 I forgot to exclude mutation assessor for non-human species. The column is displayed for mouse [here](http://staging.ensembl.org/Mus_musculus/Gene/Variation_Gene/Table?db=core;g=ENSMUSG00000050530;r=2:3114224-3227806;source=dbSNP;v=rs27096498;vdb=variation;vf=802802).

## Views affected

gene, transcript, protein variation tables

## Possible complications
no
## Merge conflicts
no
## Related JIRA Issues (EBI developers only)
na
