### PR TITLE
Use the correct link to MGI when it is using a MP ontology accession

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -375,6 +375,7 @@ KAT6BDB                     = http://www.lovd.nl/###ID###
 LMDD                        = http://www.lovd.nl/###ID###
 LOVD                        = http://varcache.lovd.nl/redirect/hg38.chr###ID###
 MAGIC                       = http://www.magicinvestigators.org/
+MGI_MP                      = http://www.informatics.jax.org/vocab/mp_ontology/###ID###
 MP                          = http://purl.obolibrary.org/obo/###ID###
 NEXTGEN_POP                 = http://projects.ensembl.org/nextgen/
 OIVD                        = http://www.lovd.nl/###ID###

--- a/modules/EnsEMBL/Web/Component/Phenotype/Locations.pm
+++ b/modules/EnsEMBL/Web/Component/Phenotype/Locations.pm
@@ -404,6 +404,12 @@ sub source_url {
       { ID => $ext_id, PR_ID => $ext_ref_id}
     ));
   }
+  if ($source_uc eq 'MGI') {
+    return ($source,$hub->get_ExtURL(
+      $source_uc.'_MP',
+      { ID => $ext_id }
+    ));
+  }
   if ($source_uc eq 'RGD') {
     $ext_id = $pf->object_id if (!$ext_id);
     return ($source,$hub->get_ExtURL(


### PR DESCRIPTION
## Description

Wrong URL to MGI when using a MP accession number.
See JIRA issue [ENSVAR-597](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-4798).

## Views affected

Phenotype/Locations:
http://www.ensembl.org/Mus_musculus/Phenotype/Locations?ph=346
Sandbox:
http://ves-hx2-76.ebi.ac.uk:5060/Mus_musculus/Phenotype/Locations?ph=346