### PR TITLE
Variants without location are non coding by definition

### DIFF
--- a/modules/EnsEMBL/Web/Object/Variation.pm
+++ b/modules/EnsEMBL/Web/Object/Variation.pm
@@ -79,6 +79,7 @@ sub is_coding_variant {
   }
   else {
     my @vari_mappings = @{ $self->get_variation_features };
+    return 0 if (!@vari_mappings);
     foreach my $f (@vari_mappings){
       my $cons = $f->most_severe_OverlapConsequence;
       my $cons_rank = $cons->rank;


### PR DESCRIPTION
## Description

The value returned by the method `is_coding_variant` is wrong for variants without location

## Views affected

The Variation `3D Protein model` page (should be greyed):
- Test site (wrong): http://test.ensembl.org/Homo_sapiens/Variation/Explore?v=rs28526234
- Sandbox (fixed): http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/Variation/Explore?v=rs28526234
