### PR TITLE
Update regex that guesses species from query in Psychic

### DIFF
--- a/modules/EnsEMBL/Web/Controller/Psychic.pm
+++ b/modules/EnsEMBL/Web/Controller/Psychic.pm
@@ -98,7 +98,7 @@ sub psychic {
   #if there is a species at the beginning of the query term then make a note in case we trying to jump to another location
   my ($query_species, $query_without_species);
   foreach my $sp (sort keys %sp_hash) {
-    if ( $query =~ /^\Q$sp\E\b/) {
+    if ( $query =~ /^\Q$sp\E\s/) {
       ($query_without_species = $query) =~ s/\Q$sp\E//;
       $query_without_species =~ s/^ //;
       $query_species = $sp;

--- a/modules/EnsEMBL/Web/Controller/Psychic.pm
+++ b/modules/EnsEMBL/Web/Controller/Psychic.pm
@@ -98,7 +98,7 @@ sub psychic {
   #if there is a species at the beginning of the query term then make a note in case we trying to jump to another location
   my ($query_species, $query_without_species);
   foreach my $sp (sort keys %sp_hash) {
-    if ( $query =~ /^\Q$sp\E/) {
+    if ( $query =~ /^\Q$sp\E\b/) {
       ($query_without_species = $query) =~ s/\Q$sp\E//;
       $query_without_species =~ s/^ //;
       $query_species = $sp;


### PR DESCRIPTION
## Description
Fixes bug that can be reproduced by the following steps:
- go to home page of ensembl site
- from the dropdown box (in the centre of the screen), select a species (doesn't matter which)
- type "amelogenin" in the search box below
Observe that the search results come for panda (because the word "amelogenin" starts with the substring "amel", which is the short code for panda).

One possible solution is to update the regex in the Psychic module that assumes that if the beginning of a query matches any species present in a species hash, then it must be a query regarding this species. The updated regex will assume that if there is a species name in the query, it will be separated from the actual query by a space.

## Views affected
Search page.

## Possible complications
Don't know

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5134