### PR TITLE
Fix gene families link for non-vertebrates sites

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -114,6 +114,8 @@ our $SYSLOG_COMMAND                   = sub { warn "$_[0]\n"; };  # command/subr
 our $TIDY_USERDB_CONNECTIONS          = 1;      # Clear user/session db connections after request is finished
 our $SERVER_ERRORS_TO_LOGS            = 1;      # Send all server exception stack traces to logs and send a unique error Id on the browser
 our $ENSEMBL_OOB_LIMITS               = {};     # Child process out-of-bounds limits for live server tweaking
+
+our $GENE_FAMILY_ACTION               = 'Family'; # Used to build the link to gene families page
 ###############################################################################
 
 

--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -498,7 +498,7 @@ sub about_feature {
     
     my $protein_url = $hub->url({
       type   => 'Gene',
-      action => 'Family',
+      action => $SiteDefs::ENSEMBL_SITETYPE eq 'Ensembl' ? 'Family' : 'Gene_families',
       g      => $gene->stable_id
     });
 

--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -498,7 +498,7 @@ sub about_feature {
     
     my $protein_url = $hub->url({
       type   => 'Gene',
-      action => $SiteDefs::ENSEMBL_SITETYPE eq 'Ensembl' ? 'Family' : 'Gene_families',
+      action => $SiteDefs::GENE_FAMILY_ACTION,
       g      => $gene->stable_id
     });
 


### PR DESCRIPTION
## Description
For some genes, the "About this gene" section of gene summary contains a link to protein families.

![image](https://user-images.githubusercontent.com/6834224/60527759-c9986980-9cea-11e9-8c79-2fd7b6200b91.png)

This link is now generated according to the same rule for both vertebrates and non-vertebrates sites; but in fact the rule should be slightly different. As a result, on non-vertebrates pages the link leads to a page with an error:

![image](https://user-images.githubusercontent.com/6834224/60527802-e59c0b00-9cea-11e9-97d1-0d7f5a6b31f5.png)

## Views affected
Gene page (gene summary, "about this gene" section)

fix on local sandbox: http://ves-hx2-76.ebi.ac.uk:8410/Magnaporthe_oryzae/Gene/Summary?db=core;g=MGG_01236;r=2:2789925-2792654;t=MGG_01236T0

## Possible complications
This fix was tested on vertebrates and fungi sandboxes. Protists have the same url structure, so should be fixed with the change in this PR. I could not find genes with gene families for plants, bacteria, or metazoa.

GRCh37 plugin [does not seem to overwrite](https://github.com/Ensembl/ebi-plugins/blob/release/96/grch37/conf/SiteDefs.pm) the ENSEMBL_SITETYPE constant; so it shouldn't break.

## Alternative solutions
We could add a special constant in the SiteDefs file, which will contain the appropriate url fragment (Gene/Family vs Gene/Gene_families) for various sites, but that will involve more changes across various repositories; and I am not sure what to call this url fragment; it looks pretty random.

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5083
