### PR TITLE
Retreat to non-cache hub add if hub contains nonsense.

### DIFF
--- a/modules/EnsEMBL/Web/Utils/TrackHub.pm
+++ b/modules/EnsEMBL/Web/Utils/TrackHub.pm
@@ -222,7 +222,7 @@ sub get_hub {
   my ($self, $args) = @_;
 
   my $out = $self->get_hub_internal($args,1);
-  if($out->{'error'}) {
+  if(!$out || $out->{'error'}) {
     $out = $self->get_hub_internal($args,0);
   }
   return $out;

--- a/modules/EnsEMBL/Web/Utils/TrackHub.pm
+++ b/modules/EnsEMBL/Web/Utils/TrackHub.pm
@@ -78,13 +78,18 @@ sub url {
   return $self->{'url'};
 }
 
-sub get_hub {
+sub get_hub_internal {
 ### Fetch metadata about the hub and (optionally) its tracks
 ### @param args Hashref (optional) 
 ###                     - parse_tracks Boolean
 ###                     - assembly_lookup Hashref
-### @return Hashref               
-  my ($self, $args) = @_;
+### @return Hashref              
+###
+### This method can be run with or without the ability to check the cache.
+### A wrapper method (called just get_hub) tries it first with and, if there
+### is an error, then without. This means that caches shouldn't get "poisoned"
+### if they fail due to an intermittent failure on first population. 
+  my ($self, $args, $search_cache) = @_;
 
   ## First check the cache
   my $cache     = $self->web_hub ? $self->web_hub->cache : undef;
@@ -92,7 +97,7 @@ sub get_hub {
   my $file_args = {'hub' => $self->{'hub'}, 'nice' => 1, 'headers' => $headers}; 
   my ($trackhub, $content, @errors);
 
-  if ($cache) {
+  if ($cache && $search_cache) {
     $trackhub = $cache->get($cache_key);
   }
 
@@ -202,6 +207,25 @@ sub get_hub {
     }
     return $trackhub;
   }
+}
+
+sub get_hub {
+### Fetch metadata about the hub and (optionally) its tracks
+### @param args Hashref (optional) 
+###                     - parse_tracks Boolean
+###                     - assembly_lookup Hashref
+### @return Hashref              
+###
+### This method calls get_hub_internal first with and, if there
+### is an error, then without. This means that caches shouldn't get "poisoned"
+### if they fail due to an intermittent failure on first population. 
+  my ($self, $args) = @_;
+
+  my $out = $self->get_hub_internal($args,1);
+  if($out->{'error'}) {
+    $out = $self->get_hub_internal($args,0);
+  }
+  return $out;
 }
 
 sub get_track_info {


### PR DESCRIPTION
## Requirements

Hotfix for datahubs. Particularly high-priority because of forthcoming covid-site release.

Added multiple reviewers just prospectively. Feel free to look if you have the time, but don't feel obliged!

## Description

This fixes part of the problem with trackhub attachment for e100.

If bad data gets into the cache such that a cache get fails, then the get is retried without the cache. This limits the scope of cache get failures to the period when requests fail. The cache is populated in either case so if the request now succeeds the cache will be corrected.

A downside is that deleted datahubs will be contacted each time a page is loaded in-case they have sprung into life.

## Views affected

Region in detail (wiuth tracks attached)

## Possible complications

See Description section, last para.

## Merge conflicts

None envisaged.

## Related JIRA Issues (EBI developers only)

None. Came through on slack from Jane.
