### PR TITLE
Uopdate banner colours to match fallback

### DIFF
--- a/htdocs/components/99_announcement_banner.css
+++ b/htdocs/components/99_announcement_banner.css
@@ -17,9 +17,9 @@
 
 
 #announcement-banner {
-    background-color: gold;
+    background-color: #dc0b0b;
     padding: 12px 8px 12px 8px;
-    color: #333;
+    color: #fdf5f5;
     text-align: center;
 }
 
@@ -29,5 +29,9 @@
 }
 
 #announcement-banner a{
-    color: #3399FF;
+    color: khaki;
+}
+
+#announcement-banner a:visited {
+    color: darkgray;
 }


### PR DESCRIPTION
Updated the announcement banner colour scheme to match the banner on the fallback site.

Current view:
http://uswest.ensembl.org/

Updated view:
http://ves-hx2-76.ebi.ac.uk:42228/index.html


