### PR TITLE
Add method to disable PDB entry in left menu for species without the …

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Explore.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Explore.pm
@@ -83,7 +83,7 @@ sub content {
     $cit_count = $avail->{'has_citation'};
   }
 
-  if ($avail->{'is_coding'}) {
+  if ($avail->{'is_coding'} && $avail->{'has_pdbe'}) {
     $prot_url = $hub->url({'action' => 'PDB'});
   }
 

--- a/modules/EnsEMBL/Web/Configuration/Transcript.pm
+++ b/modules/EnsEMBL/Web/Configuration/Transcript.pm
@@ -94,7 +94,7 @@ sub populate_tree {
 
   $prot_menu->append($self->create_node('PDB', '3D Protein model',
     [qw( alignment EnsEMBL::Web::Component::Transcript::PDB )],
-    { 'availability' => 'transcript translation','concise' => '3D Protein model (PDBe)' }
+    { 'availability' => 'transcript translation has_pdbe','concise' => '3D Protein model (PDBe)' }
   ));
  
   my $var_menu = $self->create_submenu('Variation', 'Genetic Variation');

--- a/modules/EnsEMBL/Web/Configuration/Variation.pm
+++ b/modules/EnsEMBL/Web/Configuration/Variation.pm
@@ -126,7 +126,7 @@ sub populate_tree {
 
   $self->create_node('PDB', '3D Protein model',
     [qw( alignment EnsEMBL::Web::Component::Variation::PDB )],
-    { 'availability' => 'variation is_coding','concise' => '3D Protein model (PDBe)'}
+    { 'availability' => 'variation is_coding has_pdbe','concise' => '3D Protein model (PDBe)'}
   );
 
   $self->create_subnode(

--- a/modules/EnsEMBL/Web/Object/Transcript.pm
+++ b/modules/EnsEMBL/Web/Object/Transcript.pm
@@ -70,6 +70,7 @@ sub availability {
       $availability->{'has_domains'}     = $counts->{'prot_domains'};
       $availability->{"has_$_"}          = $counts->{$_} for qw(exons evidence similarity_matches oligos);
       $availability->{ref_slice}       //= $self->Obj->slice->is_reference();
+      $availability->{'has_pdbe'}        = $self->has_pdbe_analysis();
     }
   
     $self->{'_availability'} = $availability;
@@ -270,6 +271,11 @@ sub count_oligos {
   my $total_number_of_mappings = $num_probe_set_mappings + $num_probe_mappings;
 
   return $total_number_of_mappings;
+}
+
+sub has_pdbe_analysis {
+  my $self = shift;
+  return ($self->table_info($self->get_db, 'protein_feature')->{'analyses'}{'sifts_import'}) ? 1 : 0;
 }
 
 sub default_track_by_gene {

--- a/modules/EnsEMBL/Web/Object/Variation.pm
+++ b/modules/EnsEMBL/Web/Object/Variation.pm
@@ -61,6 +61,7 @@ sub availability {
       $availability->{'is_somatic'}  = $obj->has_somatic_source;
       $availability->{'not_somatic'} = !$obj->has_somatic_source;
       $availability->{'is_coding'}   = $self->is_coding_variant;
+      $availability->{'has_pdbe'}    = $self->has_pdbe_analysis();
     }
     
     $self->{'_availability'} = $availability;
@@ -88,6 +89,11 @@ sub is_coding_variant {
     }
   }
   return ($rank < 18) ? 1 : 0;
+}
+
+sub has_pdbe_analysis {
+  my $self = shift;
+  return ($self->table_info($self->get_db, 'protein_feature')->{'analyses'}{'sifts_import'}) ? 1 : 0;
 }
 
 sub counts {


### PR DESCRIPTION
…protein feature analysis 'sifts_import'


## Description

At the moment the PDB entry in the left hand menu (Transcript and Variation) is enabled for every species with coding protein or coding variant, even though the PDB mapping is only available for human (at the moment). This can be confusing for users looking at non human species.
This PR is checking if the species has the analysis `sifts_import` which corresponds to the PDBe mapping analysis.

## Views affected

### Transcript portal:
- http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/Transcript/Summary?t=ENST00000231061
- http://ves-hx2-76.ebi.ac.uk:5060/Gallus_gallus/Transcript/Summary?t=ENSGALT00000096946

### Variation portal (and Explore page):
- http://ves-hx2-76.ebi.ac.uk:5060/Gallus_gallus/Variation/Explore?v=rs732502377
- http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/Variation/Explore?v=rs761258843

