### PR TITLE
Show 'Download family alignment' button conditionally, using SiteDefs

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -116,6 +116,7 @@ our $SERVER_ERRORS_TO_LOGS            = 1;      # Send all server exception stac
 our $ENSEMBL_OOB_LIMITS               = {};     # Child process out-of-bounds limits for live server tweaking
 
 our $GENE_FAMILY_ACTION               = 'Family'; # Used to build the link to gene families page
+our $FAMILY_ALIGNMENTS_DOWNLOADABLE   = 1; # Indicates whether sequence alignments are available
 ###############################################################################
 
 

--- a/modules/EnsEMBL/Web/Component/Gene/FamilyProteins.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/FamilyProteins.pm
@@ -238,6 +238,8 @@ sub get_export_data {
 }
 
 sub buttons {
+  return unless $SiteDefs::FAMILY_ALIGNMENTS_DOWNLOADABLE;
+
   my $self    = shift;
   my $hub     = $self->hub;
   my $members = $hub->param('members');


### PR DESCRIPTION
## Description
The Family proteins page for fungi shows "Download family alignment" button:

![image](https://user-images.githubusercontent.com/6834224/64166606-57a1e500-ce3f-11e9-9860-a4909fbc2bc4.png)

However, the actual attempt to download family alignment results in an error:

![image](https://user-images.githubusercontent.com/6834224/64166675-77390d80-ce3f-11e9-936c-1cb68bed759c.png)

The reason for this is that we do not provide sequence alignments for non-vertebrates.

## Views affected
Family proteins (e.g., for fungi, http://fungi.ensembl.org/Multi/Family/Details?fm=MF_00505; for vertebrates: http://www.ensembl.org/Multi/Family/Details?fm=PTHR11289_SF0)

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5255