### PR TITLE
Make the display of the SV populations more generic and update the ti…

### DIFF
--- a/modules/EnsEMBL/Web/Component/StructuralVariation/PopulationFrequency.pm
+++ b/modules/EnsEMBL/Web/Component/StructuralVariation/PopulationFrequency.pm
@@ -76,7 +76,7 @@ sub add_table_columns {
     { key => 'pop_name', title => 'Population'                     , align => 'left', sort => 'none' },
     { key => 'pop_size', title => 'Size'                           , align => 'left', sort => 'none' },
     { key => 'a_freqs',  title => 'Allele type: frequency (count)' , align => 'left', sort => 'none' },
-    { key => 'freqs',    title => 'Global allele frequency (count)', align => 'left', sort => 'none' },
+    { key => 'freqs',    title => 'Non-reference frequency (count)', align => 'left', sort => 'none' },
   );
 
   return $table;
@@ -144,9 +144,10 @@ sub table_data {
       $group_member = 1;
     }
 
-    my $pop_name = (split(':',$svpf->name))[2];
-    my $pop_desc = $svpf->description;
-    my $pop_size = $svpf->size;
+    my @pop_parts = split(':',$svpf->name);
+    my $pop_name  = (@pop_parts > 2) ? $pop_parts[$#pop_parts] : $pop_parts[0].':<b>'.$pop_parts[1].'</b>';
+    my $pop_desc  = $svpf->description;
+    my $pop_size  = $svpf->size;
     my $global_freq = sprintf("%.4f",$svpf->frequency);
     my $global_allele_count = 0;
     my $freqs_by_SO_term = $svpf->frequencies_by_class_SO_term;


### PR DESCRIPTION
## Description

Display SV population which are not in the 1KG format (e.g. 1000GENOMES:phase_3:GBR).
e.g.:
- 1KG (ok) - population names are correctly truncated:
https://www.ensembl.org/Homo_sapiens/StructuralVariation/Evidence?sv=esv3817090
- Non 1KG (not ok) - population names are not displayed in the Population column:
https://www.ensembl.org/Homo_sapiens/StructuralVariation/Evidence?sv=esv1851110
## Views affected

#### StructuralVariation/Evidence
The display is fixed on my sandbox:
http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/StructuralVariation/Evidence?sv=esv1851110
