### PR TITLE
Fix population graphs

### DIFF
--- a/htdocs/components/10_Content.js
+++ b/htdocs/components/10_Content.js
@@ -244,6 +244,9 @@ Ensembl.Panel.Content = Ensembl.Panel.extend({
           if (panel.elLk[this.rel][0].id) {
             window.location.hash = panel.elLk[this.rel][0].id;
           }
+        } else {
+          // remove the hash from the url
+          history.replaceState("", document.title, window.location.pathname + window.location.search);
         }
       }
       

--- a/htdocs/components/15_PopulationGraph.js
+++ b/htdocs/components/15_PopulationGraph.js
@@ -29,10 +29,13 @@ Ensembl.Panel.PopulationGraph = Ensembl.Panel.Piechart.extend({
     
     this.base();
   },
-  
+
   toggleContent: function (el) {
     if (el.hasClass('closed') && !el.data('done')) {
       this.base(el);
+      if (!this.canAddContent()) {
+        return;
+      }
       this.makeGraphs(this.el.find('.' + el.attr('rel') + ' .pie_chart > div[id^=graphHolder]').map(function() { return this.id.match(/\d+/).pop() }).toArray());
       el.data('done', true);
     } else {
@@ -40,5 +43,19 @@ Ensembl.Panel.PopulationGraph = Ensembl.Panel.Piechart.extend({
     }
     
     el = null;
+  },
+
+  /*
+    Up the prototype chain (Ensembl.Panel.Piechart -> Ensembl.Panel.Content)
+    there is the `toggleable` method that gets executed during initialization.
+    This method will trigger the toggleContent method in the current class.
+    However:
+    - there is no need for the toggleContent method to run at initialization
+    - moreover, if the getContent method on Ensembl.Panel.Piechart hasn't completed
+      by the time toggleContent is executed, calling this.makeGraphs will result in an error.
+  */
+  canAddContent: function () {
+    // A rather dumb check to test that the getContent in the parent class has completed
+    return Boolean(this.graphEls);
   }
 });


### PR DESCRIPTION
## Description
### Steps to reproduce
Note the bug depends on the state of the browser (probably cookies, although I have not investigated this further)
-  Visit http://www.ensembl.org/Homo_sapiens/Variation/Population?db=core;r=1:230709548-230710548;v=rs699;vdb=variation;vf=179
- Clear site data for ensembl.org (in Chrome: open dev tools > Application > Clear site data)
- Refresh the page (make sure that there is no hash value in the end of the url)
- You should see population charts:
![image](https://user-images.githubusercontent.com/6834224/82235878-36304d00-992b-11ea-85eb-00809057e550.png) 
- Open one of the sub-populations
- Refresh the page again
- The charts will likely stop rendering
![image](https://user-images.githubusercontent.com/6834224/82235979-5a8c2980-992b-11ea-85fa-5c0e0fe247e3.png)

### Cause of the bug
If the browser does not have certain values preserved in its state (🤷‍♂️) then loading the page will trigger the `toggleable` function in Content.js, which will [simulate click](https://github.com/Ensembl/ensembl-webcode/blob/release/100/htdocs/components/10_Content.js#L268) event on any elements that have been "opened", such as the subpopulation on this page. This will fire the [toggleContent](https://github.com/Ensembl/ensembl-webcode/blob/release/100/htdocs/components/15_PopulationGraph.js#L33-L43) method on PopulationGraph, which will call the [makeGraphs](https://github.com/Ensembl/ensembl-webcode/blob/release/100/htdocs/components/15_PopulationGraph.js#L36) function. The problem here is that for the `makeGraphs` function to work, the [getContent](https://github.com/Ensembl/ensembl-webcode/blob/release/100/htdocs/components/10_Piechart.js#L33-L59) method must first have executed; otherwise there won't be necessary data in the Piechart class, and `makeGraphs` will fail.

### Solution
Check whether the `getContent` method has completed (by an attribute that it sets on the Piechart class) before running `makeGraphs`. It may not be a very pretty solution, but since this code will eventually be replaced, it's probably ok.

### Another change
Remove the hash anchor from the url when a toggleable element is turned off.

## Views affected
Population genetics for variant.

View in sandbox: http://ves-hx2-76.ebi.ac.uk:8410/Homo_sapiens/Variation/Population?db=core;r=1:230709548-230710548;v=rs699;vdb=variation;vf=179

## Possible complications
🤷‍♂️ 

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5503