### PR TITLE
Unescape wasabi rest URL

### DIFF
--- a/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
@@ -22,7 +22,7 @@ package EnsEMBL::Web::ZMenu::ComparaTreeNode;
 use strict;
 
 use LWP::Simple qw($ua head);
-use URI::Escape qw(uri_escape);
+use URI::Escape qw(uri_escape uri_unescape);
 use IO::String;
 use Bio::AlignIO;
 
@@ -400,9 +400,11 @@ sub content {
 
           if ($hub->wasabi_status) {
             $link = $hub->get_ExtURL('WASABI_ENSEMBL', {
-              'URL' => uri_escape($rest_url)
+              'URL' => $rest_url
             });
           }
+          
+          $link = uri_unescape($link);
         }
         else {
           my $filegen_url = $hub->url('Json', {


### PR DESCRIPTION
## Description

This PR is to fix the popup error that appears when the Wasabi viewer is opened from the gene tree.

## Views affected

http://staging.ensembl.org/Homo_sapiens/Gene/Compara_Tree?db=core;g=ENSG00000148572;r=10:63133247-63155031

## Possible complications
None

## Merge conflicts
None

## Related JIRA Issues
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5027