### PR TITLE
Increase tooltip max width to prevent multiline bug

### DIFF
--- a/htdocs/components/15_ImageMap.js
+++ b/htdocs/components/15_ImageMap.js
@@ -359,11 +359,11 @@ Ensembl.Panel.ImageMap = Ensembl.Panel.Content.extend({
             tip = area.a.attrs.alt;
             
             if (!panel.elLk.helpTip) {
-              panel.elLk.helpTip = $('<div class="ui-tooltip helptip-bottom"><div class="ui-tooltip-content"></div></div>');
+              panel.elLk.helpTip = $('<div class="ui-tooltip helptip-top"><div class="ui-tooltip-content"></div></div>');
             }
             
             panel.elLk.helpTip.children().html(tip).end().appendTo('body').position({
-              of: { pageX: panel.imgOffset.left + area.l + 10, pageY: panel.imgOffset.top + area.t - 48, preventDefault: true }, // fake an event
+              of: { pageX: panel.imgOffset.left + area.l + 10 , pageY: panel.imgOffset.top + area.b + (area.b -area.t) - 15, preventDefault: true }, // fake an event
               my: 'center top'
             });
           }

--- a/htdocs/components/22_dynamic_content.css
+++ b/htdocs/components/22_dynamic_content.css
@@ -131,7 +131,7 @@ form.data_table_export { display: none; }
 img.helptip-icon                                   { vertical-align: middle; }
 
 div.ui-tooltip                                     { position: absolute; z-index: 999999; }
-div.ui-tooltip div.ui-tooltip-content              { position: relative; background-color: [[DARK_GREY]]; color: [[WHITE]]; padding: 8px; margin: 6px; line-height: 16px; border-radius: 4px; max-width: 300px; }
+div.ui-tooltip div.ui-tooltip-content              { position: relative; background-color: [[DARK_GREY]]; color: [[WHITE]]; padding: 8px; margin: 6px; line-height: 16px; border-radius: 4px; max-width: 400px; }
 div.ui-tooltip div.ui-tooltip-content p:last-child { margin-bottom: 0; }
 div.ui-tooltip div.ui-tooltip-content a            { color: inherit; }
 


### PR DESCRIPTION
# Description
Increased the max-width of the tooltip to prevent the species name getting displayed on multiple lines, creating a weird blinking effect of the tooltip.

## Views affected

http://test-plants.ensembl.org/Arabidopsis_thaliana/Location/Multi?db=core;r=1:10500-15500;r1=I:32986110-32996109:1;r2=KZ772744:980309-990308:1;s1=Theobroma_cacao;s2=Marchantia_polymorpha

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5084