### PR TITLE
Updated dbSNP URL to point to their new website/pages

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -347,7 +347,7 @@ COSMIC                      = http://cancer.sanger.ac.uk/cosmic/mutation/overvie
 COSMIC_STUDY                = http://cancer.sanger.ac.uk/cosmic/browse/tissue?#sn=###ID###&ss=&hn=&sh=&in=t&src=tissue
 COSMIC_SV                   = http://cancer.sanger.ac.uk/cosmic/rearrangement/overview?id=###ID###
 DBGAP                       = http://www.ncbi.nlm.nih.gov/gap
-DBSNP                       = http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?rs=###ID###
+DBSNP                       = https://www.ncbi.nlm.nih.gov/snp/###ID###
 DBSNP_HOME                  = http://www.ncbi.nlm.nih.gov/snp 
 DBSNPPOP                    = http://www.ncbi.nlm.nih.gov/SNP/snp_viewTable.cgi?pop=###ID###
 DBSNPSS                     = http://www.ncbi.nlm.nih.gov/SNP/snp_ss.cgi?subsnp_id=###ID###


### PR DESCRIPTION
## Description

Change the dbSNP URL to point to the new rsID pages

## Views affected
Variant summary page for instance (`View in dbSNP` link at the line `Original source`):
- Live: https://www.ensembl.org/Homo_sapiens/Variation/Explore?v=rs699
- Sandbox: http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/Variation/Explore?v=rs699
