### PR TITLE
Update variation meta key format for 'variation_source.vcf'

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
@@ -120,8 +120,8 @@ sub render {
     my $sp_dir    = $sp->{'dir'};
     my $sp_var    = $sp_dir. '_variation';
     my $databases = $hub->species_defs->get_config(ucfirst($sp_dir), 'databases');
-    my $variation_source_vcf  = $databases->{'DATABASE_VARIATION'}->{'meta_info'}->{0}->{'variation.source.vcf'}->[0];
-
+    my $variation_source_vcf  = $databases->{'DATABASE_VARIATION'}->{'meta_info'}->{0}->{'variation_source.vcf'}->[0];
+    
     push @$rows, {
       fave    => $sp->{'favourite'} ? 'Y' : '',
       species => sprintf('<b><a href="/%s/">%s</a></b><br /><i>%s</i>', $sp_url, $sp->{'common_name'}, $sp->{'sci_name'}),


### PR DESCRIPTION
## Description

This PR is related to the changes made in the following PR: https://github.com/Ensembl/ensembl-webcode/pull/699
The meta key `variation.source.vcf` has been renamed to `variation_source.vcf` for this release (98).

## Views affected
http://ves-hx2-76.ebi.ac.uk:42228/info/data/ftp/index.html

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5149
