### PR TITLE
Fix external source link to the LRG website on the LRG summary panel

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -489,6 +489,7 @@ IMGT/LIGM_DB                = http://srs.ebi.ac.uk/srsbin/cgi-bin/wgetz?-e+[IMGT
 IXODES_MANUALANNOTATION     = 
 JAMBOREE                 = http://www.sanger.ac.uk/cgi-bin/Projects/X_tropicalis/search_cDNA_by_symbol_or_keyword.pl?source=all&symbol_clone_alias_key=gene+name&search=###ID###
 LOCUSLINK                = http://www.ncbi.nlm.nih.gov/LocusLink/LocRpt.cgi?l=###ID###
+LRG_URL                  = https://www.lrg-sequence.org
 MARKERSYMBOL                = http://www.informatics.jax.org/searches/accession_report.cgi?id=###ID###
 MEDLINE                     =
 MGI_ACCESSION            = http://www.informatics.jax.org/marker/###ID###

--- a/modules/EnsEMBL/Web/Component/LRG/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/LRG/Summary.pm
@@ -48,11 +48,13 @@ sub content {
   my $external_urls = $hub->species_defs->ENSEMBL_EXTERNAL_URLS;
   my $html;
   
+  my $lrg_url = $external_urls->{'LRG_URL'};
+
   if ($hub->action eq 'Genome' || !$object) {
     $html =
       '<p>LRG (Locus Reference Genomic) sequences provide a stable genomic DNA framework ' .
       'for reporting mutations with a permanent ID and core content that never changes. ' . 
-      'For more information, visit the <a href="http://www.lrg-sequence.org">LRG website</a>.</p>';
+      'For more information, visit the <a href="'.$lrg_url.'">LRG website</a>.</p>';
   } else {
     my $lrg         = $object->Obj;
     my $lrg_gene    = $hub->param('lrg');
@@ -66,8 +68,9 @@ sub content {
     my $slice       = $lrg->feature_Slice;
     my $source      = $genes[0]->source;
        $source      = 'LRG' if $source =~ /LRG/;
-    (my $source_url = $external_urls->{uc $source}) =~ s/\/###ID###//;
-    
+    my $source_url  = ($source eq 'LRG') ?  $lrg_url : $external_urls->{uc $source};
+       $source_url  =~ s/\/###ID###//;
+
     if (scalar(@hgnc_xrefs)) {
       my $hgnc = $hgnc_xrefs[0]->display_id;
       $description .= sprintf(


### PR DESCRIPTION
## Description

Add a new url for the LRG website in order to fix the source link on the LRG summary panel.
See JIRA ticket https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5098

## Views affected

#### LRG/Summary
Example on my sandbox: http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/LRG/Summary?lrg=LRG_60