### PR TITLE
Hide strains from different parent species

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -109,11 +109,16 @@ sub content {
         next;
       }
 
-      $orthologue_list{$species} = {%{$orthologue_list{$species}||{}}, %{$homology_type->{$_}}};
-
       # Skip strains that belongs to a different parent species
-      if($self->param('species_' . lc $species) eq 'off' || ($self->is_strain && $species_defs->get_config($species, 'RELATED_TAXON') ne $species_defs->RELATED_TAXON)) {
-        $skipped{$species}        += keys %{$homology_type->{$_}}
+      if($self->is_strain && $species_defs->get_config($species, 'RELATED_TAXON') ne $species_defs->RELATED_TAXON){
+        delete $not_seen{$species};
+        delete $not_seen{lc $species};
+        next;
+      } 
+
+      $orthologue_list{$species} = {%{$orthologue_list{$species}||{}}, %{$homology_type->{$_}}};
+      if($self->param('species_' . lc $species) eq 'off') {
+        $skipped{$species}        += keys %{$homology_type->{$_}};
       }
 
       delete $not_seen{$species};


### PR DESCRIPTION
## Description
Fixed the issue with displaying skipped orthologues information from strains that belong to a different parent species.

## Views affected

http://ves-hx2-76.ebi.ac.uk:42228/Mus_spretus/Gene/Strain_Compara_Ortholog?g=MGP_SPRETEiJ_G0031873;r=8:44062-175441

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5275
