### PR TITLE
Add colours for nanaopore long read and salmobase tracks

### DIFF
--- a/conf/ini-files/COLOUR.ini
+++ b/conf/ini-files/COLOUR.ini
@@ -253,7 +253,8 @@ lrg_import                               = #8080ff         LRG gene
 devil_rnaseq                             = darkblue        RNASeq gene
 chimp_swiss_pooled_brain_rnaseq          = darkblue        RNASeq gene
 long_reads_isoseq                        = #86a2b9         Long read gene
-
+long_reads_nanopore                      = #86a2b9         Long read gene
+salmobase                                = steelblue4      Salmobase import
 
 # used for vertical joining of coding and non-coding regions of transcripts in supporting_evidence view
 coding_join                              = red3;join:azure2;label:black


### PR DESCRIPTION
## Description

Added colour info for "long_read_nanopore" and "salmobase" to COULOUR.ini

## Views affected

"Region in detail view"
long_read_nanpore for Kakapo (nanopore track)
salmobase for Atlantic salmon (salmobase annotaiton import track)

## Possible complications



## Merge conflicts



## Related JIRA Issues (EBI developers only)

