### PR TITLE
fix clinvar phenotype source

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -341,7 +341,8 @@ AMDGC                       = http://www.sph.umich.edu/csg/abecasis/public/amdge
 ANIMAL_QTLDB                = http://www.animalgenome.org/cgi-bin/QTLdb/###SP###/qdetails?QTL_ID=###ID###
 CANCER_GENE_CENSUS          = http://cancer.sanger.ac.uk/census
 CLIN_SIG                    = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
-CLINVAR                     = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR                     = http://www.ncbi.nlm.nih.gov/clinvar/###ID###
+CLINVAR_VAR                 = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
 CLINVAR_DBSNP               = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 COSMIC                      = http://cancer.sanger.ac.uk/cosmic/search?q=###ID###
 COSMIC_STUDY                = http://cancer.sanger.ac.uk/cosmic/browse/tissue?#sn=###ID###&ss=&hn=&sh=&in=t&src=tissue

--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -375,7 +375,7 @@ sub synonyms {
     elsif ($db =~ /clinvar/i) {
       foreach (@ids) {
         next if /^RCV/; # don't display RCVs as synonyms
-        push @urls, $hub->get_ExtURL_link($_, 'CLINVAR', $_);
+        push @urls, $hub->get_ExtURL_link($_, 'CLINVAR_VAR', $_);
       }
     }
     elsif ($db =~ /Uniprot/) {


### PR DESCRIPTION
## Description

At least two places link out to ClinVar requiring two different URLs: variation synonyms section and phenotype data source column.
This PR is to fix it the broken source column ClinVar link out without breaking the synonyms link out.

## Views affected

Variation summary section, phenotype data source column and all views that contain it.

Phenotype data table -> source column ->  ClinVar link out:
- Broken link: http://staging.ensembl.org/Homo_sapiens/Variation/Phenotype?r=1:230709548-230710548;v=rs699;vdb=variation;vf=179
- Fixed: http://ves-hx2-76.ebi.ac.uk:6080/Homo_sapiens/Variation/Phenotype?r=1:230709548-230710548;v=rs699;vdb=variation;vf=179


## Possible complications

None expected.


## Merge conflicts

None.

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-3252
