### PR TITLE
check if there is a vcf config file first

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -725,6 +725,9 @@ sub clinical_significance {
 
 sub change_tolerance {
   my $self = shift;
+  my $adaptor = $self->hub->get_adaptor('get_VariationFeatureAdaptor', 'variation');
+  my $c = $self->hub->species_defs->ENSEMBL_VCF_COLLECTIONS;
+  return unless (defined $c->{'CONFIG'});
   my $object = $self->object;
   my ($CADD_scores, $CADD_source) = @{$object->CADD_score};
   my ($GERP_score, $GERP_source) = @{$object->GERP_score};

--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -725,9 +725,6 @@ sub clinical_significance {
 
 sub change_tolerance {
   my $self = shift;
-  my $adaptor = $self->hub->get_adaptor('get_VariationFeatureAdaptor', 'variation');
-  my $c = $self->hub->species_defs->ENSEMBL_VCF_COLLECTIONS;
-  return unless (defined $c->{'CONFIG'});
   my $object = $self->object;
   my ($CADD_scores, $CADD_source) = @{$object->CADD_score};
   my ($GERP_score, $GERP_source) = @{$object->GERP_score};

--- a/modules/EnsEMBL/Web/Object/Variation.pm
+++ b/modules/EnsEMBL/Web/Object/Variation.pm
@@ -595,7 +595,8 @@ sub CADD_score {
   ### Returns arrayref of data, 
 
   my $self = shift;
- 
+  return [undef, undef] unless $self->hub->species_defs->ENSEMBL_VCF_COLLECTIONS; 
+
   my $vf_object = $self->get_selected_variation_feature;
   return [undef, undef] unless $vf_object;
 
@@ -623,6 +624,7 @@ sub GERP_score {
   ### Returns arrayref of data, 
 
   my $self = shift;
+  return [undef, undef] unless $self->hub->species_defs->ENSEMBL_VCF_COLLECTIONS; 
   my $vf_object = $self->get_selected_variation_feature;
   return [undef, undef] unless $vf_object;
   my $gerp_score = $vf_object->get_gerp_score;


### PR DESCRIPTION
## Requirements

None

## Description

This is a fix for a bug which I noticed on [staging](http://staging.ensembl.org/Meleagris_gallopavo/Variation/Explore?r=18:72663-73663;v=rs119118426;vdb=variation;vf=5810). The problem being that there was no vcf config file under public-plugins/ensembl/conf/json/ for the species.

## Views affected

Variant summary page

## Possible complications

Is $c->{'CONFIG'} always pointing to public-plugins/ensembl/conf/json/ if there is a config file for the given species stored in that directory?

## Merge conflicts

None

## Related JIRA Issues (EBI developers only)

None