### PR TITLE
get ancestral allele from vf

### DIFF
--- a/modules/EnsEMBL/Web/Object/Variation.pm
+++ b/modules/EnsEMBL/Web/Object/Variation.pm
@@ -586,12 +586,12 @@ sub ancestor {
 
   ### Variation_object_calls 
   ### a
-  ### Example    : $object->ancestral_allele;
+  ### Example    : $object->get_selected_variation_feature->ancestral_allele;
   ### Description: returns the ancestral allele for the variation
   ### Returns String
 
   my $self = shift;
-  return $self->vari->ancestral_allele;
+  return $self->get_selected_variation_feature->ancestral_allele;
 }
 
 


### PR DESCRIPTION
## Description
The ancestral allele used to be stored in the variation table. We moved the ancestral allele to the variation feature table and the API has been updated to return the ancestral allele for the variation_feature object. Trying to get it from the variation object has been deprecated and the API code for doing so has been removed now and added to the variation_feature object instead.

## Views affected
Variation summary page

## Possible complications
The code update is necessary to work with ensemb-variation API release 100.
Tested on my [sandbox](http://ves-hx2-76.ebi.ac.uk:5040/Homo_sapiens/Variation/Mappings?db=core;r=6:33271592-33272592;v=rs17215231;vdb=variation;vf=63916212)

## Merge conflicts
None