### PR TITLE
Fix saving of datatable hidden columns

### DIFF
--- a/htdocs/components/05_DataTable.js
+++ b/htdocs/components/05_DataTable.js
@@ -118,8 +118,9 @@ Ensembl.DataTable = {
         $('.dataTables_info, .dataTables_paginate, .dataTables_bottom', tableSettings.nTableWrapper)[tableSettings._iDisplayLength === -1 ? 'hide' : 'show']();
         
         var data          = this.data();
-        var defaultHidden = data.defaultHiddenColumns || [];
-        var hiddenCols    = $.map(tableSettings.aoColumns, function (c, j) { return c.bVisible ^ defaultHidden[j] ? null : j * (defaultHidden[j] ? -1 : 1); }).join(',');
+        var hiddenCols = tableSettings.aoColumns.reduce(function (accumulator, column, index) {
+          return !column.bVisible ? accumulator.concat(index) : accumulator;
+        }, []).join(','); // gets a string of comma-separated indices of hidden columns
         var sorting       = $.map(tableSettings.aaSorting, function (s) { return '"' + s.join(' ') + '"'; }).join(',');
         
         if (tableSettings._bInitComplete !== true) {

--- a/modules/EnsEMBL/Web/Document/Table.pm
+++ b/modules/EnsEMBL/Web/Document/Table.pm
@@ -326,7 +326,7 @@ sub data_table_config {
   my $default_hidden = $self->{'options'}{'hidden_columns'} ? $self->jsonify({ map { $_ => 1 } @$hidden_cols }) : '';
   my $config         = sprintf '<input type="hidden" name="code" value="%s" />', encode_entities($code);
   my $sort           = [];
-  
+
   foreach (@$sorting) {
     my ($col, $dir) = split / /;
     $col = $columns{$col} unless $col =~ /^\d+$/ && $col < $col_count;
@@ -336,8 +336,8 @@ sub data_table_config {
   if (scalar @$sort) {
     $config .= sprintf '<input type="hidden" name="aaSorting" value="%s" />', encode_entities($self->jsonify($sort));
   }
-  
-  $config .= sprintf '<input type="hidden" name="hiddenColumns" value="%s" />', encode_entities($self->jsonify($hidden_cols)) if scalar @$hidden_cols;
+
+  $config .= sprintf '<input type="hidden" name="hiddenColumns" value="%s" />', encode_entities($self->jsonify($hidden)) if scalar @$hidden;
   $config .= sprintf '<input type="hidden" name="defaultHiddenColumns" value="%s" />', encode_entities($default_hidden) if $default_hidden;
 
   foreach (keys %{$self->{'options'}{'data_table_config'}}) {

--- a/modules/EnsEMBL/Web/Document/Table.pm
+++ b/modules/EnsEMBL/Web/Document/Table.pm
@@ -323,7 +323,6 @@ sub data_table_config {
   my $sorting        = $record_data->{'sorting'} ?        from_json($record_data->{'sorting'})        : $self->{'options'}{'sorting'}        || [];
   my $hidden_cols    = [ keys %{{ map { $_ => 1 } @{$self->{'options'}{'hidden_columns'} || []}, map { $_->{'hidden'} ? $columns{$_->{'key'}} : () } @{$self->{'columns'}} }} ];
   my $hidden         = $record_data->{'hidden_columns'} ? from_json($record_data->{'hidden_columns'}) : $hidden_cols;
-  my $default_hidden = $self->{'options'}{'hidden_columns'} ? $self->jsonify({ map { $_ => 1 } @$hidden_cols }) : '';
   my $config         = sprintf '<input type="hidden" name="code" value="%s" />', encode_entities($code);
   my $sort           = [];
 
@@ -337,8 +336,9 @@ sub data_table_config {
     $config .= sprintf '<input type="hidden" name="aaSorting" value="%s" />', encode_entities($self->jsonify($sort));
   }
 
-  $config .= sprintf '<input type="hidden" name="hiddenColumns" value="%s" />', encode_entities($self->jsonify($hidden)) if scalar @$hidden;
-  $config .= sprintf '<input type="hidden" name="defaultHiddenColumns" value="%s" />', encode_entities($default_hidden) if $default_hidden;
+  if (scalar @$hidden) {
+    $config .= sprintf '<input type="hidden" name="hiddenColumns" value="%s" />', encode_entities($self->jsonify($hidden));
+  }
 
   foreach (keys %{$self->{'options'}{'data_table_config'}}) {
     my $option = $self->{'options'}{'data_table_config'}{$_};


### PR DESCRIPTION
## Description

Currently, if you change the columns of a data table that you want to view/hide, this configuration will be reset after a browser reload (see [example page in production](http://www.ensembl.org/Homo_sapiens/Gene/Matches?g=ENSG00000139618;r=13:32315474-32400266)). This got broken about a year ago (see, e.g. this configuration being correctly persisted for the transcript table on the [April 2018 archive site](http://apr2018.archive.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000139618;r=13:32315474-32400266))

There are two reasons why it is broken.

1) On the backend: [this pull request](https://github.com/Ensembl/ensembl-webcode/commit/e12769325ca37171366ac263d10baa5068727bf1) changed the variable used to pass hidden columns to the fronted for the one that was not using data persisted in the session (`hidden_cols` instead of `hidden`). There is no explanation for that change in the [description](https://github.com/Ensembl/ensembl-webcode/pull/649) of that PR. Reverting this change fixes the problem for the transcripts table.

2) On the frontend, there was an [old function](https://github.com/Ensembl/ensembl-webcode/blame/release/96/htdocs/components/05_DataTable.js#L122) for getting the list of hidden columns with logic that partially eludes me. That old function collected indices of hidden columns, but then multiplied the indices that also corresponded to default hidden columns by -1. These columns with negative indices were then saved, but after a browser refresh the data table could not match those negative indices to any of its columns, so it just showed all defaultHidden columns. This broke the VEP table. Rewriting that function to get rid of negative indices fixed that problem. 

## Views affected

Any views containing data tables, I expect.

You can check the working fix in the sandbox — for example on [this page](http://ves-hx2-76.ebi.ac.uk:8410/Homo_sapiens/Gene/Matches?g=ENSG00000139618;r=13:32315474-32400266).

## Possible complications

- I have no idea why the replaced old javascript function was designed to generate negative indices alongside positive ones. Don't know what fixing this might break.

- I also have no idea what the [PR](https://github.com/Ensembl/ensembl-webcode/pull/649) that changed what variable used for getting hidden values on the backend side was trying to fix.

## Related JIRA Issues
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-4991