### PR TITLE
Update variation link in 'About this transcript'

### DIFF
--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -563,7 +563,7 @@ sub about_feature {
     
     my $variation_url = $hub->url({
       type   => 'Transcript',
-      action => 'ProtVariations',
+      action => 'Variation_Transcript/Table',
       g      => $gene->stable_id
     });     
    
@@ -577,10 +577,10 @@ sub about_feature {
                         $avail->{has_domains} eq "1" ? "domain and feature" : "domains and features"
                       ) if($avail->{has_domains});
 
-    push @str_array, sprintf('is associated with <a class="dynamic-link"href="%s">%s %s</a>', 
+    push @str_array, sprintf('is associated with <a class="dynamic-link"href="%s">%s variant %s</a>',
                         $variation_url, 
                         $avail->{has_variations}, 
-                        $avail->{has_variations} eq "1" ? "variation" : "variations",
+                        $avail->{has_variations} eq "1" ? "allele" : "alleles",
                       ) if($avail->{has_variations});    
     
     push @str_array, sprintf('maps to <a class="dynamic-link" href="%s">%s oligo %s</a>',    


### PR DESCRIPTION
## Description

Change the variation link in "About this transcript" to point to the table for variants associated with the transcript  instead of those associated with the protein.

If there are no proteins, the link currently returns a message  "Sorry, this page is not available for this feature. Please select a valid link from the menu on the left"
The variation count is for the number of transcript variations - changing the link to this table.

## Views affected

Transcript/Summary

Live site:
http://Jan2019.archive.ensembl.org/Homo_sapiens/Transcript/Summary?db=core;g=ENSG00000262228;r=17:763565-765319;t=ENST00000358446

Sandbox: 
http://ves-hx2-76.ebi.ac.uk:5050/Homo_sapiens/Transcript/Summary?db=core;g=ENSG00000262228;r=17:763565-765319;t=ENST00000358446

## Possible complications


## Merge conflicts
 
Checked for merge conflicts and changes are only for update described

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-1460
