### PR TITLE
Grey out the Phenotype page links when there is no phenotype associat…

### DIFF
--- a/modules/EnsEMBL/Web/Component/StructuralVariation/Explore.pm
+++ b/modules/EnsEMBL/Web/Component/StructuralVariation/Explore.pm
@@ -46,9 +46,9 @@ sub content {
     $gt_count = $avail->{'has_transcripts'};
   }
 
-  if ($avail->{'has_transcripts'} || $avail->{'has_phenotypes'}) {
+  if ($avail->{'has_phenotypes'}) {
     $pheno_url = $hub->url({'action' => 'Phenotype'});
-    $pheno_count = $avail->{'has_phenotypes'} if ($avail->{'has_phenotypes'});
+    $pheno_count = $avail->{'has_phenotypes'};
   }
 
   if ($avail->{'has_supporting_structural_variation'}) {

--- a/modules/EnsEMBL/Web/Configuration/StructuralVariation.pm
+++ b/modules/EnsEMBL/Web/Configuration/StructuralVariation.pm
@@ -64,7 +64,7 @@ sub populate_tree {
         phenotype EnsEMBL::Web::Component::StructuralVariation::Phenotype  
         genes     EnsEMBL::Web::Component::StructuralVariation::LocalGenes 
     )],
-    { 'availability' => 'has_phenotype', 'concise' => 'Phenotype Data' }
+    { 'availability' => 'has_phenotypes', 'concise' => 'Phenotype Data' }
   );
 }
 1;


### PR DESCRIPTION
…ed with the SV

## Description

Link to SV Phenotype page available for species without Phenotype associated to SVs.

## Views affected

Structural Variation portal (left hand side menu) and StructuralVariation/Explore page:
- My sandbox:
http://ves-hx2-76.ebi.ac.uk:5060/Mus_musculus/StructuralVariation/Explore?sv=esv680873
- Live site:
https://www.ensembl.org/Mus_musculus/StructuralVariation/Explore?sv=esv680873