### PR TITLE
Update KEGG_Enzyme url

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -289,7 +289,7 @@ IMGT/GENE_DB                = http://www.imgt.org/IMGT_GENE-DB/GENElect?query=2+
 INTERACTIVEFLY              = http://www.sdbonline.org/fly###ID###
 INTERPRO                    = http://www.ebi.ac.uk/interpro/entry/###ID###
 JAX_STRAINS                 = https://www.jax.org/strain/###ID###
-KEGG_ENZYME                 = http://www.genome.jp/kegg-bin/show_pathway?map=map###ID###
+KEGG_ENZYME                 = http://www.genome.jp/kegg-bin/show_pathway?map###ID###
 MEDAKA                      =
 METACYC                     = http://metacyc.org/META/NEW-IMAGE?type=PATHWAY&object=###ID###
 MGI                         = http://www.informatics.jax.org/marker/###ID###

--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -1121,10 +1121,6 @@ sub _sort_similarity_links {
       $word .= " ($primary_id)" if $A eq 'MARKERSYMBOL';
 
       if ($link) {
-        ## KEGG Enzyme xrefs are compound, consisting of pathway and enzyme ids.
-        ## Need to modify the xref for linkouts to work.
-        $link =~ s/%2B/&multi_query=/ if $externalDB eq 'KEGG_Enzyme';
-        
         $text = qq{<a href="$link" class="constant">$word</a>};
       } else {
         $text = $word;


### PR DESCRIPTION
## Description
Biomart uses the data in the defaults.ini file to construct links for output page. But it doesn't do the post-processing in the Shared.pm file, so the biomart urls are broken. We can tweak the url template such that it works without modification, so it works for biomart and means we can eliminate the special treatment in the webcode.

## Views affected
URLs for KEGG_Enzyme xrefs on "General Identifiers" page will be different, but will resolve to the same external page as they currently do.

## Possible complications/merge conflicts
Not aware of any.
