### PR TITLE
Add option to display announcement banner

### DIFF
--- a/htdocs/components/99_announcement_banner.css
+++ b/htdocs/components/99_announcement_banner.css
@@ -1,0 +1,29 @@
+/*
+ * Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+ * Copyright [2016-2018] EMBL-European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#announcement-banner {
+    background-color: #CD0000;
+    padding: 12px 8px 12px 8px;
+    color: #FFF;
+    text-align: center;
+}
+
+#announcement-banner p{
+    margin:0;
+    font-weight: bold;
+}

--- a/htdocs/components/99_announcement_banner.css
+++ b/htdocs/components/99_announcement_banner.css
@@ -17,13 +17,17 @@
 
 
 #announcement-banner {
-    background-color: #CD0000;
+    background-color: gold;
     padding: 12px 8px 12px 8px;
-    color: #FFF;
+    color: #333;
     text-align: center;
 }
 
 #announcement-banner p{
     margin:0;
     font-weight: bold;
+}
+
+#announcement-banner a{
+    color: #3399FF;
 }

--- a/modules/EnsEMBL/Web/Document/Element/TmpMessage.pm
+++ b/modules/EnsEMBL/Web/Document/Element/TmpMessage.pm
@@ -79,7 +79,7 @@ sub content {
 
 
   return {
-    'popup_message' => $announcement_banner_message,
+    'popup_message' => $popup_message,
     'announcement_banner_message' => $announcement_banner_message 
   }
 

--- a/modules/EnsEMBL/Web/Document/Element/TmpMessage.pm
+++ b/modules/EnsEMBL/Web/Document/Element/TmpMessage.pm
@@ -44,7 +44,7 @@ sub init {
 sub content {
   my $self = shift;
 
-  return $self->{'file'}{'message'} ? $self->dom->create_element('div', {
+  my $popup_message = $self->{'file'}{'message'} ? $self->dom->create_element('div', {
     'id'        => 'tmp_message',
     'children'  => [{
       'node_name'   => 'div',
@@ -71,6 +71,19 @@ sub content {
       'value'       => $self->{'file'}{'position'} || ''
     }]
   })->render : '';
+
+  my $announcement_banner_message = $self->{'file'}{'banner_message'} ? $self->dom->create_element('div', {
+    'id'          => 'announcement-banner',
+    'inner_HTML'  => $self->{'file'}{'banner_message'}
+  })->render : '';
+
+
+  return {
+    'popup_message' => $announcement_banner_message,
+    'announcement_banner_message' => $announcement_banner_message 
+  }
+
+
 }
 
 1;

--- a/modules/EnsEMBL/Web/Template/Legacy.pm
+++ b/modules/EnsEMBL/Web/Template/Legacy.pm
@@ -21,6 +21,7 @@ package EnsEMBL::Web::Template::Legacy;
 
 ### Legacy page template, used by standard HTML pages
 
+use EnsEMBL::Web::Utils::FileHandler qw(file_get_contents);
 use parent qw(EnsEMBL::Web::Template);
 
 use HTML::Entities qw(encode_entities);
@@ -117,6 +118,11 @@ sub render_masthead {
   return qq(
   <div id="min_width_container">
     <div id="min_width_holder">
+    
+    <!-- Announcement Banner -->    
+        $elements->{'tmp_message'}->{'announcement_banner_message'}
+    <!-- /Announcement Banner -->
+
       <div id="masthead" class="js_panel$masthead_class">
         <input type="hidden" class="panel_type" value="Masthead" />
         <div class="logo_holder">$elements->{'logo'}</div>
@@ -233,7 +239,7 @@ sub render_page_end {
   <input type="hidden" id="ensembl_image_root" name="ensembl_image_root" value="$ensembl_image_root" />
   <input type="hidden" id="max_region_length" name="max_region_length" value="$max_region_length" />
     $elements->{'modal'}
-    $elements->{'tmp_message'}
+    $elements->{'tmp_message'}->{'popup_message'}
     $elements->{'body_javascript'}
   );
   

--- a/modules/EnsEMBL/Web/Template/Legacy.pm
+++ b/modules/EnsEMBL/Web/Template/Legacy.pm
@@ -20,8 +20,6 @@ limitations under the License.
 package EnsEMBL::Web::Template::Legacy;
 
 ### Legacy page template, used by standard HTML pages
-
-use EnsEMBL::Web::Utils::FileHandler qw(file_get_contents);
 use parent qw(EnsEMBL::Web::Template);
 
 use HTML::Entities qw(encode_entities);


### PR DESCRIPTION
## Description
Added the option to display an announcement banner by adding a file to the tmp directory.

Steps to add the banner:
- Look for the ENSEMBL_TMP_MESSAGE_FILE in the SiteDefs and get the path.
- Create (if not exists) the file `ensembl_tmp_message` in the above path
- add an entry for `banner_message`.
- For example: `banner_message Hello World!` will display `Hello World!` inside the banner

## Views affected
Masthead

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5494
