### PR TITLE
Set GERP root file directory

### DIFF
--- a/modules/EnsEMBL/Web/Object/Variation.pm
+++ b/modules/EnsEMBL/Web/Object/Variation.pm
@@ -647,6 +647,10 @@ sub GERP_score {
   return [undef, undef] unless $self->hub->species_defs->ENSEMBL_VCF_COLLECTIONS; 
   my $vf_object = $self->get_selected_variation_feature;
   return [undef, undef] unless $vf_object;
+
+  my $variation_db = $self->Obj->adaptor->db->get_VariationAdaptor->db;
+  $variation_db->gerp_root_dir($self->hub->species_defs->ENSEMBL_FTP_URL . '/release-' . $self->hub->species_defs->ENSEMBL_VERSION . '/compara/conservation_scores/');
+
   my $gerp_score = $vf_object->get_gerp_score;
   my $source = (keys %$gerp_score)[0];  
   my $score = $gerp_score->{$source}; 


### PR DESCRIPTION
## Requirements

-- Recently merged PR into [ensembl-variation/release/96](https://github.com/Ensembl/ensembl-variation/pull/331).
-- Setup of new ftp site with updated GERP files for release/96
-- [PR](https://github.com/Ensembl/public-plugins/pull/194) to public-plugins

## Description

As [discussed](https://github.com/Ensembl/public-plugins/pull/194) with @ens-ap5 : We want to generate the part of GERP file URL which contains the release number automatically. 

## Views affected

Variation summary page. GERP score displays on my [sandbox](http://ves-hx2-76.ebi.ac.uk:5040/Capra_hircus/Variation/Explore?r=17:60279944-60280944;v=rs666529295;vdb=variation;vf=8972194). However, I'm pointing to release-95 ftp which is why it is working on my sandbox already.

## Possible complications

None

## Merge conflicts

None

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-4943