### PR TITLE
Add the EVA source link for variants coming from an EVA study

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -242,9 +242,14 @@ sub variation_source {
   } elsif ($source =~ /LSDB/) {
     $version = ($version) ? " ($version)" : '';
     $source_link = $hub->get_ExtURL_link("$source_prefix $source", $source, $name);
-  }  elsif ($source =~ /PhenCode/) {
+  } elsif ($source =~ /PhenCode/) {
      $sname       = 'PHENCODE';
      $source_link = $hub->get_ExtURL_link("$source_prefix PhenCode", $sname, $name);
+  } elsif ($source =~ /^PRJEB\d+/) {
+    $sname       = 'EVA_STUDY';
+    my $eva_url  = $hub->get_ExtURL("EVA_STUDY");
+    my $source_label = "$source EVA study";
+    $source_link = $eva_url ? qq{<a href="$eva_url$source" class="constant">$source_label</a>} : $source_label;
   } else {
     $source_link = $url ? qq{<a href="$url" class="constant">$source_prefix $source</a>} : "$source $version";
   }


### PR DESCRIPTION
## Description

Add link to the EVA study source for a variant in the variant summary panel.

## Views affected

All the pages from the Variant portal (Variant summary panel)

Example on my sandbox (end of the line `Original source`):
http://ves-hx2-76.ebi.ac.uk:5060/Chlorocebus_sabaeus/Variation/Population?v=11:6825247:G_A:PRJEB22989;vf=11:6825247:G_A:PRJEB22989