### PR TITLE
Add the missing colours

### DIFF
--- a/conf/ini-files/COLOUR.ini
+++ b/conf/ini-files/COLOUR.ini
@@ -40,6 +40,7 @@ col_ctgs2       = darkgreen
 [feature]
 default         = blue;join:cadetblue1
 cdna            = chartreuse3;join:darkolivegreen1
+cdna_update     = chartreuse3;join:darkolivegreen1
 protein         = gold;join:lightgoldenrod1
 est             = purple2;join:mediumpurple1
 rna             = royalblue4;join:blue
@@ -178,6 +179,7 @@ tr_j_pseudogene                          = grey40;section:npc          pseudogen
 sense_intronic                           = blue;section:npc            processed transcript
 sense_overlapping                        = blue;section:npc            processed transcript
 processed_transcript                     = blue;section:npc            processed transcript
+
 nonsense_mediated_decay                  = blue;section:npc            processed transcript
 non_stop_decay                           = blue;section:npc            processed transcript
 antisense                                = blue;section:npc            processed transcript
@@ -203,7 +205,8 @@ scarna                                   = plum4;section:npc           RNA gene
 srna                                     = plum4;section:npc           RNA gene
 snorna                                   = plum4;section:npc           RNA gene
 vaultrna                                 = plum4;section:npc           RNA gene
-vault_RNA				 = plum4;section:npc           RNA gene
+vault_RNA				                 = plum4;section:npc           RNA gene
+vault_rna                                = plum4;section:npc           RNA gene
 pirna                                    = plum4;section:npc           RNA gene
 mt_rrna                                  = plum4;section:npc           RNA gene
 mt_trna                                  = plum4;section:npc           RNA gene
@@ -244,6 +247,7 @@ merged                                   = goldenrod3;section:pc      merged Ens
 #imports etc done by logic_name
 nontranslated_cds                        = darkblue;section:npc        Non Translated CDS
 ccds_import                              = chartreuse3;section:pc     CCDS set
+ccds_gene                                = chartreuse3;join:darkolivegreen1
 refseq_human_import                      = darkblue        Human RefSeq import
 refseq_mouse_import                      = darkblue        Mouse RefSeq import
 refseq_import                            = steelblue4      RefSeq GFF3 import
@@ -255,6 +259,7 @@ devil_rnaseq                             = darkblue        RNASeq gene
 chimp_swiss_pooled_brain_rnaseq          = darkblue        RNASeq gene
 long_reads_isoseq                        = #86a2b9         Long read gene
 long_reads_nanopore                      = #86a2b9         Long read gene
+aligned_transcript                       = #86a2b9         Long read gene
 salmobase                                = steelblue4      Salmobase import
 
 # used for vertical joining of coding and non-coding regions of transcripts in supporting_evidence view
@@ -269,6 +274,7 @@ projection_join                          = black       Projection
 alt_alleles_join                         = chocolate1  Alternative alleles
 
 # ensemblgenomes genes
+transposable_element                     = blue  transposable element gene
 transposable_element_gene                = blue  transposable element gene
 tmrna                                    = plum4;section:npc RNA gene
 srp_rna                                  = plum4;section:npc RNA gene


### PR DESCRIPTION
## Description
Added the following missing colour entries as instructed by Jyo:

- aligned_transcript = #86a2b9         Long read gene
- cdna = chartreuse3;join:darkolivegreen1
- transposable_element = blue  transposable element gene
- vault_rna = plum4;section:npc           RNA gene
- cdna_update = chartreuse3;join:darkolivegreen1
- ccds_gene = chartreuse3;join:darkolivegreen1
- ccds_import = chartreuse3;section:pc     CCDS set

The following entry is ignored as the key is already define with a different value:
- est = chartreuse3;join:darkolivegreen1

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEBREL-745
