### PR TITLE
Preserve info about original uri when dismissing request

### DIFF
--- a/conf/httpd.conf
+++ b/conf/httpd.conf
@@ -454,7 +454,7 @@ ServerSignature         Off
 
 # Handle CGI errors with EnsEMBL::Web::Apache::ServerError
 ErrorDocument 500 /Crash
-# Handle missing pages with EnsEMBL::Web::Apache::NotFound
+# Handle missing pages with EnsEMBL::Web::Apache::Error
 ErrorDocument 400 /Error
 ErrorDocument 401 /Error
 ErrorDocument 403 /Error

--- a/modules/EnsEMBL/Web/Apache/Handlers.pm
+++ b/modules/EnsEMBL/Web/Apache/Handlers.pm
@@ -534,7 +534,14 @@ sub handler {
   }
 
   # give up if no response code was set by any of the handlers
-  return DECLINED unless defined $response_code;
+  if (not defined $response_code) {
+    # when the request is declined, it will eventually be treated by Apache as a 404,
+    # at which point its uri will be re-written to /Error (see httpd.conf);
+    # so let's keep the original uri in a custom header
+    # (not using the standard Referer header, because a referrer is a full url, with protocol and hostname)
+    $r->headers_in->add('X-Declined-From' => $r->unparsed_uri);
+    return DECLINED;
+  }
 
   # kill off the process when it grows too large
   # Rely on OOB now. (Mart exceeds what this package can handle)


### PR DESCRIPTION
## Description
**Problem:** The 404 page is rendered when the apache handler dismisses the request.  At this point, apache re-routes the request to `/Error`, which is handled by the Apache::Error module (is it a good idea to re-route the request? probably not; but I'm not even attempting to touch this in this PR). As a result of this re-routing, the request object loses information about its initial uri; so the 404 page cannot behave differently depending on which page the user is coming from.

**Solution:** Add a custom header containing the original uri to the request object before dismissing it. This header can then be used to customise the 404 page depending on the requested url.

## Views affected
404 page

## Related JIRA Issues (EBI developers only)
ENSWEB-5233

sandbox: http://ves-hx2-76.ebi.ac.uk:8430/