### PR TITLE
Change url for 'What are assembly exceptions' link in zmenu

### DIFF
--- a/modules/EnsEMBL/Web/ZMenu/AssemblyException.pm
+++ b/modules/EnsEMBL/Web/ZMenu/AssemblyException.pm
@@ -45,11 +45,7 @@ sub content {
   $self->add_entry({
     'label'       => 'What are assembly exceptions?',
     'link_class'  => 'popup',
-    'link'        => $hub->url({
-                      'type'    => 'Help',
-                      'action'  => 'Glossary',
-                      'id'      => 296,
-                      }),
+    'link'        => '/info/genome/genebuild/haplotypes_patches.html',
   });
 }
 


### PR DESCRIPTION
## Description
Change url for the "What are assembly exceptions" link in zmenu.

## Views affected
Chromosome idiogram in /:species/Location/View

## Possible complications
None that I can think of.

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5268