### PR TITLE
Hide strains from other species in the orthologues tables

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -90,11 +90,6 @@ sub content {
       delete $not_seen{lc $_};
     }
 
-    if($self->is_strain && $species_defs->get_config($_, 'RELATED_TAXON') != $species_defs->RELATED_TAXON) {
-      delete $not_seen{$_};
-      delete $not_seen{lc $_};
-    }
-
     #do not show strain species on main species view
     if (!$self->is_strain && $species_defs->get_config($_, 'IS_STRAIN_OF')) {
       delete $not_seen{$_};

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -90,6 +90,11 @@ sub content {
       delete $not_seen{lc $_};
     }
 
+    if($self->is_strain && $species_defs->get_config($_, 'RELATED_TAXON') != $species_defs->RELATED_TAXON) {
+      delete $not_seen{$_};
+      delete $not_seen{lc $_};
+    }
+
     #do not show strain species on main species view
     if (!$self->is_strain && $species_defs->get_config($_, 'IS_STRAIN_OF')) {
       delete $not_seen{$_};
@@ -110,7 +115,12 @@ sub content {
       }
 
       $orthologue_list{$species} = {%{$orthologue_list{$species}||{}}, %{$homology_type->{$_}}};
-      $skipped{$species}        += keys %{$homology_type->{$_}} if $self->param('species_' . lc $species) eq 'off';
+
+      # Skip strains that belongs to a different parent species
+      if($self->param('species_' . lc $species) eq 'off' || ($self->is_strain && $species_defs->get_config($species, 'RELATED_TAXON') ne $species_defs->RELATED_TAXON)) {
+        $skipped{$species}        += keys %{$homology_type->{$_}}
+      }
+
       delete $not_seen{$species};
       delete $not_seen{lc $species};
     }


### PR DESCRIPTION
## Description
Orthologues tables should only display the strains from the same strain set. (Eg. Pigs should not show Mouse strains)

## Views affected
http://ves-hx2-76.ebi.ac.uk:42228/Mus_spretus/Gene/Strain_Compara_Ortholog?collapse=none;db=core;g=MGP_SPRETEiJ_G0031873;r=8:44062-175441

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5275
