### PR TITLE
[ENSWEB-4912] Use data from Ontology Lookup Service for the biotypes page

### DIFF
--- a/modules/EnsEMBL/Web/Component/Help/Biotypes.pm
+++ b/modules/EnsEMBL/Web/Component/Help/Biotypes.pm
@@ -1,0 +1,73 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::Component::Help::Biotypes;
+
+use strict;
+use warnings;
+no warnings "uninitialized";
+
+use base qw(EnsEMBL::Web::Component::Help);
+
+sub _init {
+#  my $self = shift;
+#  $self->cacheable( 0 );
+#  $self->ajaxable(  0 );
+#  $self->configurable( 0 );
+}
+
+sub content {
+  my $self = shift;
+  my $hub = $self->hub;
+  my %biotypes = $hub->species_defs->multiX('ENSEMBL_BIOTYPES');
+  my $rendered_term_tree = render_term(\%biotypes);
+
+  return "<ul>${rendered_term_tree}</ul>"
+}
+
+sub render_term {
+  my $term = shift;
+
+  my $label = $term->{label};
+  my $description = join ' ', @{$term->{description}}; # description field is an array;
+  my $rendered_children = '';
+  my $children = $term->{children};
+
+  if ($children and scalar(@{$children})) {
+    $rendered_children = render_children($children);
+  }
+ 
+  my $html = "<li><strong>${label}:</strong> ${description} ${rendered_children}</li>";
+  return $html;
+}
+
+sub render_children {
+  my $children = shift;
+  my $rendered_children = '';
+
+  my @sorted_children = sort { $a->{label} cmp $b->{label} } @{$children};
+  
+  foreach my $term (@sorted_children) {
+    $rendered_children = $rendered_children . render_term($term);
+  }
+
+  return "<ul>${rendered_children}</ul>";
+}
+
+1;

--- a/modules/EnsEMBL/Web/Component/Help/Biotypes.pm
+++ b/modules/EnsEMBL/Web/Component/Help/Biotypes.pm
@@ -26,10 +26,10 @@ no warnings "uninitialized";
 use base qw(EnsEMBL::Web::Component::Help);
 
 sub _init {
-#  my $self = shift;
-#  $self->cacheable( 0 );
-#  $self->ajaxable(  0 );
-#  $self->configurable( 0 );
+  my $self = shift;
+  $self->cacheable( 1 );
+  $self->ajaxable( 0 );
+  $self->configurable( 0 );
 }
 
 sub content {
@@ -38,7 +38,7 @@ sub content {
   my %biotypes = $hub->species_defs->multiX('ENSEMBL_BIOTYPES');
   my $rendered_term_tree = render_term(\%biotypes);
 
-  return "<ul>${rendered_term_tree}</ul>"
+  return "<ul>$rendered_term_tree</ul>"
 }
 
 sub render_term {
@@ -53,7 +53,7 @@ sub render_term {
     $rendered_children = render_children($children);
   }
  
-  my $html = "<li><strong>${label}:</strong> ${description} ${rendered_children}</li>";
+  my $html = "<li><strong>$label:</strong> $description $rendered_children</li>";
   return $html;
 }
 
@@ -67,7 +67,7 @@ sub render_children {
     $rendered_children = $rendered_children . render_term($term);
   }
 
-  return "<ul>${rendered_children}</ul>";
+  return "<ul>$rendered_children</ul>";
 }
 
 1;

--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -29,7 +29,6 @@ use EnsEMBL::Web::File::Utils::URL qw(read_file);
 
 use JSON qw(from_json);
 use URI::Escape;
-use Data::Dumper;
 
 sub munge {
   my ($self, $func) = @_;
@@ -1058,7 +1057,7 @@ sub _summarise_website_db {
       if ($children_link) {
         $result{'children'} = [ fetch_children_terms($children_link) ];
       }
-      return %result;
+      return \%result;
     }
 
     sub fetch_children_terms {
@@ -1067,15 +1066,12 @@ sub _summarise_website_db {
       my $response = $self->_get_rest_data($url);
       my $children = $response->{_embedded}->{terms};
       
-     return map { fetch_term($_->{_links}->{self}->{href}) } @{$children};
+      return map { fetch_term($_->{_links}->{self}->{href}) } @{$children};
     }
 
-    my %root_term = fetch_term($biotype_term_url);
+    my $root_term = fetch_term($biotype_term_url);
 
-print'FINALLY!';
-    print Dumper %root_term;
- 
-    $self->db_tree->{'ENSEMBL_BIOTYPES'} = %root_term; 
+    $self->db_tree->{'ENSEMBL_BIOTYPES'} = $root_term;
  }
 
 

--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -1044,32 +1044,7 @@ sub _summarise_website_db {
     my $safe_biotype_url = uri_escape(uri_escape($biotype_url));
     my $biotype_term_url = $terms_endpoint . '/' . $safe_biotype_url;
  
-    sub fetch_term {
-      my %result;
-      my $url = $_[0];
-      my $term = $self->_get_rest_data($url);
-      my $children_link = $term->{_links}->{children}->{href};
-
-      $result{label} = $term->{label};
-      $result{description} = $term->{description};
-      $result{synonyms} = $term->{synonyms};
-
-      if ($children_link) {
-        $result{'children'} = [ fetch_children_terms($children_link) ];
-      }
-      return \%result;
-    }
-
-    sub fetch_children_terms {
-      my $url = @_[0];
-
-      my $response = $self->_get_rest_data($url);
-      my $children = $response->{_embedded}->{terms};
-      
-      return map { fetch_term($_->{_links}->{self}->{href}) } @{$children};
-    }
-
-    my $root_term = fetch_term($biotype_term_url);
+    my $root_term = $self->_fetch_ols_term($biotype_term_url);
 
     $self->db_tree->{'ENSEMBL_BIOTYPES'} = $root_term;
  }
@@ -1086,6 +1061,33 @@ sub _summarise_website_db {
 
 
   $dbh->disconnect();
+}
+ 
+sub _fetch_ols_term {
+  my ($self, $url) = @_;
+  my %result;
+  my $term = $self->_get_rest_data($url);
+  my $children_link = $term->{_links}->{children}->{href};
+
+  $result{label} = $term->{label};
+  $result{description} = $term->{description};
+  $result{synonyms} = $term->{synonyms};
+
+  if ($children_link) {
+    $result{'children'} = [ $self->_fetch_children_ols_terms($children_link) ];
+  }
+  return \%result;
+}
+
+sub _fetch_children_ols_terms {
+  my ($self, $url) = @_;
+
+  my $response = $self->_get_rest_data($url);
+  my $children = $response->{_embedded}->{terms};
+
+  return map {
+    $self->_fetch_ols_term($_->{_links}->{self}->{href})
+  } @{$children};
 }
 
 sub _get_rest_data {

--- a/modules/EnsEMBL/Web/Document/HTML/Biotypes.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Biotypes.pm
@@ -1,0 +1,40 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::Document::HTML::Biotypes;
+
+### This module outputs a list of biotypes
+
+use strict;
+use warnings;
+
+use EnsEMBL::Web::Component::Help::Biotypes;
+
+use base qw(EnsEMBL::Web::Document::HTML);
+
+sub render {
+  my $self = shift;
+
+  my $component = EnsEMBL::Web::Component::Help::Biotypes->new($self->hub);
+
+  return $component->content;
+}
+
+1;
+


### PR DESCRIPTION
## Description

This PR replaces static html content of the [biotypes page](http://www.ensembl.org/info/genome/genebuild/biotypes.html) with the definitions retrieved from Ontology Lookup Service. The list of definitions is retrieved once, at the build time of the MULTI package, and then used when rendering the page. This is done in a similar way to how the [glossary page](http://www.ensembl.org/info/website/glossary.html) is displayed.

See related PR in the public-plugins repo: https://github.com/Ensembl/public-plugins/pull/208

## Views affected

[Biotypes page](http://www.ensembl.org/info/genome/genebuild/biotypes.html).

Screenshot of the updated page:
![image](https://user-images.githubusercontent.com/6834224/57311453-961ed180-70e3-11e9-8ecd-27db344d7ba6.png)

## Possible complications

None that I am aware of.

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/projects/ENSWEB/issues/ENSWEB-4912