### PR TITLE
Fix ConfigMatrix incorrect numbers bug

### DIFF
--- a/htdocs/components/25_ConfigMatrix.js
+++ b/htdocs/components/25_ConfigMatrix.js
@@ -434,7 +434,7 @@ Ensembl.Panel.ConfigMatrix = Ensembl.Panel.Configurator.extend({
           track = $(this);
           if (track.hasClass('on') !== on[i]) {
             panel.elLk.options.filter('.' + track.data('track').colClass).find('.on').html(function (j, html) {
-              return parseInt(html, 10) + panel.params.defaultRenderers[$(this).parents('td.opt')[0].title] * off;
+              return parseInt(html, 10) * off;
             });
           }
         });

--- a/htdocs/components/25_ConfigMatrix.js
+++ b/htdocs/components/25_ConfigMatrix.js
@@ -423,7 +423,6 @@ Ensembl.Panel.ConfigMatrix = Ensembl.Panel.Configurator.extend({
   changeTrackRenderer: function (tracks, renderer, isColumn) {
     var panel = this;
     var on    = tracks.map(function () { return $(this).hasClass('on'); }).toArray();
-    var off   = renderer === 'off' ? -1 : 1;
     var track;
     
     this.base(tracks, renderer, false, true);
@@ -434,7 +433,7 @@ Ensembl.Panel.ConfigMatrix = Ensembl.Panel.Configurator.extend({
           track = $(this);
           if (track.hasClass('on') !== on[i]) {
             panel.elLk.options.filter('.' + track.data('track').colClass).find('.on').html(function (j, html) {
-              return parseInt(html, 10) * off;
+              return parseInt(html, 10);
             });
           }
         });


### PR DESCRIPTION
## Description
When configuring the RNASeq tracks, the numbers in the "tickboxes" are not correct. When not select it usually shows "0 1" and it shows "2 1" when selected. I would have expected "1 1" when the box is selected.

## Views affected
http://ves-hx2-76.ebi.ac.uk:42229/Homo_sapiens/Gene/Summary?g=ENSG00000139618;r=13:32315086-32400266

Configure this page -> RNASeq models

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5406
