### PR TITLE
Fix SV- track ZMenu not refreshing - ENSWEB 5254

### DIFF
--- a/modules/EnsEMBL/Web/Document/Element/Acknowledgements.pm
+++ b/modules/EnsEMBL/Web/Document/Element/Acknowledgements.pm
@@ -70,7 +70,7 @@ sub survey_box {
   my $hub  = $self->hub;
   ## Temporary ad for survey
   my $html = '';
-  my $show_survey = 1;
+  my $show_survey = 0;
   my $is_relevant_page = ($hub->type eq 'Gene' || $hub->type eq 'Transcript' || $hub->type eq 'Variation');
 
   ## Only show it to returning visitors who haven't clicked on the button

--- a/modules/EnsEMBL/Web/ZMenu/StructuralVariation.pm
+++ b/modules/EnsEMBL/Web/ZMenu/StructuralVariation.pm
@@ -140,7 +140,7 @@ sub feature_content {
     }
     elsif ($source =~ /DECIPHER/i) {
       my $sv_samples = $variation->get_all_StructuralVariationSamples; 
-      my $individual = (scalar(@$sv_samples)) ? $sv_samples->[0]->individual->name : '';
+      my $individual = (scalar(@$sv_samples)) ? $sv_samples->[0]->strain->name : '';
       my $external_url = $hub->get_ExtURL_link("View in $source", 'DECIPHER', { ID => $individual });
       $self->add_entry({
         label_html => $external_url


### PR DESCRIPTION
## Description
Fixed the issue with the menu not displaying the proper data.

Bio::EnsEMBL::Variation::StructuralVariationSample->individual was deprecated and removed in the following commit which caused this issue:
https://github.com/Ensembl/ensembl-variation/commit/b83934394c3c5b4bc252031576b7eeed1eb91336#diff-94790d4b956c63b792bb0639379da20eL233

## Views affected
Broken:
http://www.ensembl.org/Homo_sapiens/Location/View?r=12:118925-165410;db=core

Fixed:
http://debug.ensembl.org/Homo_sapiens/Location/View?r=12:118925-165410;db=core


## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5254#