### PR TITLE
Escape wasabi viewer url to preserve subtree_node_id

### DIFF
--- a/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
@@ -22,7 +22,7 @@ package EnsEMBL::Web::ZMenu::ComparaTreeNode;
 use strict;
 
 use LWP::Simple qw($ua head);
-use URI::Escape qw(uri_escape uri_unescape);
+use URI::Escape qw(uri_escape);
 use IO::String;
 use Bio::AlignIO;
 
@@ -400,11 +400,10 @@ sub content {
 
           if ($hub->wasabi_status) {
             $link = $hub->get_ExtURL('WASABI_ENSEMBL', {
-              'URL' => $rest_url
+              'URL' => uri_escape($rest_url)
             });
           }
           
-          $link = uri_unescape($link);
         }
         else {
           my $filegen_url = $hub->url('Json', {


### PR DESCRIPTION
## Description

This PR is to revert the commits from PR https://github.com/Ensembl/ensembl-webcode/pull/697.
It turns out the Wasabi viewer URL needs to be escaped to prevent the subtree_node_id from getting stripped off.

## Views affected

http://ves-hx2-76.ebi.ac.uk:42229/Homo_sapiens/Gene/Compara_Tree?db=core;g=ENSG00000148572;r=10:63133247-63155031

## Possible complications

None

## Merge conflicts

None

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5027