### PR TITLE
[ENSWEB-5042] remove db param from url for Tools

### DIFF
--- a/modules/EnsEMBL/Web/Hub.pm
+++ b/modules/EnsEMBL/Web/Hub.pm
@@ -434,7 +434,8 @@ sub url {
   delete $pars{'v'}  if $params->{'vf'};
   delete $pars{'time'};
   delete $pars{'_'};
-
+  # db param not required for tools (as it breaks when accessing RID view from blast results with db=otherfeatures param which gets added from search results).
+  delete $pars{'db'} if $params->{'type'} eq 'Tools';
   # add the requested GET params to the query string
   foreach (keys %$params) {
     $_ =~ /^(__)?(species|type|action|function)?(.*)$/;


### PR DESCRIPTION
## Description

When you open a link from search result with url param db=otherfeatures and then go to Tools page, this param is carried across. It has no issues until a blast result link is clicked where db=core is needed.
So better to remove db param if accessing tools page which is not used in tools.

## Views affected
Only url change in Tools pages

## Possible complications

Nothing I am aware of.

## Merge conflicts

No

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5042
