### PR TITLE
Fix potentially duplicated population frequency in the horizontal bar…

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/PopulationGenotypes.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/PopulationGenotypes.pm
@@ -609,10 +609,12 @@ sub frequency_bar {
 
   my @alleles = @{$data->{'Alleles'}};
   my $added_width = 0;
+  my %alleles_seen;
 
   for my $i(sort { ($alleles[$a] !~ /$ref_allele/ cmp $alleles[$b] !~ /$ref_allele/) || $alleles[$a] cmp $alleles[$b] } 0..$#alleles) {
     my $allele = $alleles[$i];
-
+    next if ($alleles_seen{$allele});
+    $alleles_seen{$allele} = 1;
     my $width = sprintf('%.0f', $data->{'AlleleFrequency'}->[$i] * $bar_width);
     $added_width += $width;
 


### PR DESCRIPTION
## Description

Remove duplicated population frequency in the horizontal barchart.

## Views affected

Variation "Population genetics" page. Might be due to an issue when Horse VCF file has been remapped to more recent assembly.
e.g.:
- Staging: http://staging.ensembl.org/Equus_caballus/Variation/Population?v=rs68637648;
- Sandbox (fixed): http://ves-hx2-76.ebi.ac.uk:5060/Equus_caballus/Variation/Population?v=rs68637648
