### PR TITLE
Add sticky headers to DataTables

### DIFF
--- a/htdocs/components/05_DataTable.js
+++ b/htdocs/components/05_DataTable.js
@@ -538,6 +538,7 @@ function StickyHeader (table) {
   this.scrollHandler = this.syncHeadScroll.bind(this);
 
   this.observeBody();
+  this.handleWindowResize();
 };
 
 StickyHeader.prototype.constructor = StickyHeader;

--- a/htdocs/components/05_DataTable.js
+++ b/htdocs/components/05_DataTable.js
@@ -538,7 +538,7 @@ function StickyHeader (table) {
   this.scrollHandler = this.syncHeadScroll.bind(this);
 
   this.observeBody();
-}
+};
 
 StickyHeader.prototype.constructor = StickyHeader;
 
@@ -552,14 +552,27 @@ StickyHeader.prototype.observeBody = function () {
       }
     }.bind(this));
   }.bind(this));
-}
+};
+
+StickyHeader.prototype.handleWindowResize = function () {
+  window.addEventListener('resize', function () {
+    window.requestAnimationFrame(function () {
+      if (this.shouldStickHead()) {
+        this.unstickHead();
+        this.stickHead();
+      } else {
+        this.unstickHead();
+      }
+    }.bind(this));
+  }.bind(this));
+};
 
 StickyHeader.prototype.shouldStickHead = function () {
   var tableBodyBoundingRect = this.tableBody.getBoundingClientRect();
   var tableBodyTop = tableBodyBoundingRect.top;
   var tableBodyBottom = tableBodyBoundingRect.bottom;
   return tableBodyTop < 0 && tableBodyBottom - this.tableHead.offsetHeight > 0;
-}
+};
 
 StickyHeader.prototype.buildStickyHeaderContainer = function () {
   var container = document.createElement('div');
@@ -570,7 +583,7 @@ StickyHeader.prototype.buildStickyHeaderContainer = function () {
   container.style.width = wrapperDimensions.width;
   container.style.overflow = 'hidden';
   return container;
-}
+};
 
 StickyHeader.prototype.getDimensionsForStickyHeaderContainer = function () {
   // sometimes a wide table can be placed inside a horizontally scrollable container,
@@ -595,7 +608,7 @@ StickyHeader.prototype.getDimensionsForStickyHeaderContainer = function () {
     left: refetenceRect.left + 'px',
     width: refetenceRect.width + 'px'
   }
-}
+};
 
 StickyHeader.prototype.stickHead = function () {
   if (this.isHeaderStuck) return;
@@ -620,7 +633,7 @@ StickyHeader.prototype.stickHead = function () {
   
   this.handleTableScroll();
   this.isHeaderStuck = true;
-}
+};
 
 StickyHeader.prototype.handleTableScroll = function () {
   if (!this.scrollableWrapper) {
@@ -628,13 +641,13 @@ StickyHeader.prototype.handleTableScroll = function () {
   }
   this.syncHeadScroll();
   this.scrollableWrapper.addEventListener('scroll', this.scrollHandler);
-}
+};
 
 StickyHeader.prototype.syncHeadScroll = function () {
   var tableParent = this.table.parentElement;
   var offsetLeft = tableParent.scrollLeft;
   this.container.scrollLeft = offsetLeft;
-}
+};
 
 StickyHeader.prototype.setColumnWidths = function () {
   var headColumns = Array.prototype.slice.call(this.tableHead.querySelectorAll('th'));
@@ -652,7 +665,7 @@ StickyHeader.prototype.setColumnWidths = function () {
     });
     this.areColumnWidthsSet = true;
   }
-}
+};
 
 StickyHeader.prototype.unsetColumnWidths = function () {
   if (!this.areColumnWidthsSet) return;
@@ -663,7 +676,7 @@ StickyHeader.prototype.unsetColumnWidths = function () {
     headColumn.style.removeProperty('width');
   });
   this.areColumnWidthsSet = false;
-}
+};
 
 
 StickyHeader.prototype.unstickHead = function () {
@@ -681,4 +694,4 @@ StickyHeader.prototype.unstickHead = function () {
     var tableParent = this.table.parentElement;
     tableParent.removeEventListener('scroll', this.scrollHandler);
   }
-}
+};

--- a/htdocs/components/05_DataTable.js
+++ b/htdocs/components/05_DataTable.js
@@ -516,7 +516,7 @@ Ensembl.DataTable = {
     filters = null;
   },
 
-  makeHeaderSticky(table) {
+  makeHeaderSticky: function (table) {
     if (!table || this.headerIsSticky) {
       return;
     }
@@ -561,14 +561,22 @@ StickyHeader.prototype.shouldStickHead = function () {
 
 StickyHeader.prototype.buildStickyHeaderContainer = function () {
   var container = document.createElement('div');
-  var wrapper = document.querySelector('.dataTables_wrapper');
-  var wrapperBoundingRect = wrapper.getBoundingClientRect();
+  var wrapperDimensions = this.getDimensionsForStickyHeaderContainer();
   container.style.position = 'fixed';
   container.style.top = '0';
-  container.style.left = wrapperBoundingRect.left + 'px';
-  container.style.width = wrapperBoundingRect.width + 'px';
+  container.style.left = wrapperDimensions.left;
+  container.style.width = wrapperDimensions.width;
   container.style.overflow = 'hidden';
   return container;
+}
+
+StickyHeader.prototype.getDimensionsForStickyHeaderContainer = function () {
+  var wrapper = $(this.table).parent('div')[0];
+  var wrapperBoundingRect = wrapper.getBoundingClientRect();
+  return {
+    left: wrapperBoundingRect.left + 'px',
+    width: wrapperBoundingRect.width + 'px'
+  }
 }
 
 StickyHeader.prototype.stickHead = function () {
@@ -612,9 +620,9 @@ StickyHeader.prototype.syncHeadScroll = function () {
 StickyHeader.prototype.setColumnWidths = function () {
   var headColumns = Array.prototype.slice.call(this.tableHead.querySelectorAll('th'));
   var referenceColumns = Array.prototype.slice.call(this.tweenTableHead.querySelectorAll('th'));
-  var shouldAddWidths = headColumns.every((element) => !element.style.width);
+  var shouldAddWidths = headColumns.every(function (element) { return !element.style.width });
   if (shouldAddWidths) {
-    headColumns.forEach((headColumn, index) => {
+    headColumns.forEach(function (headColumn, index) {
       var column = referenceColumns[index];
       var columnWidth = column.offsetWidth;
       var computedStyles = window.getComputedStyle(column);
@@ -630,7 +638,7 @@ StickyHeader.prototype.setColumnWidths = function () {
 StickyHeader.prototype.unsetColumnWidths = function () {
   if (!this.areColumnWidthsSet) return;
   var headColumns = Array.prototype.slice.call(this.tableHead.querySelectorAll('th'));
-  headColumns.forEach((headColumn) => {
+  headColumns.forEach(function (headColumn) {
     headColumn.style.removeProperty('box-sizing');
     headColumn.style.removeProperty('display');
     headColumn.style.removeProperty('width');

--- a/htdocs/components/85_spreadsheet_table.css
+++ b/htdocs/components/85_spreadsheet_table.css
@@ -147,6 +147,7 @@ tr.row-sub td:first-child { text-indent:24px; }
 
 .new_table { border: 1px [[PALE_GREY]] solid; margin: 0 0 16px; }
 .new_table table    { table-layout: fixed;  width: 100%; border-spacing: 0; }
+.new_table > table { position: sticky; top: 0; }
 .new_table th { cursor: pointer; padding: 2px 20px 2px 4px; background-color: [[PALE_GREY]]; line-height: 16px; }
 .new_table tbody tr { background-color: [[WHITE]]; }
 .new_table tbody tr:nth-child(odd) { background-color: [[LIGHT_GREY]]; }

--- a/modules/EnsEMBL/Web/Component/VariationTable.pm
+++ b/modules/EnsEMBL/Web/Component/VariationTable.pm
@@ -150,7 +150,7 @@ sub content {
     my $vf_count = $self->_count_variation_features($slice);
     my $warning_content  = "There are ".$self->thousandify($vf_count)." variants for this $object_type, which is too many to display in this page, so <b>only exonic variants</b> are displayed.";
        $warning_content .= " Please use <a href=\"$biomart_link\">BioMart</a> to extract all data." if ($biomart_link ne '');
-    $html .= $self->_warning( "Too many data to display", $warning_content);
+    $html .= $self->_warning( "Too much data to display", $warning_content);
 
     $only_exonic = 1;
   }


### PR DESCRIPTION
## Description
1. Add sticky headers for data tables. Data tables are wrapped in all sorts of wrappers that prevent use of a simple pure CSS solution for sticky headers; so the headers were made sticky using javascript. When the table that is higher than the window height is scrolled past the top border of the screen, the top row of column headings will still be visible at the top of the screen to make it easier to navigate the columns of the table.
2. Add sticky headers for new tables. This was done purely with CSS (`position: sticky; top: 0`). I tested that on a gene variant table, where the sticky header works fine. Won't work in browsers that do not support this CSS rule (e.g. in IE11).

## Views affected
- Any views containing data tables.
E.g.: http://ves-hx2-76.ebi.ac.uk:8410/Homo_sapiens/Gene/Phenotype?db=core;g=ENSG00000139618;r=13:32315086-32400266

- Views containing new tables
E.g. BRCA2 variant table: http://ves-hx2-76.ebi.ac.uk:8410/Homo_sapiens/Gene/Variation_Gene/Table?db=core;g=ENSG00000139618;r=13:32315086-32400266

## Possible complications
Can't dare to imagine. Data tables can break in unexpected ways in unexpected places. From what I've tested, though, they look fine. Sticky headers in data tables (i.e. implemented with javascript rather than CSS) even work fine in IE11.

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5052