### PR TITLE
Remove dN/dS column from Compara orthologues table

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -188,7 +188,6 @@ sub content {
     { key => 'Species',    align => 'left', width => '10%', sort => 'html'                                                },
     { key => 'Type',       align => 'left', width => '10%', sort => 'html'                                            },   
     { key => 'identifier', align => 'left', width => '15%', sort => 'none', title => 'Orthologue'},      
-    { key => 'dN/dS',      align => 'left', width => '5%',  sort => 'html'                                             },
     { key => 'Target %id', align => 'left', width => '5%',  sort => 'position_html', label => 'Target %id', help => "Percentage of the orthologous sequence matching the $species_name sequence" },
     { key => 'Query %id',  align => 'left', width => '5%',  sort => 'position_html', label => 'Query %id',  help => "Percentage of the $species_name sequence matching the sequence of the orthologue" },
     { key => 'goc_score',  align => 'left', width => '5%',  sort => 'position_html', label => 'GOC Score',  help => "<a href='/info/genome/compara/Ortholog_qc_manual.html/#goc'>Gene Order Conservation Score (values are 0-100)</a>" },
@@ -210,10 +209,6 @@ sub content {
       
       # Add in Orthologue description
       my $orthologue_desc = $orthologue_map{$orthologue->{'homology_desc'}} || $orthologue->{'homology_desc'};
-      
-      # Add in the dN/dS ratio
-      my $orthologue_dnds_ratio = $orthologue->{'homology_dnds_ratio'} || 'n/a';
-      my $dnds_class  = ($orthologue_dnds_ratio ne "n/a" && $orthologue_dnds_ratio >= 1) ? "box-highlight" : "";
 
       # GOC Score, wgac and high confidence
       my $goc_score  = (defined $orthologue->{'goc_score'} && $orthologue->{'goc_score'} >= 0) ? $orthologue->{'goc_score'} : 'n/a';
@@ -319,7 +314,6 @@ sub content {
       my $table_details = {
         'Species'    => join('<br />(', split(/\s*\(/, $species_defs->species_label($species))),
         'Type'       => $self->html_format ? glossary_helptip($hub, ucfirst $orthologue_desc, ucfirst "$orthologue_desc orthologues").qq{<p class="top-margin"><a href="$tree_url">View Gene Tree</a></p>} : glossary_helptip($hub, ucfirst $orthologue_desc, ucfirst "$orthologue_desc orthologues") ,
-        'dN/dS'      => qq{<span class="$dnds_class">$orthologue_dnds_ratio</span>},
         'identifier' => $self->html_format ? $id_info : $stable_id,
         'Target %id' => qq{<span class="$target_class">}.sprintf('%.2f&nbsp;%%', $target).qq{</span>},
         'Query %id'  => qq{<span class="$query_class">}.sprintf('%.2f&nbsp;%%', $query).qq{</span>},


### PR DESCRIPTION
## Description
Turns out, the Compara team wants to remove the dN/dS data from their database, which makes the dN/dS column in the orthologs table redundant. This PR removes this column.

## Views affected
Orthologs table in /:species/Gene/Compara_Ortholog

Sandbox: http://ves-hx2-76.ebi.ac.uk:8410/Homo_sapiens/Gene/Compara_Ortholog?db=core;g=ENSG00000139618;r=13:32315086-32400266;t=ENST00000380152

## Possible complications
🤷‍♂

## Related JIRA Issues (EBI developers only)
ENSWEB-5457
