### PR TITLE
Fix Ensembl version for Gene Summary

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/GeneSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GeneSummary.pm
@@ -166,7 +166,9 @@ sub content {
   # add a row to the table
   $table->add_row('LRG', $lrg_html) if $lrg_html;
 
-  $table->add_row('Ensembl version', $object->stable_id_version);
+  if ($object->version) {
+    $table->add_row('Ensembl version', $object->stable_id_version);
+  }
 
   ## Link to another assembly, e.g. previous archive
   my $current_assembly = $hub->species_defs->ASSEMBLY_VERSION;

--- a/modules/EnsEMBL/Web/Component/Gene/GeneSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GeneSummary.pm
@@ -166,7 +166,7 @@ sub content {
   # add a row to the table
   $table->add_row('LRG', $lrg_html) if $lrg_html;
 
-  $table->add_row('Ensembl version', $object->stable_id.'.'.$object->version);
+  $table->add_row('Ensembl version', $object->stable_id_version);
 
   ## Link to another assembly, e.g. previous archive
   my $current_assembly = $hub->species_defs->ASSEMBLY_VERSION;

--- a/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
@@ -84,7 +84,7 @@ sub content {
     $table->add_row('Incomplete CDS', sprintf('<span class="ts_flag">%s</span>',$self->get_CDS_text($incomplete)));
   }
 
-  $table->add_row('Version', $object->stable_id.'.'.$object->version);
+  $table->add_row('Version', $object->stable_id_version);
 
   ## add some Vega info
   if ($db eq 'vega') {

--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -501,6 +501,7 @@ sub caption {
 sub gene                        { return $_[0]->Obj;             }
 sub type_name                   { return $_[0]->species_defs->translate('Gene'); }
 sub stable_id                   { return $_[0]->Obj->stable_id;  }
+sub stable_id_version           { return $_[0]->Obj->stable_id_version;  }
 sub feature_type                { return $_[0]->Obj->type;       }
 sub source                      { return $_[0]->Obj->source;     }
 sub version                     { return $_[0]->Obj->version;    }

--- a/modules/EnsEMBL/Web/Object/Transcript.pm
+++ b/modules/EnsEMBL/Web/Object/Transcript.pm
@@ -379,6 +379,7 @@ sub type_name {
 sub transcript             { return $_[0]->Obj; }
 sub source                 { return $_[0]->gene ? $_[0]->gene->source : undef; }
 sub stable_id              { return $_[0]->Obj->stable_id;  }
+sub stable_id_version      { return $_[0]->Obj->stable_id_version;  }
 sub feature_type           { return $_[0]->Obj->type;       }
 sub version                { return $_[0]->Obj->version;    }
 sub logic_name             { return $_[0]->gene ? $_[0]->gene->analysis->logic_name : $_[0]->Obj->analysis->logic_name; }


### PR DESCRIPTION
## Description
**Bug:** Currently, GeneSummary module expects a gene to always have a version number, which results in this Ensembl stable id for Saccharomyces (notice the dot in the end):

![image](https://user-images.githubusercontent.com/6834224/63113672-f0ed8200-bf8a-11e9-801f-be66199f7625.png)

Currently, some of our components have code to generate the versioned stable id:

![image](https://user-images.githubusercontent.com/6834224/63113784-30b46980-bf8b-11e9-9ada-492c2158ae98.png)

, although this functionality already exists in the Perl api of the objects that we are using:

![image](https://user-images.githubusercontent.com/6834224/63113798-3b6efe80-bf8b-11e9-830d-bed51d7076a1.png)

This pull requests updates the code to rely on the parent objects to return the correct versioned stable id value. Also, hiding the Ensembl version field in Gene summary if Ensembl stable id does not have a version (as is done on Ensembl Genomes sites, e.g.: http://fungi.ensembl.org/Saccharomyces_cerevisiae/Gene/Summary?g=YDL168W;r=IV:159604-160764;t=YDL168W) 

**Note:** Shared.pm component has its own code to output stable id version of genes, transcripts or translations. I left it untouched.

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5204