### PR TITLE
Update SV views to cope with new data source

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -352,10 +352,11 @@ DBSNP_HOME                  = http://www.ncbi.nlm.nih.gov/snp
 DBSNPPOP                    = http://www.ncbi.nlm.nih.gov/SNP/snp_viewTable.cgi?pop=###ID###
 DBSNPSS                     = http://www.ncbi.nlm.nih.gov/SNP/snp_ss.cgi?subsnp_id=###ID###
 DBSNPSSID                   = http://www.ncbi.nlm.nih.gov/projects/SNP/snp_viewTable.cgi?handle=###ID###
+DBVAR                       = https://www.ncbi.nlm.nih.gov/dbvar
 DDG2P                       = https://decipher.sanger.ac.uk/ddd#ddgenes
 DECIPHER                    = https://decipher.sanger.ac.uk/patient/###ID###
 DECIPHER_BROWSER            = https://decipher.sanger.ac.uk/browser#q/###ID###
-DGVA                        = http://www.ebi.ac.uk/dgva/
+DGVA                        = https://www.ebi.ac.uk/dgva/
 DOID                        = http://purl.obolibrary.org/obo/###ID###
 EFO                         = https://www.ebi.ac.uk/ols/ontologies/efo/terms?short_form=###ID###
 EGA_SEARCH                  = http://www.ebi.ac.uk/ebisearch/search.ebi?db=ega&query=###ID###

--- a/modules/EnsEMBL/Web/Component/StructuralVariation/Phenotype.pm
+++ b/modules/EnsEMBL/Web/Component/StructuralVariation/Phenotype.pm
@@ -84,7 +84,8 @@ sub table_data {
   foreach my $pf (@$sv_pf) {
     my $phe = $pf->phenotype->description;
     if (!exists $phenotypes{$phe}) {
-      $phenotypes{$phe} = { disease => qq{<b>$phe</b>} };
+      my $phe_url = $hub->url({ type => 'Phenotype', action => 'Locations', ph => $pf->phenotype->dbID, name => $phe });
+      $phenotypes{$phe} = { disease => qq{<a href="$phe_url" title="View associate loci"><b>$phe</b></a>} };
     }
 
     # Ontology data
@@ -127,8 +128,9 @@ sub table_data {
           $phenotypes{$phe}{s_evidence} .= ', '.$sva->object_id;
         } 
         else {
+          my $phe_url = $hub->url({ type => 'Phenotype', action => 'Locations', ph => $sva->phenotype->dbID, name => $phe });
           $phenotypes{$phe} = {
-            disease    => qq{<b>$phe</b>},
+            disease    => qq{<a href="$phe_url" title="View associate loci"><b>$phe</b></a>},
             s_evidence => $sva->object_id
           };
         }

--- a/modules/EnsEMBL/Web/Component/StructuralVariation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/StructuralVariation/Summary.pm
@@ -145,8 +145,10 @@ sub get_source {
   my $source_link = $source;
   
   if ($source eq 'DGVa') {
-    $source_link = $hub->get_ExtURL_link($source, 'DGVA', $source);
-  } elsif ($source =~ /affy/i ) {
+    $source_link = $hub->get_ExtURL_link($source, uc($source), $source);
+  } elsif ($source eq 'dbVar') {
+    $source_link = $hub->get_ExtURL_link($source, uc($source), $source);
+  } elsif ($source =~ /affy/i) {
     $source_link = $hub->get_ExtURL_link($source, 'AFFYMETRIX', $source);
   } elsif ($source =~ /illumina/i) {
     $source_link = $hub->get_ExtURL_link($source, 'ILLUMINA', $source);


### PR DESCRIPTION
## Description

- Add URL to the new SV data source for human (dbVar)
- Add phenotype links in the SV phenotype page, like we did for the Variation phenotype page

## Views affected
- StructuralVariation/Summary panel (dbVar source link)
- StructuralVariation/Phenotype page (phenotype links)

Example on my sandbox with `nsv1397926`:
http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/StructuralVariation/Phenotype?sv=nsv1397926
