### PR TITLE
Add CLS zmenu for long reads tracks

### DIFF
--- a/modules/EnsEMBL/Web/ImageConfig.pm
+++ b/modules/EnsEMBL/Web/ImageConfig.pm
@@ -667,7 +667,7 @@ sub menus {
     # Transcripts/Genes
     gene_transcript     => 'Genes and transcripts',
     transcript          => [ 'Genes',                  'gene_transcript' ],
-    longreads           => [ 'Longreads',              'gene_transcript' ],
+    longreads           => [ 'Long reads',             'gene_transcript' ],
     prediction          => [ 'Prediction transcripts', 'gene_transcript' ],
     lrg                 => [ 'LRG',                    'gene_transcript' ],
     rnaseq              => [ 'RNASeq models',          'gene_transcript' ],

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -446,11 +446,6 @@ sub add_genes {
         }
       }
 
-      # this will separate all Long-Seq tracks into longreads submenu
-      if ($data->{$key2}{'name'} =~ /Long-Seq/) {
-        $t = 'longreads';
-      }
-
       my $menu = $self->get_node($t);
       next unless $menu;
 

--- a/modules/EnsEMBL/Web/ZMenu/CLS.pm
+++ b/modules/EnsEMBL/Web/ZMenu/CLS.pm
@@ -1,0 +1,94 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::ZMenu::CLS;
+
+use strict;
+
+use Bio::EnsEMBL::SubSlicedFeature;
+use EnsEMBL::Web::Utils::FormatText qw(helptip);
+
+use base qw(EnsEMBL::Web::ZMenu);
+
+sub content {
+  my $self        = shift;
+  my $hub         = $self->hub;
+  my $object      = $self->object;
+  my @click = $self->click_location;
+  my ($gene, $transcript);
+
+  eval {
+    $gene = $object->gene;
+  };
+
+  if ($@) {
+    $gene = $object->gene;
+  }
+
+  $self->caption($gene->stable_id . ' (Long-Seq)');
+  
+  $self->add_entry({
+    type  => 'Location',
+    label => sprintf(
+      '%s: %s-%s',
+      $self->neat_sr_name($object->seq_region_type, $object->seq_region_name),
+      $self->thousandify($object->seq_region_start),
+      $self->thousandify($object->seq_region_end)
+    ),
+    link_class => '_location_change _location_mark',
+    link  => $hub->url({
+      type   => 'Location',
+      action => 'View',
+      r      => $object->seq_region_name . ':' . $object->seq_region_start . '-' . $object->seq_region_end
+    })
+  });
+
+  eval {
+    $transcript = $object->transcript;
+  };
+  
+  if ($@) {
+    $transcript = undef;
+  }
+
+  $self->add_entry({
+    type  => 'Transcript',
+    label => $transcript->stable_id
+  }) if $transcript;
+    
+  $self->add_entry({
+    type  => 'Strand',
+    label => $object->seq_region_strand < 0 ? 'Reverse' : 'Forward'
+  });
+  
+  $self->add_entry({
+    type  => 'Base pairs',
+    label => $self->thousandify($transcript->seq->length)
+  }) if $transcript;
+
+  my $analysis = $object->analysis;
+  my $source = $object->source;
+
+  $self->add_entry({
+    type        => 'Source',
+    label_html  => $source eq 'havana_tagene' ? helptip('Havana tagene', 'Transcript which was created by the HAVANA-Ensembl manually supervised computational pipeline for long-read sequence data') : helptip($analysis->display_label, $analysis->description)
+  });
+}
+
+1;

--- a/modules/EnsEMBL/Web/ZMenu/Gene/CLS.pm
+++ b/modules/EnsEMBL/Web/ZMenu/Gene/CLS.pm
@@ -1,0 +1,75 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::ZMenu::Gene::CLS;
+
+use strict;
+
+use Bio::EnsEMBL::SubSlicedFeature;
+use EnsEMBL::Web::Utils::FormatText qw(helptip);
+
+use base qw(EnsEMBL::Web::ZMenu::Gene);
+
+sub content {
+  my $self        = shift;
+  my $hub         = $self->hub;
+  my $object      = $self->object;
+  my $gene;
+
+  eval {
+    $gene = $object->gene;
+  };
+
+  if ($@) {
+    $gene = $object->gene;
+  }
+
+  $self->caption($gene->stable_id . ' (Long-Seq)');
+  
+  $self->add_entry({
+    type  => 'Location',
+    label => sprintf(
+      '%s: %s-%s',
+      $self->neat_sr_name($object->seq_region_type, $object->seq_region_name),
+      $self->thousandify($object->seq_region_start),
+      $self->thousandify($object->seq_region_end)
+    ),
+    link_class => '_location_change _location_mark',
+    link  => $hub->url({
+      type   => 'Location',
+      action => 'View',
+      r      => $object->seq_region_name . ':' . $object->seq_region_start . '-' . $object->seq_region_end
+    })
+  });
+    
+  $self->add_entry({
+    type  => 'Strand',
+    label => $object->seq_region_strand < 0 ? 'Reverse' : 'Forward'
+  });
+
+  my $analysis = $gene->analysis;
+  my $source = $gene->source;
+
+  $self->add_entry({
+    type        => 'Source',
+    label_html  => helptip($analysis->display_label, $analysis->description)
+  });
+}
+
+1;

--- a/modules/EnsEMBL/Web/ZMenu/Transcript/CLS.pm
+++ b/modules/EnsEMBL/Web/ZMenu/Transcript/CLS.pm
@@ -17,20 +17,19 @@ limitations under the License.
 
 =cut
 
-package EnsEMBL::Web::ZMenu::CLS;
+package EnsEMBL::Web::ZMenu::Transcript::CLS;
 
 use strict;
 
 use Bio::EnsEMBL::SubSlicedFeature;
 use EnsEMBL::Web::Utils::FormatText qw(helptip);
 
-use base qw(EnsEMBL::Web::ZMenu);
+use base qw(EnsEMBL::Web::ZMenu::Transcript);
 
 sub content {
   my $self        = shift;
   my $hub         = $self->hub;
   my $object      = $self->object;
-  my @click = $self->click_location;
   my ($gene, $transcript);
 
   eval {
@@ -82,12 +81,12 @@ sub content {
     label => $self->thousandify($transcript->seq->length)
   }) if $transcript;
 
-  my $analysis = $object->analysis;
-  my $source = $object->source;
+  my $analysis = $transcript->analysis;
+  my $source = $transcript->source;
 
   $self->add_entry({
     type        => 'Source',
-    label_html  => $source eq 'havana_tagene' ? helptip('Havana tagene', 'Transcript which was created by the HAVANA-Ensembl manually supervised computational pipeline for long-read sequence data') : helptip($analysis->display_label, $analysis->description)
+    label_html  => helptip($analysis->display_label, $analysis->description)
   });
 }
 


### PR DESCRIPTION
## Description

Long reads tracks have different zmenu criteria and did not have a custom zmenu for them. CLS is the specified zmenu in webdata for these tracks, though they actually didn't exist in the code. So a CLS zmenu module was created for this. There is also a minor fix for the long reads menu entry and removing of track code that was separating the long reads tracks (as they are now separated using web data).

## Views affected

Control panel and long reads zmenu

## Possible complications

Not sure

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5226
