### PR TITLE
check pops against samples

### DIFF
--- a/modules/EnsEMBL/Web/Object/Variation.pm
+++ b/modules/EnsEMBL/Web/Object/Variation.pm
@@ -203,8 +203,22 @@ sub count_samples {
 sub count_ldpops {
   my $self = shift;
   my $pa  = $self->database('variation')->get_PopulationAdaptor;
-  my $count = scalar @{$pa->fetch_all_LD_Populations};
-  
+  my @ldpops = @{$pa->fetch_all_LD_Populations};
+  return undef if (!scalar @ldpops);
+  my $var  = $self->Obj;
+  my $gts = $var->get_all_SampleGenotypes();
+  return undef if (!scalar @$gts);
+  my @gts_names = map {$_->sample->name} @$gts;
+  my $count = 0;
+  foreach (@ldpops) {
+    my @ldpops_sample_names = map {$_->name} @{$_->get_all_Samples};
+    foreach my $gts_name (@gts_names) {
+      if (grep {$gts_name eq $_ } @ldpops_sample_names) {
+        $count++;
+        last;
+      }
+    }
+  }
   return ($count > 0 ? $count : undef);
 }
 


### PR DESCRIPTION
## Requirements
None
## Description

This a bugfix. The LD icon on the variant page is switched on if the variant has LD populations and sample genotypes. There are cases where a variant has sample genotypes from HapMap and not 1000Genomes. However, we don't display HapMap LD plots anymore. The fix checks that for the LD populations there are the samples from those populations represented in the sample genotypes.

## Views affected

Variant summary page. Switched off [here](http://ves-hx2-76.ebi.ac.uk:5040/Homo_sapiens/Variation/Explore?db=core;r=19:39248014-39249015;v=rs368234815;vdb=variation;vf=143410401) and on [here](http://ves-hx2-76.ebi.ac.uk:5040/Homo_sapiens/Variation/Explore?db=core;r=19:39248014-39249014;v=rs11322783;vdb=variation;vf=142426185).

## Possible complications

I'm slightly worried about how the fix affects speed. If I can rule out that the _ldpops_ count is used for anything else than just show the existence of LD populations I can break out of the loop earlier.

## Merge conflicts

None

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-1215
