### PR TITLE
Fix display issue on long allele variants in Variant tables

### DIFF
--- a/htdocs/components/85_spreadsheet_table.css
+++ b/htdocs/components/85_spreadsheet_table.css
@@ -218,7 +218,7 @@ div.new_table_section_1 > div { display: block; margin: 0 auto; text-align: cent
 .newtable_toggle { padding-right: 16px; position: relative; word-break: break-all; }
 .newtable_toggle_img { background: url(/i/closed2.gif); width: 14px; height: 14px; position: absolute; right: 0; top: 0; }
 .newtable_toggle.open .newtable_toggle_img { background: url(/i/open2.gif); }
-.newtable_toggle.open .newtable_toggle_short { display: none; }
+.newtable_toggle.open .newtable_toggle_short { display: block; }
 .newtable_toggle .newtable_toggle_long { display: none; }
 .newtable_toggle.open .newtable_toggle_long { display: block; }
 .new_table_loading { height: 64px; width: 100%; display: block; font-size: 32px; font-weight: bold; color: #aaa; vertical-align: middle; text-align: center; line-height: 61px; background: [[PALE_GREY]]; }

--- a/modules/EnsEMBL/Web/Component.pm
+++ b/modules/EnsEMBL/Web/Component.pm
@@ -803,7 +803,6 @@ sub trim_large_string {
       <div class="toggle_div">
         <span class="%s">%s</span>
         <span class="cell_detail">%s</span>
-        <span class="toggle_img"></span>
       </div>
     </div>),
       join(" ",@summary_classes),$truncated,$string);  


### PR DESCRIPTION
## Description

The display of the long alleles and the long codons in the Variant Table views are not correct:
2 `+` buttons and when you click on them (only 1 works), the content of the cell is hidden

## Views affected

### Transcript/ProtVariations (columns `Alleles` and `Codons`):
- Live: http://www.ensembl.org/Homo_sapiens/Transcript/ProtVariations?t=ENST00000525701
- Sandbox: http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/Transcript/ProtVariations?t=ENST00000525701
