### PR TITLE
bugfix: Add the missing label of sub-speciation nodes

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
@@ -314,7 +314,7 @@ sub _init {
             'height'    => 5 + 2 * $bold,
             'colour'    => $node_colour,
             'bordercolour' => $tree->isa('Bio::EnsEMBL::Compara::CAFEGeneFamilyNode') ? 'black' : $node_colour,            
-            'zindex'    => ($f->{_node_type} ne 'speciation' ? 40 : -20),
+            'zindex'    => ($f->{_node_type} !~ /speciation/ ? 40 : -20),
             'href'      => $node_href
           });
       push @node_glyphs, $node_glyph;
@@ -325,7 +325,7 @@ sub _init {
               'width'     => 5,
               'height'    => 5,
               'bordercolour' => "white",
-              'zindex'    => ($f->{_node_type} ne 'speciation' ? 40 : -20),
+              'zindex'    => ($f->{_node_type} !~ /speciation/ ? 40 : -20),
               'href'      => $node_href
             });
         push @node_glyphs, $node_glyph;

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -136,7 +136,7 @@ sub content {
 
   $html                 .= sprintf '<h3>GeneTree%s</h3>%s', $link, $self->new_twocol(
     ['Number of genes',             scalar(@$leaves)                                                  ],
-    ['Number of speciation nodes',  $self->get_num_nodes_with_tag($tree, 'node_type', 'speciation')   ],
+    ['Number of speciation nodes',  $self->get_num_nodes_with_tag($tree, 'node_type', 'speciation') + $self->get_num_nodes_with_tag($tree, 'node_type', 'sub-speciation')   ],
     ['Number of duplication',       $self->get_num_nodes_with_tag($tree, 'node_type', 'duplication')  ],
     ['Number of ambiguous',         $self->get_num_nodes_with_tag($tree, 'node_type', 'dubious')      ],
     ['Number of gene split events', $self->get_num_nodes_with_tag($tree, 'node_type', 'gene_split')   ]

--- a/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
@@ -208,11 +208,14 @@ sub content {
     my $node_type = $tagvalues->{'node_type'};
     
     if (defined $node_type) {
-      my $label;
-         $label = 'Dubious duplication' if $node_type eq 'dubious';
-         $label = sprintf 'Duplication (%d%s confid.)', 100 * ($tagvalues->{'duplication_confidence_score'} || 0), '%' if $node_type eq 'duplication';
-         $label = 'Speciation' if $node_type eq 'speciation';
-         $label = 'Gene split' if $node_type eq 'gene_split';
+      my $label = {
+          'dubious'         => 'Dubious duplication',
+          'duplication'     => 'Duplication',
+          'speciation'      => 'Speciation',
+          'sub-speciation'  => 'Sub-speciation',
+          'gene_split'      => 'Gene split',
+      }->{$node_type};
+      $label .= sprintf ' (%d%s confid.)', 100 * ($tagvalues->{'duplication_confidence_score'} || 0), '%' if $node_type eq 'duplication';
       
       $self->add_entry({
         type  => 'Type',


### PR DESCRIPTION
## Description

In e95 we introduced the term "sub-speciation" for non-duplication splits within a species ("speciation" is not right in those cases). I had misread the web-code and was assuming that the node type would be shown as is, but it isn't :) so I've added it.

## Views affected

Gene-tree view: http://ves-hx2-76.ebi.ac.uk:5085/Homo_sapiens/Gene/Compara_Tree?collapse=none;db=core;g=ENSG00000139618;r=13:32315474-32400266

Click on the parent node of the two Naked mole-rats and it will now show "Sub-speciation"

## Possible complications

`modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm` now has the mapping between database terms and display terms. Perhaps you'd prefer this in a Compara module instead ?

Also, this change is only for Vertebrates I believe since EG have overridden several modules:
```
eg-web-pombase/modules/EnsEMBL/Web/Component/Gene/ComparaTreeSummary.pm:      ['Number of speciation nodes',  $self->get_num_nodes_with_tag($tree, 'node_type', 'speciation')   ],
eg-web-parasite/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm:         $label = 'Speciation' if $node_type eq 'speciation';
eg-web-common/modules/EnsEMBL/Draw/GlyphSet/genetree.pm:            'zindex'    => ($f->{_node_type} ne 'speciation' ? 40 : -20),
eg-web-common/modules/EnsEMBL/Draw/GlyphSet/genetree.pm:              'zindex'    => ($f->{_node_type} ne 'speciation' ? 40 : -20),
eg-web-common/modules/EnsEMBL/Web/Component/Gene/TreeSummary.pm:    ['Number of speciation nodes',  $self->get_num_nodes_with_tag($tree, 'node_type', 'speciation')   ],
eg-web-common/modules/EnsEMBL/Web/Component/Gene/ComparaTreeSummary.pm:      ['Number of speciation nodes',  $self->get_num_nodes_with_tag($tree, 'node_type', 'speciation')   ],
```
Exactly the same fix can be applied, but it will only impact the divisions that have had an update in e95 (with Compara's e95 code), e.g. Plants

## Merge conflicts

None