### PR TITLE
Fetch ClinGen Allele Registry from database instead of REST call

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -1036,15 +1036,19 @@ sub allele_registry_synonyms_urls {
 
   return []  if (!$hgvsg);
 
+  my $allele_synonyms = $object->get_allele_synonyms();
+  return [] if (!$allele_synonyms);
+
+  my %ar_lu = map {$_->hgvs_genomic => $_->name } @$allele_synonyms;
+
   my $hgvs_ar;
 
   # For each allele, for each HGVSg, lookup caid
   foreach my $allele (keys %$hgvsg) {
     next if $hgvsg->{$allele} !~ /^NC_/;
-    my $ar_results = $object->get_allele_registry_data($hgvsg->{$allele});
-    next if (! %$ar_results);
+    next if (! defined $ar_lu{$hgvsg->{$allele}});
     $hgvs_ar->{$allele} = [$hgvsg->{$allele},
-                           $ar_results->{'caid'},
+                           $ar_lu{$hgvsg->{$allele}},
                           ];
   }
   return [] if (!$hgvs_ar);

--- a/modules/EnsEMBL/Web/Object/Variation.pm
+++ b/modules/EnsEMBL/Web/Object/Variation.pm
@@ -1899,6 +1899,12 @@ sub get_allele_registry_data {
   return {'caid' => $caid, 'caid_uri' => $ref->{'@id'}};
 }
 
+# Get all the allele synonyms for a variation
+sub get_allele_synonyms {
+  my $self = shift;
+  return $self->vari->get_all_AlleleSynonyms();
+}
+
 sub get_hgvsg {
   my $self = shift;
 


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

_Using one or more sentences, describe the proposed changes and the reason for making them._
The Variant summary page currently makes ClinGen Allele Registry REST API calls to look up the Canonial Allele Identifier(CAid). The information is available in the variation database and is now looked up using the variation API

## Views affected

_List the website view(s) that you know are affected by this change._
Variant Summary page
_If possible please provide a URL that shows the change. For Ensembl developers this could be your sandbox._
http://ves-hx2-76.ebi.ac.uk:5050/Homo_sapiens/Variation/Explore?db=core;r=1:230709548-230710548;v=rs699;vdb=variation;vf=501900148

## Possible complications

_We appreciate this can be difficult but please highlight any views that you think might possibly be adversely affected by this change. For example a change to method in ApacheHandlers.pm has potential for widespread consequences._

None. No known views that might possibly be adversely affected by this change.

## Merge conflicts

_At certain stages of the release there is potential for many people to be working on the same modules. To avoid merge conflicts please confirm you have tested for this before submitting the pull request, eg by updating your feature branch and checking that the only changes being submitted are ones from you._

None

## Related JIRA Issues (EBI developers only)

_Please provide the URL(s) for any JIRA issues related to this PR._
