### PR TITLE
[ENSWEB-4979] Gene phenotypes missing/reported incorrectly 

### DIFF
--- a/modules/EnsEMBL/Web/Query/Availability/Gene.pm
+++ b/modules/EnsEMBL/Web/Query/Availability/Gene.pm
@@ -152,12 +152,6 @@ sub _get_phenotype {
   my $pfa = $self->phenotype_feature_adaptor($args);
   my $phen_count = $pfa->count_all_by_Gene($args->{'gene'});
   return $phen_count if $phen_count;
-  my $hgncs = $args->{'gene'}->get_all_DBEntries('hgnc');
-  if($hgncs and @$hgncs and $hgncs->[0]) {
-    my $hgnc_name = $hgncs->[0]->display_id;
-    $phen_count = $pfa->_check_gene_by_HGNC($hgnc_name) if $hgnc_name;
-    return $phen_count if $phen_count;
-  }
   return 0;
 }
 


### PR DESCRIPTION
## Description

This PR is to fix the phenotypes count inconsistencies in the gene summary section. I have updated the code in the summary section to only count the associated phenotypes based on Gene and not on  HGNC.

## Views affected

http://www.ensembl.org/Homo_sapiens/Gene/Phenotype?db=core;g=ENSG00000173153;r=11:64305063-64317335;t=ENST00000405666

## Possible complications

None

## Merge conflicts

None

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-4979