### PR TITLE
Do not add facet_strain parameter to species search url in Psychic

### DIFF
--- a/modules/EnsEMBL/Web/Controller/Psychic.pm
+++ b/modules/EnsEMBL/Web/Controller/Psychic.pm
@@ -267,7 +267,6 @@ sub psychic {
 
       $url = $self->escaped_url(($species eq 'ALL' || !$species ? '/Multi' : $species_path) . "/$script?species=%s;idx=%s;q=%s", $species || 'all', $index, $query);
       my $common = $species_defs->get_config($species,'SPECIES_COMMON_NAME');
-      $url .= ";facet_strain=$common" if $coll and lc $coll ne lc $common;
     }
   }
 


### PR DESCRIPTION
## Description
Fixes bug with search from species page.

**Steps to reproduce the bug** (was introduced in release 98; can be seen on test site):
- go to species page (e.g. Mouse)
- click on the link to example gene
- (bug) the search results page will be empty

**Cause of bug:**
When generating redirect url for search page, Psychic adds incorrectly adds species common name as `facet_strain` parameter, e.g.:

`/mus_musculus/Search/Results?species=Mus_musculus;idx=;q=;facet_strain=Mouse;site=ensembl`

There was a guard in the code preventing generation of such urls, but when a metakey got renamed (in [this PR](https://github.com/Ensembl/ensembl-webcode/pull/728)), the guard stopped working.

**Solution:**
The code that adds the `facet_strain` parameter was added in [this task](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-3151), when we expected to have dedicated strain pages. Since we ended up not having strain pages, this code is no longer relevant, so this line can be safely deleted.

## Views affected
- Species page (transition from species page to search results page)

Sandbox: http://ves-hx2-76.ebi.ac.uk:8410/Mus_musculus/Info/Index

## Possible complications
None that anyone could think of.

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5303