### PR TITLE
Update apache handler to handle 'common/psychic'

### DIFF
--- a/modules/EnsEMBL/Web/Apache/Handlers.pm
+++ b/modules/EnsEMBL/Web/Apache/Handlers.pm
@@ -108,6 +108,11 @@ sub get_redirect_uri {
   if ($uri =~ /\/Multi\/psychic/) {
     return $uri =~ s/\/Multi\/psychic/\/Multi\/Psychic/r;
   }
+  
+  ## Redirect incoming search links from ensemblgenomes.org 
+  if ($uri =~ /\/common\/psychic/) {
+    return $uri =~ s/\/common\/psychic/\/Multi\/Psychic/r;
+  }
 
   ## quick fix for solr autocomplete js bug
   if ($uri =~ /undefined\//) {


### PR DESCRIPTION
## Description
This PR is to fix the issue with redirection of links coming from ensemblgenomes.org

## Views affected
Sandbox: http://ves-hx2-76.ebi.ac.uk:42229/common/psychic?site=ensembl;genomic_unit=bacteria;x=0;y=0;q=ABQ19260

Prod: http://bacteria.ensembl.org/common/psychic?site=ensembl;genomic_unit=bacteria;x=0;y=0;q=ABQ19260

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5522
