### PR TITLE
Fix region highlighting after removal of a track

### DIFF
--- a/htdocs/components/15_ImageMap.js
+++ b/htdocs/components/15_ImageMap.js
@@ -951,7 +951,7 @@ Ensembl.Panel.ImageMap = Ensembl.Panel.Content.extend({
     this.removeShare();
     Ensembl.EventManager.trigger('removeShare')
 
-    Object.keys(this.highlightRegions) > 0 && this.highlightImage(this.imageNumber, 0);
+    Object.keys(this.highlightRegions).length > 0 && this.highlightImage(this.imageNumber, 0);
     this.markLocation(Ensembl.markedLocation);
 
     return true;


### PR DESCRIPTION
## Description
**Bug:** While viewing a region, if a track is switched off, the highlighted region does not get updated.

**Steps to reproduce:** 
- visit http://www.ensembl.org/Homo_sapiens/Location/View?r=17%3A63992802-64038237
- make sure all tracks in the bottom image are turned on
- turn off a track that takes up a lot of vertical space (to better see the results); for example — Genes (Comprehensive set...)
- observe that the red box marking the region now extends past the bottom border of the image:

![image](https://user-images.githubusercontent.com/6834224/63096003-92151200-bf64-11e9-8b63-93c50a682ad0.png)

**Cause of the bug:** syntax error, combined with excessive javascript leniency and crazy type conversions. Apparently, an array can be compared with a number, and `[0] > 0 === false` (but `[1] > 0 === true`). It is the moment when one really wishes for typescript.

## Views affected
Location view (`/:species/Location/View?r=something`)

## Related JIRA Issues (EBI developers only)
Related to a comment in ENSWEB-4339.