### PR TITLE
Fix issue with data export missing entries

### DIFF
--- a/modules/EnsEMBL/Web/Component/VariationTable.pm
+++ b/modules/EnsEMBL/Web/Component/VariationTable.pm
@@ -635,8 +635,6 @@ sub variation_table {
   ROWS: foreach my $transcript (@$transcripts) {
 
     my $tr_id = $transcript ? $transcript->Obj->dbID : 0;
-    my $cache = $self->{_transcript_variations} ||= {};
-    next if(exists($cache->{$tr_id}));
 
     my $tvs = $self->_get_transcript_variations($transcript->Obj, $tv_count, $exonic_types);
 


### PR DESCRIPTION
## Description

Data export from the Gene/Variation_Gene/Table page were missing entries for all the transcripts except the last one.
The issue was due to the fact we were skipping the loop if the transcript was already in the cache.
Didn't know that the export of the NewTable was rerunning the method `variation_table`, therefore was skipping the transcripts

## Views affected

Vue: Gene/Variation_Gene/Table (for all the species)
- Live website: http://www.ensembl.org/Canis_familiaris/Gene/Variation_Gene/Table?g=ENSCAFG00000016290
- Sandbox: http://ves-hx2-76.ebi.ac.uk:5060/Canis_familiaris/Gene/Variation_Gene/Table?g=ENSCAFG00000016290
Try to export the `missense_variant` only (2 transcripts and 12 rows in total).

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-4826
