### PR TITLE
Fix munging of refseq alignment output

### DIFF
--- a/modules/EnsEMBL/Web/Component/Transcript/ExternalRecordAlignment.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/ExternalRecordAlignment.pm
@@ -64,7 +64,7 @@ sub get_data {
 
     my $alignment = $object->get_alignment($ext_seq->{'sequence'}, $trans_seq, $seq_type);
     my $munged    = $seq_type eq 'PEP' ? $self->_munge_psw($alignment, $psv, $hit_id)
-                                       : $self->_munge_matcher($alignment, $tsv, $hit_id);; 
+                                       : $self->_munge_matcher($alignment, $tsv, $hit_id);
 
     $data->{'description'}{'content'} = $seq_type eq 'PEP'
       ? qq(Alignment between external feature $hit_id and translation of transcript $tsv)
@@ -91,7 +91,6 @@ sub _munge_psw {
   my $col_1_width = length($psv) > length($hit_id) ? length($psv) : length($hit_id);
   $col_1_width   += 2;
   my $col_2_width = 5;
-  my $col_3_width;
   my $col_1_pattern = '%-0'.$col_1_width.'s'; 
   my $col_2_pattern = '%-0'.$col_2_width.'s';
 
@@ -103,7 +102,10 @@ sub _munge_psw {
       }
       else {
         ## Identifier plus sequence
-        my ($id, $seq) = split(/\s+/, $line);
+        my @line_parts = split(/\s+/, $line);
+        # no matter how many intermediate elements a line contains, the identifier is always first and the sequence always last
+        my $id = $line_parts[0];
+        my $seq = $line_parts[-1];
 
         ## Add the correct identifier
         my $identifier = ($line_count % 3 == 0) ? $psv : $hit_id;


### PR DESCRIPTION
## Description
Fix alignment issue that became apparent with refseq sequences.

**Problem:**
![image](https://user-images.githubusercontent.com/6834224/74251969-dd766600-4ce4-11ea-89cb-26dd1944664b.png)

when correct alignment would look like this:
![image](https://user-images.githubusercontent.com/6834224/74253687-4ced5500-4ce7-11ea-9da1-6a58c8a0e2b7.png)

**Cause:**
We [rely](https://github.com/Ensembl/ensembl-webcode/blob/2b4bc3ebab916797afb5a3dbe08d480f37d227a5/modules/EnsEMBL/Web/Object/Transcript.pm#L1429-L1430) on the `psw` (pairwise Smith-Waterman) script to perform alignments. 

When we align refseq sequence with the sequence of the transcript, the output currently looks as follows:

```
ENSP00000286100      MSLSENSVFAYESSVHSTNVLLSLNDQRKKDVLCDVTIFVEGQRFRAHR
                     MSLSENSVFAYESSVHSTNVLLSLNDQRKKDVLCDVTIFVEGQRFRAHR
NP_001177.1 1        MSLSENSVFAYESSVHSTNVLLSLNDQRKKDVLCDVTIFVEGQRFRAHR


ENSP00000286500      SVLAACSSYFHSRIVGQADGELNITLPEEVTVKGFEPLIQFAYTAKLIL
                     SVLAACSSYFHSRIVGQADGELNITLPEEVTVKGFEPLIQFAYTAKLIL
NP_001177.1 50       SVLAACSSYFHSRIVGQADGELNITLPEEVTVKGFEPLIQFAYTAKLIL
```

Notice that the script adds a number (amino acid position) after the name of the external sequence (3rd line). I don't know whether it has started doing this after some recent update or whether it has always done so, but our subsequent formatter assumes that there are only two significant parts in the third line (molecule id and its sequence), while in fact there are three (molecule id, position, sequence).

This PR adds the smallest change that should fix the problem and at the same time hopefully not break anything else.

## Views affected
`/:species/Transcript/Similarity/Align`

sandbox: http://ves-hx2-76.ebi.ac.uk:8410/Homo_sapiens/Transcript/Similarity/Align?db=core;extdb=refseq_peptide;g=ENSG00000156273;r=21:29298922-29346148;sequence=NP_001177.1;t=ENST00000286800

Note that the sandbox currently works only for the exact url above, because it cannot connect to refseq ([these dictionaries](https://github.com/Ensembl/ensembl-webcode/blob/master/modules/EnsEMBL/Web/Hub.pm#L665-L666), called from [here](https://github.com/Ensembl/ensembl-webcode/blob/2b4bc3ebab916797afb5a3dbe08d480f37d227a5/modules/EnsEMBL/Web/Component/Transcript/ExternalRecordAlignment.pm#L59), are empty 🤷‍♂ ).

## Related JIRA Issues (EBI developers only)
ENSWEB-5479