### PR TITLE
Bugfix100/feature overlap glyph

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
@@ -128,7 +128,8 @@ sub content {
   );
   my $reg_table = $self->new_table(\@reg_columns, [], { data_table => 1, sorting => ['type asc'], class => 'cellwrap_inside', data_table_config => {iDisplayLength => 10} } );
   my @motif_columns = (
-    { key => 'bm',       width => '20%',  title => 'Binding matrix',            sort => 'html'                             },
+    { key => 'mf',       width => '10%',  title => 'Motif feature',             sort => 'html'                             },
+    { key => 'bm',       width => '10%',  title => 'Binding matrix',            sort => 'html'                             },
     { key => 'allele',   width => '10%',  title => 'Allele',                    sort => 'string'                           },
     { key => 'type',     width => '10%',  title => 'Consequence type',          sort => 'position_html'                    },
     { key => 'names',    width => '40%',  title => 'Transcription factors',     sort => 'string'                           },
@@ -398,10 +399,10 @@ sub content {
         my $m_allele = $self->trim_large_string($mfva->variation_feature_seq,'mfva_'.$mf->stable_id,25);
         
         my $motif_overlap = $self->_overlap_glyph(1, $motif_length, $mfva->motif_start, $mfva->motif_end, $mf, 'Motif feature', 1, $mfv_colour);
-
         my $motif_length_label = $self->_overlap_glyph_label($mfva->motif_start, $mfva->motif_end, $motif_length);
 
         my $row = {
+          mf       => $mf->stable_id,
           bm       => $matrix_link,
           allele   => $m_allele,
           type     => $type,

--- a/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
@@ -541,6 +541,7 @@ sub _sort_start_end {
     } else {
       $end   = $length if ($length && $length < $end);
       $start = $length if ($length && $length < $start);
+      $start = 1 if ($start < 0);
       return join("-", sort {$a <=> $b} ($start, $end));
     }
   } else {


### PR DESCRIPTION
## Description
The glyph overlap in the genes and regulation section was not displayed correctly when the variant is bigger than the feature it overlaps.

I also added the motif feature stable id to the Motif feature consequences table.

## Views affected
[Genes and regulation](https://www.ensembl.org/Homo_sapiens/Variation/Mappings?db=core;r=19:1455514-1456542;v=rs1340856546;vdb=variation;vf=285873926)
With PR applied [genes and regulation](http://ves-hx2-76.ebi.ac.uk:5040//Homo_sapiens/Variation/Mappings?db=core;r=19:1455514-1456542;v=rs1340856546;vdb=variation;vf=285873926)

## Possible complications
None

## Merge conflicts
None

## Related JIRA Issues (EBI developers only)
This came up through a related question https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-2976
