### PR TITLE
Update OMIA phenotypes default url - e98

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -380,7 +380,7 @@ MP                          = http://purl.obolibrary.org/obo/###ID###
 NEXTGEN_POP                 = http://projects.ensembl.org/nextgen/
 OIVD                        = http://www.lovd.nl/###ID###
 OLS                         = http://www.ebi.ac.uk/ols/search?q=###ID###
-OMIA                        = http://omia.angis.org.au/###ID###/###TAX###/
+OMIA                        = https://omia.org/###ID###/###TAX###/
 OMIM                        = http://www.omim.org/###ID###
 ORDO                        = http://www.orpha.net/ORDO/###ID###
 ORPHANET                    = http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=###ID###


### PR DESCRIPTION
## Description

_Using one or more sentences, describe the proposed changes and the reason for making them._

Phenotypes are linked out to the original source. The OMIA source url has been updated in the variation db and requires also this update to the ini files.

## Views affected

_List the website view(s) that you know are affected by this change._
_If possible please provide a URL that shows the change. For Ensembl developers this could be your sandbox._
sandbox url: http://ves-hx2-76.ebi.ac.uk:6080/Gallus_gallus/Phenotype/Locations?ph=338
staging url: http://staging.ensembl.org/Gallus_gallus/Phenotype/Locations?ph=338
e97 url: http://www.ensembl.org/Gallus_gallus/Phenotype/Locations?ph=338

## Possible complications

_We appreciate this can be difficult but please highlight any views that you think might possibly be adversely affected by this change. For example a change to method in ApacheHandlers.pm has potential for widespread consequences._

NA

## Merge conflicts

_At certain stages of the release there is potential for many people to be working on the same modules. To avoid merge conflicts please confirm you have tested for this before submitting the pull request, eg by updating your feature branch and checking that the only changes being submitted are ones from you._

checked

## Related JIRA Issues (EBI developers only)

_Please provide the URL(s) for any JIRA issues related to this PR._
https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-2112