### PR TITLE
Remove gene_autocomplete table from ensembl_website database

### DIFF
--- a/conf/ini-files/MULTI.ini
+++ b/conf/ini-files/MULTI.ini
@@ -8,6 +8,7 @@ ENSEMBL_INSTITUTE_2 = <a href="http://www.ebi.ac.uk/" rel="external"><img src="/
 DATABASE_WEBSITE  = ensembl_website_%
 DATABASE_COMPARA  = ensembl_compara_%
 DATABASE_SESSION  = ensembl_session
+DATABASE_GENE_AUTOCOMPLETE  = ensembl_gene_autocomplete_%
 # The following are extra configuration parameters for the databases
 # You can overide the default settings for specific databases. Just add a
 # like this for each database you want to overide the settings for

--- a/conf/ini-files/MULTI.ini
+++ b/conf/ini-files/MULTI.ini
@@ -8,7 +8,7 @@ ENSEMBL_INSTITUTE_2 = <a href="http://www.ebi.ac.uk/" rel="external"><img src="/
 DATABASE_WEBSITE  = ensembl_website_%
 DATABASE_COMPARA  = ensembl_compara_%
 DATABASE_SESSION  = ensembl_session
-DATABASE_GENE_AUTOCOMPLETE  = ensembl_gene_autocomplete_%
+DATABASE_GENE_AUTOCOMPLETE  = ensembl_autocomplete_%
 # The following are extra configuration parameters for the databases
 # You can overide the default settings for specific databases. Just add a
 # like this for each database you want to overide the settings for

--- a/modules/EnsEMBL/Web/Controller/Ajax.pm
+++ b/modules/EnsEMBL/Web/Controller/Ajax.pm
@@ -27,7 +27,7 @@ use URI::Escape qw(uri_unescape);
 use JSON;
 
 use EnsEMBL::Web::Utils::DynamicLoader qw(dynamic_require);
-use EnsEMBL::Web::DBSQL::WebsiteAdaptor;
+use EnsEMBL::Web::DBSQL::GeneStableIDAdaptor;
 use EnsEMBL::Web::File::Utils::URL;
 
 use parent qw(EnsEMBL::Web::Controller);
@@ -76,7 +76,7 @@ sub ajax_autocomplete {
   }
 
   if ($query && !$results) {
-    my $dbh = EnsEMBL::Web::DBSQL::WebsiteAdaptor->new($hub)->db;
+    my $dbh = EnsEMBL::Web::DBSQL::GeneStableIDAdaptor->new($hub)->db;
     my $sth = $dbh->prepare(sprintf 'select display_label, stable_id, location, db from gene_autocomplete where species = "%s" and display_label like %s', $species, $dbh->quote("$query%"));
 
     $sth->execute;

--- a/modules/EnsEMBL/Web/DBSQL/GeneStableIDAdaptor.pm
+++ b/modules/EnsEMBL/Web/DBSQL/GeneStableIDAdaptor.pm
@@ -1,0 +1,56 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::DBSQL::GeneStableIDAdaptor;
+
+### A simple adaptor to fetch gene autocomplete data from the ensembl_gene_autocomplete database
+
+
+use strict;
+use warnings;
+no warnings 'uninitialized';
+
+use DBI;
+
+sub new {
+  my ($class, $hub, $settings) = @_;
+  $settings ||= {};
+  
+    my $self = {
+    'NAME' => $settings->{'name'} || $hub->species_defs->multidb->{'DATABASE_GENE_AUTOCOMPLETE'}{'NAME'},
+    'HOST' => $settings->{'host'} || $hub->species_defs->multidb->{'DATABASE_GENE_AUTOCOMPLETE'}{'HOST'},
+    'PORT' => $settings->{'port'} || $hub->species_defs->multidb->{'DATABASE_GENE_AUTOCOMPLETE'}{'PORT'},
+    'USER' => $settings->{'user'} || $hub->species_defs->multidb->{'DATABASE_GENE_AUTOCOMPLETE'}{'USER'},
+    'PASS' => $settings->{'pass'} || $hub->species_defs->multidb->{'DATABASE_GENE_AUTOCOMPLETE'}{'PASS'},
+  };
+  bless $self, $class;
+  return $self;
+}
+
+sub db {
+  my $self = shift;
+  return unless $self->{'NAME'};
+  $self->{'dbh'} ||= DBI->connect(
+      "DBI:mysql:database=$self->{'NAME'};host=$self->{'HOST'};port=$self->{'PORT'}",
+      $self->{'USER'}, "$self->{'PASS'}"
+  );
+  return $self->{'dbh'};
+}
+
+1;

--- a/modules/EnsEMBL/Web/Tools/Registry.pm
+++ b/modules/EnsEMBL/Web/Tools/Registry.pm
@@ -52,6 +52,7 @@ sub configure {
     USERDATA            => 'Bio::EnsEMBL::DBSQL::DBAdaptor',
     COMPARA_MULTIPLE    => undef,
     WEBSITE             => undef,
+    GENE_AUTOCOMPLETE   => undef,
     WEB_HIVE            => undef,
     WEB_TOOLS           => undef,
     ARCHIVE             => undef,


### PR DESCRIPTION
******* IMPORTANT NOTE: This PR is for e101 *******

## Description

Created a separate database for the gene_autocomplete table called `ensembl_autocomplete_100` and removed it from `ensembl_website`

## Views affected
Sandbox URL:
http://ves-hx2-76.ebi.ac.uk:42229/Homo_sapiens/Location/View?r=7:116210506-116258783;g=ENSG00000135269;db=core

http://ves-hx2-76.ebi.ac.uk:42229/Homo_sapiens/Ajax/autocomplete?q=BRCA

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5366
