### PR TITLE
Fix/data table sorting

### DIFF
--- a/modules/EnsEMBL/Web/Component/Transcript/DomainGenes.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/DomainGenes.pm
@@ -98,12 +98,15 @@ sub content {
     { key => 'desc', title => 'Description (if known)', width => '55%', align => 'left' }
   );
   
+  my $row_index = -1;
   foreach my $gene (sort { $object->seq_region_sort($a->seq_region_name, $b->seq_region_name) || $a->seq_region_start <=> $b->seq_region_start } @$genes) {
+    # the result of the sorting is the same as sorting by Genome Location column in the data table on the client; so we want to preserve this sorting order in a data attribute of the 'loc' column
+    $row_index += 1;
     my $row       = {};
     my $xref_id   = $gene->display_xref ? $gene->display_xref->display_id : '-';
     my $stable_id = $gene->stable_id;
     
-    $row->{'id'} = sprintf '<a href="%s">%s</a>', $hub->url({ type => 'Gene', action => 'Summary', g => $stable_id }), $stable_id, $xref_id;
+    $row->{'id'} = sprintf '<a data-order="%s" href="%s">%s</a>', $stable_id, $hub->url({ type => 'Gene', action => 'Summary', g => $stable_id }), $stable_id;
     $row->{'name'} = $xref_id;
     my $readable_location = sprintf(
       '%s: %s',
@@ -111,7 +114,9 @@ sub content {
       $gene->start
     );
     
-    $row->{'loc'}= sprintf '<a href="%s">%s</a>', $hub->url({ type => 'Location', action => 'View', g => $stable_id, __clear => 1}), $readable_location;
+    my $url_for_gene_location = $hub->url({ type => 'Location', action => 'View', g => $stable_id, __clear => 1});
+    my $gene_location_order_number = sprintf("%05d", $row_index); # pad index with up to 4 zeros to enable correct ordering by DataTable based on string comparison
+    $row->{'loc'}= sprintf '<a data-order="%s" href="%s">%s</a>', $gene_location_order_number, $url_for_gene_location, $readable_location;
     
     my %description_by_type = ( bacterial_contaminant => 'Probable bacterial contaminant' );
     

--- a/modules/EnsEMBL/Web/Component/Transcript/DomainGenes.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/DomainGenes.pm
@@ -109,9 +109,10 @@ sub content {
     $row->{'id'} = sprintf '<a data-order="%s" href="%s">%s</a>', $stable_id, $hub->url({ type => 'Gene', action => 'Summary', g => $stable_id }), $stable_id;
     $row->{'name'} = $xref_id;
     my $readable_location = sprintf(
-      '%s: %s',
+      '%s:%s-%s',
       $self->neat_sr_name($gene->slice->coord_system->name, $gene->slice->seq_region_name),
-      $gene->start
+      $gene->start,
+      $gene->end
     );
     
     my $url_for_gene_location = $hub->url({ type => 'Location', action => 'View', g => $stable_id, __clear => 1});


### PR DESCRIPTION
## Description
Fix for incorrect data table ordering.

**Steps to reproduce the bug**
- visit the [Transcript/Domain/Genes page for mouse](http://www.ensembl.org/Mus_musculus/Transcript/Domains/Genes?db=core;domain=IPR026271;g=ENSMUSG00000028591;r=4:100000001-150000000;t=ENSMUST00000030326)
- notice the large data table in the bottom of the page
- notice that the second column (Genome Location) is sortable
- try sorting this column
- notice that the cells in this column get sorted in an irregular way
- notice too that sorting of the cells in this column yields the same result as if the sorting was done using the first column (Gene)

**Cause of the bug**
During initialisation, the dataTable library gets data from the table by simply reading the contents of each cell. In the case, the contents of the second column of the table are links that look as follows:

```
<a href="/Mus_musculus/Location/View?g=ENSMUSG00000079423">Chromosome 5: 95510758</a>
```

When we try to order rows by values of the second column, the dataTable library performs string comparison of these html strings, which start differing at the stable id parameter; and so orders them according to stable ids.

**Solution**
Consists of two steps:
1) use the `data-order` attribute of the `td` element to define the data by that will be used for ordering table rows
2) since the value of the `data-order` attribute is a string, pad it with enough zeroes to ensure correct comparison (e.g. 2 becomes `00002` and is placed before `00010`, whereas otherwise string `2` would have been placed after string `10`)

## Views affected
`/:species/Transcript/Domains/Genes`

[Example in sandbox](http://ves-hx2-76.ebi.ac.uk:8410/Mus_musculus/Transcript/Domains/Genes?db=core;domain=IPR026271;g=ENSMUSG00000028591;r=4:100000001-150000000;t=ENSMUST00000030326)

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5292