### PR TITLE
Various bugfixes for the gene-tree stats of polyploid genomes

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/Compara/GeneTrees.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara/GeneTrees.pm
@@ -294,6 +294,10 @@ sub get_html_for_gene_tree_coverage {
 
   foreach my $sp (@$species) {
     my $piecharts; 
+    # Exclude species with no data. This only applies to polyploid genomes
+    # for which we use the components in the gene-trees instead of the
+    # total genome
+    next unless $sp->get_value_for_tag('nb_genes');
 
     if ($method eq 'PROTEIN_TREES') { 
       $piecharts = $self->get_piecharts_for_species($sp, $counter_raphael_holders);
@@ -473,7 +477,12 @@ sub get_html_for_tree_stats_overview {
 
 sub draw_tree {
   my ($self, $matrix, $node, $next_y, $counter_raphael_holders, $method) = @_;
-  my $nchildren = scalar(@{$node->children});
+
+  # Exclude species with no data. This only applies to polyploid genomes
+  # for which we use the components in the gene-trees instead of the
+  # total genome
+  my @children = grep {$_->get_value_for_tag('nb_nodes') || $_->get_value_for_tag('nb_genes')} @{$node->sorted_children};
+  my $nchildren = scalar(@children);
 
   my $horiz_branch  = q{<img style="width: 28px; height: 28px;" alt="---" src="ct_hor.png" />};
   my $vert_branch   = q{<img style="width: 28px; height: 28px;" alt="---" src="ct_ver.png" />};
@@ -483,7 +492,7 @@ sub draw_tree {
   my $half_horiz_branch  = q{<img style="width: 14px; height: 28px;" alt="-" src="ct_half_hor.png" />};
 
   if ($nchildren) {
-    my @subtrees = map {$self->draw_tree($matrix, $_, $next_y, $counter_raphael_holders, $method)} @{$node->sorted_children};
+    my @subtrees = map {$self->draw_tree($matrix, $_, $next_y, $counter_raphael_holders, $method)} @children;
     my $anchor_x_pos = min(map {$_->[0]} @subtrees)-1;
     my $min_y = min(map {$_->[1]} @subtrees);
     my $max_y = max(map {$_->[1]} @subtrees);

--- a/modules/EnsEMBL/Web/Hub.pm
+++ b/modules/EnsEMBL/Web/Hub.pm
@@ -1069,7 +1069,7 @@ sub order_species_by_clade { # TODO - move to EnsEMBL::Web::Document::HTML::Comp
 
   my %stn_by_name = ();
   foreach my $stn (@$species) {
-    $stn_by_name{$stn->genome_db->name} = $stn;
+    push @{$stn_by_name{$stn->genome_db->name}}, $stn;
   };
 
   ## Sort species into desired groups
@@ -1086,7 +1086,7 @@ sub order_species_by_clade { # TODO - move to EnsEMBL::Web::Document::HTML::Comp
   my $favourites    = $self->get_favourite_species;
   if (scalar @$favourites) {
     my @allowed_production_names = grep {$stn_by_name{$_}} map {$species_defs->get_config($_, 'SPECIES_PRODUCTION_NAME')} @$favourites;
-    push @final_sets, ['Favourite species', [map {$stn_by_name{$_}} @allowed_production_names]] if @allowed_production_names;
+    push @final_sets, ['Favourite species', [map {@{$stn_by_name{$_}}} @allowed_production_names]] if @allowed_production_names;
   }
 
   ## Output in taxonomic groups, ordered by common name
@@ -1096,7 +1096,7 @@ sub order_species_by_clade { # TODO - move to EnsEMBL::Web::Document::HTML::Comp
       my $name_to_use = ($group_name eq 'no_group') ? (scalar(@group_order) > 1 ? 'Other species' : 'All species') : encode_entities($group_name);
       my @sorted_by_common = sort { $species_info->{$a}->{'common'} cmp $species_info->{$b}->{'common'} } @$species_list;
       my @allowed_production_names = grep {$stn_by_name{$_}} map {$species_defs->get_config($_, 'SPECIES_PRODUCTION_NAME')} @sorted_by_common;
-      push @final_sets, [$name_to_use, [map {$stn_by_name{$_}} @allowed_production_names]] if @allowed_production_names;
+      push @final_sets, [$name_to_use, [map {@{$stn_by_name{$_}}} @allowed_production_names]] if @allowed_production_names;
   }
 
   return \@final_sets;


### PR DESCRIPTION
## Description

We process polyploid genomes (wheat) in a particular way: instead of using the whole genome at once, we use the so-called "components" (A, B, D) as if they were distinct genomes. Some gene-tree stats views were not aware of this:
 - http://plants.ensembl.org/prot_tree_stats.html displays the components *and* the whole genome, but there are no stats for the whole genome, thus displaying a tribute to Trivial Pursuit instead.
 - http://plants.ensembl.org/prot_tree_stats.html?page=coverage#cladegroup1 is not aware that multiple GenomeDBs can thus have the same name when it sorts them by clade. Once fixed, the entry for the whole genome also has to be discarded as it has no stats attached to it.

## Views affected

Both views fixed on my sandbox:
 - http://ves-hx2-77.ebi.ac.uk:5082/prot_tree_stats.html
 - http://ves-hx2-77.ebi.ac.uk:5082/prot_tree_stats.html?page=coverage#cladegroup1

## Possible complications

None

## Merge conflicts

None

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-1640
