### PR TITLE
Regroup the protein prediction classes into a common method

### DIFF
--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -1457,23 +1457,7 @@ sub classify_sift_polyphen {
 
   return [undef,'-','','-'] unless defined($pred) || defined($score);
 
-  my %classes = (
-    '-'                 => '',
-    'probably damaging' => 'bad',
-    'possibly damaging' => 'ok',
-    'benign'            => 'good',
-    'unknown'           => 'neutral',
-    'tolerated'         => 'good',
-    'deleterious'       => 'bad',
-
-    # slightly different format for SIFT low confidence states
-    # depending on whether they come direct from the API
-    # or via the VEP's no-whitespace processing
-    'tolerated - low confidence'   => 'neutral',
-    'deleterious - low confidence' => 'neutral',
-    'tolerated low confidence'     => 'neutral',
-    'deleterious low confidence'   => 'neutral',
-  );
+  my %classes = %{$self->predictions_classes};
 
   my %ranks = (
     '-'                 => 0,
@@ -1509,18 +1493,7 @@ sub classify_score_prediction {
   
   return [undef,'-','','-'] unless defined($pred) || defined($score);
   
-  my %classes = (
-    '-'                 => '',
-    'likely deleterious' => 'bad',
-    'likely benign' => 'good',
-    'likely disease causing' => 'bad',
-    'tolerated' => 'good',
-    'damaging'   => 'bad',
-    'high'    => 'bad',
-    'medium'  => 'ok',
-    'low'     => 'good',
-    'neutral' => 'neutral',
-  );
+  my %classes = %{$self->predictions_classes};
   
   my %ranks = (
     '-'                 => 0,
@@ -1547,6 +1520,41 @@ sub classify_score_prediction {
   }
   return [$rank,$pred,$rank_str];
 }
+
+# Common list of variant protein prediction results with their corresponding CSS classes
+sub predictions_classes {
+  my $self = shift;
+
+  my %classes = (
+    '-'                 => '',
+    'probably damaging' => 'bad',
+    'possibly damaging' => 'ok',
+    'benign'            => 'good',
+    'unknown'           => 'neutral',
+    'tolerated'         => 'good',
+    'deleterious'       => 'bad',
+
+    'likely deleterious'     => 'bad',
+    'likely benign'          => 'good',
+    'likely disease causing' => 'bad',
+    'damaging'               => 'bad',
+    'high'                   => 'bad',
+    'medium'                 => 'ok',
+    'low'                    => 'good',
+    'neutral'                => 'neutral',
+
+    # slightly different format for SIFT low confidence states
+    # depending on whether they come direct from the API
+    # or via the VEP's no-whitespace processing
+    'tolerated - low confidence'   => 'neutral',
+    'deleterious - low confidence' => 'neutral',
+    'tolerated low confidence'     => 'neutral',
+    'deleterious low confidence'   => 'neutral',
+  );
+
+  return \%classes;
+}
+
 
 sub render_consequence_type {
   my $self        = shift;

--- a/modules/EnsEMBL/Web/Component/Transcript/ProteinVariations.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/ProteinVariations.pm
@@ -97,7 +97,7 @@ sub table_content {
       # consequence type
       my $type = $self->new_consequence_type($tva);    
 
-      # SIFT and PolyPhen
+      # SIFT, PolyPhen-2 and other prediction tools
       my $sifts = $self->classify_sift_polyphen($tva->sift_prediction,$tva->sift_score);
       my $polys = $self->classify_sift_polyphen($tva->polyphen_prediction, $tva->polyphen_score);
       my $cadds = $self->classify_score_prediction($tva->cadd_prediction, $tva->cadd_score);
@@ -381,27 +381,8 @@ sub snptype_classes {
 sub sift_poly_classes {
   my ($self,$table) = @_;
 
-  my %sp_classes = (
-    '-'                 => '',
-    'probably damaging' => 'bad',
-    'possibly damaging' => 'ok',
-    'benign'            => 'good',
-    'unknown'           => 'neutral',
-    'tolerated'         => 'good',
-    'deleterious'       => 'bad',
-    'tolerated - low confidence'   => 'neutral',
-    'deleterious - low confidence' => 'neutral',
-    'tolerated low confidence'     => 'neutral',
-    'deleterious low confidence'   => 'neutral',
-    'likely deleterious'     => 'bad',
-    'likely benign'          => 'good',
-    'likely disease causing' => 'bad',
-    'damaging'               => 'bad',
-    'high'                   => 'bad',
-    'medium'                 => 'ok',
-    'low'                    => 'good',
-    'neutral'                => 'good',
-  );
+  my %sp_classes = %{$self->predictions_classes};
+
   foreach my $column_name (qw(sift polyphen cadd revel meta_lr mutation_assessor)) {
     my $value_column = $table->column("${column_name}_value");
     my $class_column = $table->column("${column_name}_class");

--- a/modules/EnsEMBL/Web/Component/VariationTable.pm
+++ b/modules/EnsEMBL/Web/Component/VariationTable.pm
@@ -168,27 +168,8 @@ sub content {
 sub sift_poly_classes {
   my ($self,$table) = @_;
 
-  my %sp_classes = (
-    '-'                 => '',
-    'probably damaging' => 'bad',
-    'possibly damaging' => 'ok',
-    'benign'            => 'good',
-    'unknown'           => 'neutral',
-    'tolerated'         => 'good',
-    'deleterious'       => 'bad',
-    'tolerated - low confidence'   => 'neutral',
-    'deleterious - low confidence' => 'neutral',
-    'tolerated low confidence'     => 'neutral',
-    'deleterious low confidence'   => 'neutral',
-    'likely deleterious'     => 'bad',
-    'likely benign'          => 'good',
-    'likely disease causing' => 'bad',
-    'damaging'               => 'bad',
-    'high'                   => 'bad',
-    'medium'                 => 'ok',
-    'low'                    => 'good',
-    'neutral'                => 'good',
-  );
+  my %sp_classes = %{$self->predictions_classes};
+
   foreach my $column_name (qw(sift polyphen cadd revel meta_lr mutation_assessor)) {
     my $value_column = $table->column("${column_name}_value");
     my $class_column = $table->column("${column_name}_class");


### PR DESCRIPTION
## Description

Remove code redundancy to associated protein prediction result with CSS classes (for colouring the score boxes) by grouping the hashes into a common hash/method

## Views affected
(look for missense variants)
- Transcript/Variation_Transcript/Table
http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/Transcript/Variation_Transcript/Table?t=ENST00000366667
- Transcript/ProtVariations
http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/Transcript/ProtVariations?t=ENST00000366667
- Gene/Variation_Gene/Table
http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/Gene/Variation_Gene/Table?g=ENSG00000135744
- Variation/Mappings
http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/Variation/Mappings?v=rs699
