### PR TITLE
Wrap long variation sequences

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -583,7 +583,7 @@ sub to_VCF {
   my $vcf_rep = $vf->to_VCF_record();
   return unless $vcf_rep && @$vcf_rep;
   
-  return '<span style="font-family:Courier,monospace;white-space:nowrap;margin-left:5px;padding:2px 4px;background-color:#F6F6F6">'.join("&nbsp;&nbsp;", map {encode_entities($_)} @{$vcf_rep}[0..4]).'</span>';
+  return '<span style="font-family:Courier,monospace;word-break:break-all;margin-left:5px;padding:2px 4px;background-color:#F6F6F6">'.join("&nbsp;&nbsp;", map {encode_entities($_)} @{$vcf_rep}[0..4]).'</span>';
 }
 
 sub location {


### PR DESCRIPTION
## Description
Update CSS to wrap VCF sequences for long alleles.

## Views affected
Variation summary.

Before fix (notice the sequence in the Location field is cropped by the right edge of the viewport):
![image](https://user-images.githubusercontent.com/6834224/75800811-0af98100-5d72-11ea-8afc-3ea2c4023a6e.png)

After fix (notice the sequence in the Location field wraps when it reaches the edge of the viewport):
![image](https://user-images.githubusercontent.com/6834224/75800846-18167000-5d72-11ea-8a7c-1d1451c3b889.png)

Sandbox: http://ves-hx2-76.ebi.ac.uk:8410/Homo_sapiens/Variation/Explore?r=18:5307973-5309186;v=rs1567915543;vdb=variation;vf=456734367

## Possible complications
🤷‍♂ 

## Related JIRA Issues (EBI developers only)
ENSWEB-5582