### PR TITLE
Check if variation feature is defined

### DIFF
--- a/modules/EnsEMBL/Web/Object/Variation.pm
+++ b/modules/EnsEMBL/Web/Object/Variation.pm
@@ -591,7 +591,12 @@ sub ancestor {
   ### Returns String
 
   my $self = shift;
-  return $self->get_selected_variation_feature->ancestral_allele;
+
+  my $anc_allele;
+  if($self->get_selected_variation_feature) {
+    $anc_allele = $self->get_selected_variation_feature->ancestral_allele;
+  }
+  return $anc_allele;
 }
 
 


### PR DESCRIPTION
## Description

Fetching the ancestral allele from the variation feature throws an error on staging.  
Before fetching the ancestral allele we need to check if the variant has any variation feature. 

## Views affected

Variation summary page
Tested on my [sandbox](http://ves-hx2-76.ebi.ac.uk:7040/Mus_musculus/Variation/Explore?db=core;v=rs2020807;vdb=variation)

## Possible complications

Fix is necessary to work with API release 100. 

## Merge conflicts

None

## Related JIRA Issues (EBI developers only)


