### PR TITLE
Feature/display vervet variation from vcf

### DIFF
--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -1378,7 +1378,7 @@ sub add_sequence_variations {
   my ($self, $key, $hashref) = @_;
   my $menu = $self->get_node('variation');
 
-  return unless $menu && $hashref->{'variation_feature'}{'rows'} > 0;
+  return unless $menu;
 
   my $options = {
     db         => $key,
@@ -1391,12 +1391,13 @@ sub add_sequence_variations {
     renderers  => [ 'off', 'Off', 'normal', 'Normal (collapsed for windows over 200kb)', 'compact', 'Collapsed', 'labels', 'Expanded with name (hidden for windows over 10kb)', 'nolabels', 'Expanded without name' ],
   };
 
-  if (defined($hashref->{'menu'}) && scalar @{$hashref->{'menu'}}) {
-    $self->add_sequence_variations_meta($key, $hashref, $options);
-  } else {
-    $self->add_sequence_variations_default($key, $hashref, $options);
+  if ($hashref->{'variation_feature'}{'rows'} > 0) {
+    if (defined($hashref->{'menu'}) && scalar @{$hashref->{'menu'}}) {
+      $self->add_sequence_variations_meta($key, $hashref, $options);
+    } else {
+      $self->add_sequence_variations_default($key, $hashref, $options);
+    }
   }
-
   $self->add_sequence_variations_vcf($key, $hashref, $options);
 
   $self->add_track('information', 'variation_legend', 'Variant Legend', 'variation_legend', { strand => 'r' });
@@ -1615,7 +1616,7 @@ sub add_sequence_variations_vcf {
   foreach my $coll(@{$ad->fetch_all_for_web}) {
     $vcf_menu->append_child($self->create_track_node("variation_vcf_".$coll->id, $coll->id, {
       %$options,
-      caption     => $coll->id,
+      caption     => $coll->source_name,
       description => $coll->description,
       db          => 'variation',
     }));

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -1397,9 +1397,9 @@ sub add_sequence_variations {
     } else {
       $self->add_sequence_variations_default($key, $hashref, $options);
     }
+  } else {
+    $self->add_sequence_variations_vcf($key, $hashref, $options);
   }
-  $self->add_sequence_variations_vcf($key, $hashref, $options);
-
   $self->add_track('information', 'variation_legend', 'Variant Legend', 'variation_legend', { strand => 'r' });
 }
 
@@ -1616,9 +1616,10 @@ sub add_sequence_variations_vcf {
   foreach my $coll(@{$ad->fetch_all_for_web}) {
     $vcf_menu->append_child($self->create_track_node("variation_vcf_".$coll->id, $coll->id, {
       %$options,
-      caption     => $coll->source_name,
+      caption     => 'Variants from ' . $coll->source_name,
       description => $coll->description,
       db          => 'variation',
+      display => 'default'
     }));
   }
 }


### PR DESCRIPTION
## Requirements

The update is required to display variants directly from VCF in region in detail. This is a small update to the VCF backend code written by Will. A json config file with VCF location information is required and has been [submitted](https://github.com/Ensembl/public-plugins/pull/182).

## Description

The track wasn't displayed because there was a check for row count in the variation_feature table. But for vervet we are not populating the variation_feature table. It is working on my [sandbox](http://ves-hx2-76.ebi.ac.uk:5040/Chlorocebus_sabaeus/Location/View?db=core;g=ENSCSAG00000010263;r=11:6780282-6907410;t=ENSCSAT00000008350;v=11:6820497:T_G:PRJEB22989;vdb=variation;vf=11:6820497:T_G:PRJEB22989) (ongoing development on other features not related to this PR and lots of restarts going on)

## Views affected

Region in detail

## Possible complications

Possibly overseen a dependency on current track display. In the future we need to come up with a configuration of tracks that are displayed from VCF files and from database. The change now only displays from VCF if variation_feature table is empty.

I want to show the track on as default. But I'm not sure if setting display to default is the right thing to do.

## Merge conflicts

No

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-1634