### PR TITLE
Use ENSEMBL_FTP_OVER_HTTP_URL variable

### DIFF
--- a/modules/EnsEMBL/Web/Object/Variation.pm
+++ b/modules/EnsEMBL/Web/Object/Variation.pm
@@ -649,7 +649,7 @@ sub GERP_score {
   return [undef, undef] unless $vf_object;
 
   my $variation_db = $self->Obj->adaptor->db->get_VariationAdaptor->db;
-  $variation_db->gerp_root_dir($self->hub->species_defs->ENSEMBL_FTP_URL . '/release-' . $self->hub->species_defs->ENSEMBL_VERSION . '/compara/conservation_scores/');
+  $variation_db->gerp_root_dir($self->hub->species_defs->ENSEMBL_FTP_OVER_HTTP_URL . '/release-' . $self->hub->species_defs->ENSEMBL_VERSION . '/compara/conservation_scores/');
 
   my $gerp_score = $vf_object->get_gerp_score;
   my $source = (keys %$gerp_score)[0];  


### PR DESCRIPTION
## Description
Use a new variable (defined in [this PR](https://github.com/Ensembl/public-plugins/pull/320) in public plugins) to access variation files stored on the ftp server using http protocol rather than ftp.

The reasons for doing so are as follows:
- there is a firewall on web machines, which the FTP client was unaware of; so it currently can't retrieve ftp files
- even without the firewall problem, http protocol is more resilient than ftp, so it should be preferred

## Views affected
All Variation-related views that use variation files stored on the ftp server. 

See e.g. a SNP page on [sandbox](http://ves-hx2-76.ebi.ac.uk:8410/Homo_sapiens/Variation/Explore?r=1:230709548-230710548;v=rs699;vdb=variation;vf=179), where the GERP scor in the "Change tolerance"
line is retrieved from ftp (compare it with the same page in production, which is missing GERP score in this line, and also takes a long time to load, because the FTP client keeps trying to connect to the ftp server)

## Possible complications
Note that the changes in this PR expect the new `ENSEMBL_FTP_OVER_HTTP_URL` variable to be present.

## Related JIRA Issues (EBI developers only)
ENSWEB-5607