### PR TITLE
[ENSWEB-4928] do not overwrite a section with defaults if it is already in the hash

### DIFF
--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -543,7 +543,7 @@ sub _read_in_ini_file {
           $tree->{$current_section} ||= {}; # create new element if required
           
           # add settings from default
-          if (defined $defaults->{$current_section}) {
+          if (!%{$tree->{$current_section}} && defined $defaults->{$current_section}) {
             my %hash = %{$defaults->{$current_section}};
             
             $tree->{$current_section}{$_} = $defaults->{$current_section}{$_} for keys %hash;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

DEFAULT_XREFS entries in homo_sapiens.ini file were missing from the gene external refs table. 
There is a problem in parsing ini files. As far as I understand we should not overwrite a section with the default values if the tree already has that section added.

## Views affected

Gene External references table and Transcripts table in Gene Summary view. But may be other views as well.

## Possible complications

This change may affect other views as well which I am not aware of, as it will make changes to config.packed file. Until now though the ini files were read properly, the db_tree was not properly generated. So you may see some changes in other views too.

## Merge conflicts

No conflicts. Please use mpush after merging.

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-4928
