### PR TITLE
update phenotype sql to exclude non_specified

### DIFF
--- a/utils/indexing/indexXMLDumper
+++ b/utils/indexing/indexXMLDumper
@@ -1006,6 +1006,7 @@ sub dumpPhenotype {
      SELECT p.description, p.phenotype_id
        FROM phenotype p, phenotype_feature pf
       WHERE p.phenotype_id = pf.phenotype_id
+        AND p.class_attrib_id !=663
         AND pf.is_significant = 1
       GROUP BY p.phenotype_id),'description');
   foreach my $phen (keys %$phenotype_info) {

--- a/utils/indexing/indexXMLDumper
+++ b/utils/indexing/indexXMLDumper
@@ -1006,7 +1006,12 @@ sub dumpPhenotype {
      SELECT p.description, p.phenotype_id
        FROM phenotype p, phenotype_feature pf
       WHERE p.phenotype_id = pf.phenotype_id
-        AND p.class_attrib_id !=663
+        AND p.class_attrib_id != (
+            SELECT a.attrib_id
+            FROM   attrib_type att, attrib a
+            WHERE  att.attrib_type_id = a.attrib_type_id
+            AND    att.code ='phenotype_type'
+            AND    a.value = 'non_specified')
         AND pf.is_significant = 1
       GROUP BY p.phenotype_id),'description');
   foreach my $phen (keys %$phenotype_info) {


### PR DESCRIPTION
##  Description

Non specified phenotypes are now tagged with the class_attrib_id 663 and this PR updates the search query to exclude them from the phenotype search creation.

## Views affected

Phenotype search page will not return any results for 'Clinvar: phenotype not specified'.
[Phenotype search ](http://www.ensembl.org/Multi/Search/Results?q=Clinvar%3A%20phenotype%20not%20specified;site=ensembl)
[Phenotype link out](http://www.ensembl.org/Homo_sapiens/Phenotype/Locations?db=core;name=ClinVar:%20phenotype%20not%20specified;ph=74869;r=1:230709548-230710548;v=rs699;vdb=variation;vf=179)


## Possible complications

None.

## Merge conflicts

None.

## Related JIRA Issues (EBI developers only)

[ENSVAR-2926](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-2926)
