### PR TITLE
add eval around gerp score retrieval

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -735,7 +735,10 @@ sub change_tolerance {
   my $self = shift;
   my $object = $self->object;
   my ($CADD_scores, $CADD_source) = @{$object->CADD_score};
-  my ($GERP_score, $GERP_source) = @{$object->GERP_score};
+  my ($GERP_score, $GERP_source);
+  eval {
+    ($GERP_score, $GERP_source) = @{$object->GERP_score};
+  };
 
   return unless (defined $CADD_scores || defined $GERP_score);
   my $html = '';


### PR DESCRIPTION
Same as https://github.com/Ensembl/ensembl-webcode/pull/759 but for release/99

We would prefer to catch the error which is thrown in the variation API in the webcode. The reason for this is that users might not notice the warning message (related to FTP problems) the variation API now returns until after they have run long running analysis.