### PR TITLE
Feature/genome wide scores variant summary

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -54,6 +54,7 @@ sub content {
   my $summary_table = $self->new_twocol(    
     $self->most_severe_consequence(),
     $self->alleles($feature_slice),
+    $self->change_tolerance,
     $self->location,
     $feature_slice ? $self->co_located($feature_slice) : (),
     $self->evidence_status,
@@ -720,6 +721,36 @@ sub clinical_significance {
   );
 
   return [ "Clinical significance $info_link" , $cs_content ];
+}
+
+sub change_tolerance {
+  my $self = shift;
+  my $object = $self->object;
+  my ($CADD_scores, $CADD_source) = @{$object->CADD_score};
+  my ($GERP_score, $GERP_source) = @{$object->GERP_score};
+
+  return unless (defined $CADD_scores || defined $GERP_score);
+  my $html = '';
+  if (defined $CADD_scores) {
+    my $cadd_helptip = helptip(
+      'CADD',
+      'CADD scores for all alternative alleles from ' . $CADD_source
+    );
+    my $display_scores = join(', ', map {$_ . ':' . $CADD_scores->{$_}} sort keys %$CADD_scores);
+    my $cadd_summary = sprintf(qq{<span class="_ht ht">%s</span>: %s}, $cadd_helptip, $display_scores);
+    $html .= qq{<span>$cadd_summary</span>}
+  }
+  if (defined $GERP_score) {
+    my $gerp_helptip = helptip(
+      'GERP',
+      'GERP score from ' . $GERP_source
+    );
+    my $gerp_summary = sprintf(qq{<span class="_ht ht">%s</span>: %s}, $gerp_helptip, $GERP_score);
+    $html .= $self->text_separator if ($html);
+    $html .= qq{<span>$gerp_summary</span>};
+  }
+
+  return [ 'Change tolerance ', qq(<div class="twocol-cell">$html</div>) ];
 }
 
 sub hgvs {

--- a/modules/EnsEMBL/Web/Object/Variation.pm
+++ b/modules/EnsEMBL/Web/Object/Variation.pm
@@ -37,7 +37,6 @@ use Bio::EnsEMBL::Utils::Eprof qw(eprof_start eprof_end eprof_dump);
 use strict;
 use warnings;
 no warnings "uninitialized";
-use Data::Dumper;
 use HTML::Entities qw(encode_entities);
 use EnsEMBL::Web::REST;
 use base qw(EnsEMBL::Web::Object);

--- a/modules/EnsEMBL/Web/Object/Variation.pm
+++ b/modules/EnsEMBL/Web/Object/Variation.pm
@@ -37,7 +37,7 @@ use Bio::EnsEMBL::Utils::Eprof qw(eprof_start eprof_end eprof_dump);
 use strict;
 use warnings;
 no warnings "uninitialized";
-
+use Data::Dumper;
 use HTML::Entities qw(encode_entities);
 use EnsEMBL::Web::REST;
 use base qw(EnsEMBL::Web::Object);
@@ -588,6 +588,52 @@ sub clinical_significance {
   return $self->vari->get_all_clinical_significance_states;
 }
 
+
+sub CADD_score {
+  ### Args       : none
+  ### Example    : my $data = $object->CADD_score;
+  ### Description: gets CADD score and CADD score source. We know from the config file that we only expect one source for the website.
+  ### Returns arrayref of data, 
+
+  my $self = shift;
+ 
+  my $vf_object = $self->get_selected_variation_feature;
+  return [undef, undef] unless $vf_object;
+
+  my @alleles = split('/', $vf_object->allele_string);
+  
+  my $cadd_scores_for_all_alternatives = $vf_object->get_all_cadd_scores;
+  my $cadd_scores = {};
+
+  my $source = (keys %$cadd_scores_for_all_alternatives)[0];  
+ 
+  my $cadd_scores_for_source = $cadd_scores_for_all_alternatives->{$source};
+
+  my $cadd_scores = {};
+
+  foreach my $allele (@alleles) {
+    $cadd_scores->{$allele} = $cadd_scores_for_source->{$allele} if (exists $cadd_scores_for_source->{$allele});
+  }
+  return [undef, undef] if (!scalar keys %$cadd_scores); 
+
+  return [$cadd_scores, $source];
+}
+
+sub GERP_score {
+  ### Args       : none
+  ### Example    : my $data = $object->GERP_score;
+  ### Description: gets GERP score and GERP score source. We know from the config file that we only expect one source for the website.
+  ### Returns arrayref of data, 
+
+  my $self = shift;
+  my $vf_object = $self->get_selected_variation_feature;
+  return [undef, undef] unless $vf_object;
+  my $gerp_score = $vf_object->get_gerp_score;
+  my $source = (keys %$gerp_score)[0];  
+  my $score = $gerp_score->{$source}; 
+  return [undef, undef] if (!defined $score); 
+  return [$score, $source];
+}
 
 sub freqs {
 


### PR DESCRIPTION
## Requirements

- updated config file pointing to files from which to read see [PR](https://github.com/Ensembl/public-plugins/pull/188)

## Description

We are displaying genome wide scores, CADD and GERP, indicating the tolerance of change introduced by a variant, on the variant summary page. The scores are making use of our vcf backend code in the variation API and are therefore read from file and not stored in the variation database. See my [sandbox](http://ves-hx2-76.ebi.ac.uk:5040/Homo_sapiens/Variation/Explore?db=core;v=rs699) for display details under **change tolerance**.

## Views affected

Variant summary page

## Possible complications
- possible slowness in reading from file to retrieve score. This should be mininmal because we are only retrieving data for a small region.

## Merge conflicts
None

## Related JIRA Issues (EBI developers only)

Config file updates [PR](https://github.com/Ensembl/public-plugins/pull/188)
