### PR TITLE
Hide gene tree when NO_COMPARA

### DIFF
--- a/modules/EnsEMBL/Web/Component/Info/HomePage.pm
+++ b/modules/EnsEMBL/Web/Component/Info/HomePage.pm
@@ -251,11 +251,17 @@ sub genebuild_text {
 
 sub compara_text {
   my $self         = shift;
+
+  if($SiteDefs::NO_COMPARA eq 1){
+    return '';
+  }
+  
   my $hub          = $self->hub;
   my $species_defs = $hub->species_defs;
   my $sample_data  = $species_defs->SAMPLE_DATA;
   my $ftp          = $self->ftp_url;
   
+
   return sprintf('
     <div class="homepage-icon">
       %s

--- a/modules/EnsEMBL/Web/Component/Info/HomePage.pm
+++ b/modules/EnsEMBL/Web/Component/Info/HomePage.pm
@@ -252,7 +252,7 @@ sub genebuild_text {
 sub compara_text {
   my $self         = shift;
 
-  if($SiteDefs::NO_COMPARA eq 1){
+  if($SiteDefs::NO_COMPARA){
     return '';
   }
   


### PR DESCRIPTION
## Description

Hide gene tree when NO_COMPARA is set to 1.

## Views affected
http://ves-hx2-76.ebi.ac.uk:42227/Sars_cov_2/Info/Index?db=core;g=ENSSASG00005000003;r=MN908947.3:266-13483;t=ENSSAST00005000003
## Possible complications

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5709
