### PR TITLE
Handle ID lookup redirects from ensemblgenomes.org

### DIFF
--- a/modules/EnsEMBL/Web/Apache/Handlers.pm
+++ b/modules/EnsEMBL/Web/Apache/Handlers.pm
@@ -109,9 +109,9 @@ sub get_redirect_uri {
     return $uri =~ s/\/Multi\/psychic/\/Multi\/Psychic/r;
   }
   
-  ## Redirect incoming search links from ensemblgenomes.org 
-  if ($uri =~ /\/common\/psychic/) {
-    return $uri =~ s/\/common\/psychic/\/Multi\/Psychic/r;
+  ## Handle id lookups from ensemblgenomes.org to the corresponding page
+  if ($uri =~ /\/common\/psychic/ && $uri =~ /[\&\;\?]{1}q=([^\&\;]+)/ ) {
+    return stable_id_redirect_uri('id', $1)
   }
 
   ## quick fix for solr autocomplete js bug


### PR DESCRIPTION
## Description

Updated the Apache handlers to handle incoming ID lookups redirects from ensemblgenomes.org.

I've made an update so that the `q` parameter form any URL matching the path `/common/psychic` will be considered as a stable ID and will be handled by the sub `stable_id_redirect_uri` present in `Handlers.pm`.

## Views affected
Prod:
http://plants.ensembl.org/common/psychic?site=ensembl;genomic_unit=plants;x=0;y=0;q=AT3G52430.1

Sandbox:
http://ves-hx2-76.ebi.ac.uk:42229/common/psychic?site=ensembl;genomic_unit=plants;x=0;y=0;q=AT3G52430.1

## Possible complications
I am not very sure if this is the intended behaviour but the path `/common/psychic` doesn't seem to be handled elsewhere .

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5535
