### PR TITLE
Fix zmenu position

### DIFF
--- a/htdocs/components/10_ZMenu.js
+++ b/htdocs/components/10_ZMenu.js
@@ -659,13 +659,11 @@ Ensembl.Panel.ZMenu = Ensembl.Panel.extend({
     Ensembl.EventManager.trigger('panelToFront', this.id);
     
     if (!this.el.css({ top: 0, left: 0, display: 'block' }).position({ of: this.event, my: 'left top', collision: 'fit' }).hasClass('ui-draggable')) {
-      this.el.scrollTop(0).draggable($.extend({
+      this.el.scrollTop(0).draggable({
         handle:       '.header:not(.subheader)',
-        containment:  'document'
-      }, Ensembl.browser.webkit ? {} : {
         start:        function() { $(this).css({'margin-top': -1 * $(window).scrollTop() }); },
         stop:         function() { $(this).css({'top': parseInt($(this).css('top')) + parseInt($(this).css('margin-top')), 'margin-top': 0 }); }
-      }));
+      });
     }
     
     if (this.relatedEl) {      


### PR DESCRIPTION
## Description

Fixes incorrect position of zmenu while it's being dragged.

**Steps to reproduce the bug**
- Open Chrome
- Open any page with an image that shows zmenu (for example, view of a human chromosome, or a detailed view of a region)
- Make sure to scroll the page down (the exact scroll distance is irrelevant, as long as the page is not exactly at the top)
- Click on the image to see a zmenu
- Drag the zmenu. You will see that it jumps down from your cursor (by the same distance that the page is scrolled down)

**Cause**
The current bug is result of several corrections:
1) [6 years ago](https://github.com/Ensembl/ensembl-webcode/commit/581c12020ee3b9d20ec013b5d57f409a3c4fb90b): `margin-top` and `top` css properties of zmenu were corrected when user started and stopped dragging. Without these corrections, window scroll distance is added to zmenu top position, and the zmenu moves down from under the cursor by the distance that the window is scrolled from the top. Not sure why this is happening — whether it's a real limitation of jquery-ui or whether it's because we are doing something wrong.
2) Soon afterwards, there [followed a commit](https://github.com/Ensembl/ensembl-webcode/commit/48ccefe0d845c74f7bd7e5e9496c75f4f2491fbd) that limited the previous change only to non-webkit browsers. I do not know why webkit browsers did not require the correction introduced in the previous commit.
3) Now we got to the point when webkit-based browsers (Chrome, Safari) behave as other browsers, and the fix introduced in the previous step actually breaks the zmenu in these browsers. So the logical step to do is to revert the changes made in step 2.

## Views affected
Any visualisations that use the zmenu.

**Link to sandbox:**
http://ves-hx2-76.ebi.ac.uk:8410/Homo_sapiens/Location/View?db=core;r=4:37836115-37837115;v=rs2608307;vdb=variation;vf=1218239

**Tested in:**
- Chrome (v. 78)
- Firefox (v.70)
- Safari (v. 13)

## Possible complications
I do not know why the [original code change](https://github.com/Ensembl/ensembl-webcode/commit/48ccefe0d845c74f7bd7e5e9496c75f4f2491fbd) that made zmenu behave differently in different browsers was necessary. It is possible that in some older versions of Chrome users will now experience the original incorrect zmenu behaviour.

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5428