### PR TITLE
Hide phenotypes associated with non mapped variants

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Explore.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Explore.pm
@@ -69,7 +69,7 @@ sub content {
     }
   }
 
-  if ($avail->{'has_ega'}) {
+  if ($avail->{'has_ega'} && $avail->{'has_locations'}) {
     $pheno_url   = $hub->url({'action' => 'Phenotype'});
     $pheno_count = $avail->{'has_ega'}
   }

--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -106,7 +106,7 @@ sub feature_summary {
                       $phenotype_url, 
                       $avail->{has_ega}, 
                       $avail->{has_ega} eq "1" ? "phenotype" : "phenotypes"
-                  ) if($avail->{has_ega});  
+                  ) if($avail->{has_ega} && $avail->{has_locations});
   push @str_array, sprintf('is mentioned in <a class="dynamic-link" href="%s">%s %s</a>', 
                       $citation_url, 
                       $avail->{has_citation}, 

--- a/modules/EnsEMBL/Web/Configuration/Variation.pm
+++ b/modules/EnsEMBL/Web/Configuration/Variation.pm
@@ -78,7 +78,7 @@ sub populate_tree {
         phenotype EnsEMBL::Web::Component::Variation::Phenotype 
         genes     EnsEMBL::Web::Component::Variation::LocalGenes
     )],
-    { 'availability' => 'variation has_ega', 'concise' => 'Phenotype Data' }
+    { 'availability' => 'variation has_locations has_ega', 'concise' => 'Phenotype Data' }
   );
   
   $self->create_node('Populations', 'Sample information',


### PR DESCRIPTION
## Description

Minor fixes to hide phenotype entries which are associated with variants that no longer map to the genome. 

## Views affected

The Variation/Phenotype pages.
This cause an issue because the Phenotype page is made available, but when you click on it, it's empty (mainly because the page is looking at the variation_feature, in case a variant maps to several locations).

Here is an example on my sandbox:
http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/Variation/Explore?db=core;v=rs505922;vdb=variation
versus on the live website:
http://www.ensembl.org/Homo_sapiens/Variation/Explore?db=core;v=rs505922;vdb=variation

## Possible complications

We are going to cleanup the phenotype_feature table in e98 to avoid this kind of issue in the future.
