### PR TITLE
Improve zmenu for protein align features

### DIFF
--- a/modules/EnsEMBL/Web/ZMenu/Genome.pm
+++ b/modules/EnsEMBL/Web/ZMenu/Genome.pm
@@ -92,16 +92,15 @@ sub content {
   my $cigar_string = $features->[0] ? $features->[0]->cigar_string : undef;
 
   if($align_type and $cigar_string){
-    my $alength = new Bio::EnsEMBL::BaseAlignFeature( -align_type => $align_type, -cigar_string => $cigar_string)->alignment_length();
-    if($alength){
-      $self->add_entry({
-        type    => 'Alignment length',
-        'label' => $alength
-      });
-    }
+    my $alength;
+    eval{ $alength = new Bio::EnsEMBL::BaseAlignFeature( -align_type => $align_type, -cigar_string => $cigar_string)->alignment_length() };
+    $self->add_entry({
+      type    => 'Alignment length',
+      'label' => $alength ? $alength : '-'
+    });
   }
 
-  my $percent_id = $features->[0] ? $features->[0]->percent_id : undef;
+  my $percent_id = $features->[0] ? $features->[0]->percent_id : '-';
   
   $self->add_entry({
     type    => '%id',

--- a/modules/EnsEMBL/Web/ZMenu/Genome.pm
+++ b/modules/EnsEMBL/Web/ZMenu/Genome.pm
@@ -76,8 +76,8 @@ sub content {
     });
   }
 
-  $self->add_entry({
-    'label'   => 'View all hits',
+    $self->add_entry({
+    'label'   => 'View all locations',
     'link'    => $hub->url({
       'type'    => 'Location',
       'action'  => 'Genome',
@@ -86,6 +86,26 @@ sub content {
       'db'      => $db,
       '__clear' => 1
     })
+  });
+
+  my $align_type   = $features->[0] ? $features->[0]->align_type : undef;
+  my $cigar_string = $features->[0] ? $features->[0]->cigar_string : undef;
+
+  if($align_type and $cigar_string){
+    my $alength = new Bio::EnsEMBL::BaseAlignFeature( -align_type => $align_type, -cigar_string => $cigar_string)->alignment_length();
+    if($alength){
+      $self->add_entry({
+        type    => 'Alignment length',
+        'label' => $alength
+      });
+    }
+  }
+
+  my $percent_id = $features->[0] ? $features->[0]->percent_id : undef;
+  
+  $self->add_entry({
+    type    => '%id',
+    'label' => $percent_id
   });
 
   my @attrs;


### PR DESCRIPTION
## Description

Added `Alignment length` and `%id` to the zmenu of protein align features.



## Views affected
http://ves-hx2-76.ebi.ac.uk:42229/Homo_sapiens/Location/View?r=17:63992802-64038237

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-2615
