### PR TITLE
add eval around gerp score retrieval

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -738,8 +738,10 @@ sub change_tolerance {
   my $self = shift;
   my $object = $self->object;
   my ($CADD_scores, $CADD_source) = @{$object->CADD_score};
-  my ($GERP_score, $GERP_source) = @{$object->GERP_score};
-
+  my ($GERP_score, $GERP_source);
+  eval {
+    ($GERP_score, $GERP_source) = @{$object->GERP_score};
+  };
   return unless (defined $CADD_scores || defined $GERP_score);
   my $html = '';
   if (defined $CADD_scores) {


### PR DESCRIPTION
## Requirements
None

## Description
We started having problems retrieving files from the FTP site. This is still a problem for [staging](http://staging.ensembl.org/Homo_sapiens/Variation/Explore?r=1:230709548-230710548;v=rs699;vdb=variation;vf=179). The error message doesn't appear anymore on the page after applying the PR [[my sandbox](http://ves-hx2-76.ebi.ac.uk:5040/Homo_sapiens/Variation/Explore?r=1:230709548-230710548;v=rs699;vdb=variation;vf=179)].

For the release 99 page we changed a die to a warning message [[merged PR](https://github.com/Ensembl/ensembl-variation/pull/556)]. We are planning to revert the API update and also provide a web code update. It is likely that users will run an analysis with the API code and only after will notice the warning message about the FTP site problem. 

## Views affected
Variant summary page

## Possible complications
FTP site errors will be more difficult to spot now

## Merge conflicts
None
## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-3021

