### PR TITLE
Hotfix/isoseq colour

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -34,9 +34,9 @@ use Sys::Hostname::Long;
 
 ###############################################################################
 ## Ensembl Version and release dates (these get updated every release)
-our $ENSEMBL_VERSION        = 98;            # Ensembl release number
-our $ARCHIVE_VERSION        = 'Sep2019';     # Archive site for this version
-our $ENSEMBL_RELEASE_DATE   = 'September 2019'; # As it would appear in the copyright/footer
+our $ENSEMBL_VERSION        = 99;            # Ensembl release number
+our $ARCHIVE_VERSION        = 'Dec2019';     # Archive site for this version
+our $ENSEMBL_RELEASE_DATE   = 'December 2019'; # As it would appear in the copyright/footer
 ###############################################################################
 
 

--- a/conf/ini-files/COLOUR.ini
+++ b/conf/ini-files/COLOUR.ini
@@ -252,6 +252,7 @@ human_rnaseq                             = darkblue        RNASeq gene
 lrg_import                               = #8080ff         LRG gene
 devil_rnaseq                             = darkblue        RNASeq gene
 chimp_swiss_pooled_brain_rnaseq          = darkblue        RNASeq gene
+long_reads_isoseq                        = #86a2b9         Long read gene
 
 
 # used for vertical joining of coding and non-coding regions of transcripts in supporting_evidence view

--- a/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
@@ -118,16 +118,11 @@ sub content {
   my $text  = "No $label defined in database";
 
   eval {
-    if ($transcript->source eq 'havana_tagene' ){
-      $text = 'Transcript which was created by the HAVANA-Ensembl manually supervised computational pipeline for long-read sequence data';
-    }
-    elsif ($transcript && $transcript->can('analysis') && $transcript->analysis && $transcript->analysis->description) {
+    if ($transcript && $transcript->can('analysis') && $transcript->analysis && $transcript->analysis->description) {
       $text = $transcript->analysis->description;
-    }
-    elsif ($object->can('gene') && $object->gene->can('analysis') && $object->gene->analysis && $object->gene->analysis->description) {
+    } elsif ($object->can('gene') && $object->gene->can('analysis') && $object->gene->analysis && $object->gene->analysis->description) {
       $text = $object->gene->analysis->description;
-    }
-    else {
+    } else {
       my $logic_name = $transcript->can('analysis') && $transcript->analysis ? $transcript->analysis->logic_name : '';
 
       if ($logic_name) {

--- a/modules/EnsEMBL/Web/ZMenu/Transcript.pm
+++ b/modules/EnsEMBL/Web/ZMenu/Transcript.pm
@@ -210,10 +210,9 @@ sub content {
 
   if ($object->analysis) {
     my $analysis = $transcript->analysis;
-    my $trans_source = $object->transcript->source;
     $self->add_entry({
       type        => 'Source',
-      label_html  => $trans_source eq 'havana_tagene' ? helptip('Havana tagene', 'Transcript which was created by the HAVANA-Ensembl manually supervised computational pipeline for long-read sequence data') : helptip($analysis->display_label, $analysis->description)
+      label_html  => helptip($analysis->display_label, $analysis->description)
     });
   }
   my $alt_allele_link = $object->get_alt_allele_link('Location');


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

_Using one or more sentences, describe the proposed changes and the reason for making them._
At the moment the CLS/long read zmenu is using the colour from refseq_import. I have set the name to long_reads_isoseq and the colour is a different blue
## Views affected

_List the website view(s) that you know are affected by this change._
Location view
_If possible please provide a URL that shows the change. For Ensembl developers this could be your sandbox._

## Possible complications

_We appreciate this can be difficult but please highlight any views that you think might possibly be adversely affected by this change. For example a change to method in ApacheHandlers.pm has potential for widespread consequences._
None
## Merge conflicts

_At certain stages of the release there is potential for many people to be working on the same modules. To avoid merge conflicts please confirm you have tested for this before submitting the pull request, eg by updating your feature branch and checking that the only changes being submitted are ones from you._
NA
## Related JIRA Issues (EBI developers only)

_Please provide the URL(s) for any JIRA issues related to this PR._
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5329