### PR TITLE
Update LRG external links

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -235,7 +235,7 @@ Translation       = Peptide
 
 ## Used by more than one group
 EPMC_MED                    = http://europepmc.org/abstract/MED/###ID###
-LRG                         = http://www.lrg-sequence.org/LRG/###ID### 
+LRG                         = https://www.lrg-sequence.org/search/?query=###ID###
 MIM                         = http://www.omim.org/###ID###
 MIM_GENE                    = http://www.omim.org/###ID###
 MIM_MORBID                  = http://www.omim.org/###ID###
@@ -466,7 +466,7 @@ HET                      = http://www.ebi.ac.uk/msd-srv/chempdb/cgi-bin/cgi.pl?F
 HSSP                     = http://expasy.cbr.nrc.ca/cgi-bin/niceprot.pl?###ID###
 HUMAN_CONTIGVIEW         = /Homo_sapiens/contigview?contig=###ID###
 HUMAN_ORESTES            = http://ensembl.fugu-sg.org/perl/bioperldbview?format=GenBank;id=###ID###;biodb=HUMAN_ORESTES
-ENS_LRG_SEQUENCE            = http://www.lrg-sequence.org/LRG/LRG_###ID###
+ENS_LRG_SEQUENCE            = https://www.lrg-sequence.org/search/?query=LRG_###ID###
 ENS_GG_GENE                 = http://www.ensembl.org/Gallus_gallus/Gene/Summary?g=###ID###
 ENS_GG_TRANSCRIPT           = http://www.ensembl.org/Gallus_gallus/Transcript/Summary?t=###ID###
 ENS_GG_TRANSLATION          = http://www.ensembl.org/Gallus_gallus/Transcript/ProteinSummary?peptide=###ID###


### PR DESCRIPTION
## Description

Fix the LRG external links to point to the new URL on the (not so) new LRG website.

## Views affected

LRG portal, LRG track ZMenu.

Example of link: https://www.lrg-sequence.org/search/?query=LRG_1
