### PR TITLE
Be more careful as not all genomes are in the compara db

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -232,7 +232,9 @@ sub content {
   my $genome_db_adaptor = $tree->adaptor->db->get_GenomeDBAdaptor;
   foreach my $species_name (keys %{$self->hub->get_species_info}) {  
     foreach my $clade (@{ $self->hub->species_defs->get_config($species_name, 'SPECIES_GROUP_HIERARCHY') }) {
-      push @{$genome_db_ids_by_clade{$clade}}, $genome_db_adaptor->fetch_by_name_assembly($hub->species_defs->get_config($species_name, 'SPECIES_PRODUCTION_NAME'))->dbID;
+      my $production_name = $hub->species_defs->get_config($species_name, 'SPECIES_PRODUCTION_NAME');
+      my $genome_db = $genome_db_adaptor->fetch_by_name_assembly($production_name);
+      push @{$genome_db_ids_by_clade{$clade}}, $genome_db->dbID if $genome_db;
     }
   }
 


### PR DESCRIPTION
## Description

This commit allows viewing the gene-tree page even if the Compara database doesn't have all the genomes.
I did that change locally a while ago, after trying to visualize our production gene-tree databases (which are missing either the mouse-strains or the non-murinae species) on my sandbox. Yesterday, @jyothishnt noticed that the same error happens on staging as the database is the e96 one (thus missing the e97 species). See http://staging.ensembl.org/Homo_sapiens/Gene/Compara_Tree?g=ENSG00000139618;r=13:32315086-32400266

## Views affected

Gene-tree view. Fixed on my sandbox: http://ves-hx2-77.ebi.ac.uk:5081/Homo_sapiens/Gene/Compara_Tree?g=ENSG00000139618;r=13:32315086-32400266 (note that the sandbox is using the same database as staging.ensemblorg)

## Possible complications

As the page will now be displayed on staging, people may think that the new Compara database is available

## Merge conflicts

This commit is on top of master. There shouldn't be any conflict.

## Related JIRA Issues (EBI developers only)

N/A
