### PR TITLE
remove display ClinVar RCV as synonyms - e100

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -373,7 +373,10 @@ sub synonyms {
       @urls = map { s/%23/#/; $_ } map $hub->get_ExtURL_link($_, 'OMIM', $url_ids{$_}), @ids;
     }
     elsif ($db =~ /clinvar/i) {
-      @urls = map $hub->get_ExtURL_link($_, 'CLINVAR', $_), @ids;
+      foreach (@ids) {
+        next if /^RCV/; # don't display RCVs as synonyms
+        push @urls, $hub->get_ExtURL_link($_, 'CLINVAR', $_);
+      }
     }
     elsif ($db =~ /Uniprot/) {
       push @urls, $hub->get_ExtURL_link($_, 'UNIPROT_VARIATION', $_) for @ids;


### PR DESCRIPTION
## Description

ClinVar RCVs  have been listed as variation synonyms. These have now been replaced with VCVs. RCVs will not be displayed as synonyms any more.

## Views affected

The variation summary page, 'Synonyms' 'ClinVar' source: 
http://ves-hx2-76.ebi.ac.uk:6080/Homo_sapiens/Variation/Explore?r=1:230709548-230710548;v=rs699;vdb=variation;vf=179
vs.
http://staging.ensembl.org/Homo_sapiens/Variation/Explore?r=1:230709548-230710548;v=rs699;vdb=variation;vf=179

## Possible complications

None expected.

## Merge conflicts

None.

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-1116