### PR TITLE
Remove link out for non specified phenotypes

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/GenePhenotype.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GenePhenotype.pm
@@ -55,6 +55,7 @@ sub gene_phenotypes {
   my (@rows, %list, $list_html);
   my $has_allelic = 0;  
   my $has_study   = 0;
+  my $skip_phenotypes_link = "non_specified";
   my %phenotypes;
 
   return if($obj->isa('Bio::EnsEMBL::Compara::Family'));
@@ -69,6 +70,7 @@ sub gene_phenotypes {
       my $features;
       foreach my $pf (@{$pfa->fetch_all_by_Gene($obj)}) {
         my $phe    = $pf->phenotype->description;
+        my $phe_class = $pf->phenotype_class;
         my $ext_id = $pf->external_id;
         my $source = $pf->source_name;
         my $strain = $pf->strain;
@@ -111,7 +113,7 @@ sub gene_phenotypes {
         my $key = join("\t", ($phe, $strain_name, $allele_symbol));
         $features->{$key}->{source} = $source;
         push @{$features->{$key}->{gender}}, $strain_gender;
-        $features->{$key}->{url} = $phe_url;
+        $features->{$key}->{url} = $phe_class eq $skip_phenotypes_link ? $phe : $phe_url;
         $features->{$key}->{pmid} = $pmids;
       }
       foreach my $key (sort keys %$features) {
@@ -127,6 +129,7 @@ sub gene_phenotypes {
     } else {    
       foreach my $pf(@{$pfa->fetch_all_by_Gene($obj)}) {
         my $phe     = $pf->phenotype->description;
+        my $phe_class = $pf->phenotype_class;
         my $source  = $pf->source_name;
         my $ext_id  = $pf->external_id;
 
@@ -163,7 +166,7 @@ sub gene_phenotypes {
           'View associate loci',
           $phe
         );
-        $phenotypes{$phe}{'url'} = $phe_url;
+        $phenotypes{$phe}{'url'} = $phe_class eq $skip_phenotypes_link? $phe : $phe_url;
 
         my $allelic_requirement = '-';
         if ($self->_inheritance($attribs)) {

--- a/modules/EnsEMBL/Web/Component/Gene/GenePhenotypeOrthologue.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GenePhenotypeOrthologue.pm
@@ -39,6 +39,7 @@ sub content {
   my $species_defs = $hub->species_defs;
   my $cdb          = shift || $hub->param('cdb') || 'compara';
   
+  my $skip_phenotypes_link = 'non_specified';
   my $html = '';
   
   my @orthologues = (
@@ -87,6 +88,7 @@ sub content {
         
         # phenotype
         my $phen_desc = $pf->phenotype->description;
+        my $phen_class = $pf->phenotype_class;
         my $phen_link = $hub->url({
           species => $species,
           type    => 'Phenotype',
@@ -100,6 +102,7 @@ sub content {
           $phen_desc,
           $pf->source_name
         );
+        $phen = $phen_desc if $phen_class eq $skip_phenotypes_link;
         
         # source
         my $source = $pf->source_name;

--- a/modules/EnsEMBL/Web/Component/Gene/GenePhenotypeVariation.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GenePhenotypeVariation.pm
@@ -103,6 +103,8 @@ sub stats_table {
   my $pf_adaptor   = $self->hub->database('variation')->get_PhenotypeFeatureAdaptor;
   my ($total_counts, %phenotypes, @va_ids);
 
+  my $skip_phenotypes_link = "non_specified";
+
   my $columns = [
     { key => 'phen',    title => 'Phenotype, disease and trait', sort => 'string', width => '35%'  },
     { key => 'source',  title => 'Source(s)', sort => 'string', width => '11%'  },
@@ -117,10 +119,12 @@ sub stats_table {
 
     my $var_name = $pf->object_id;
     my $phe      = $pf->phenotype->description;
+    my $phe_class= $pf->phenotype_class;
    
     $phenotypes{$phe} ||= { id => $pf->{'_phenotype_id'} , name => $pf->{'_phenotype_name'}};
     $phenotypes{$phe}{'count'}{$var_name} = 1;
     $phenotypes{$phe}{'source'}{$phe_source} = 1;
+    $phenotypes{$phe}{skip_link} = $phe_class eq $skip_phenotypes_link ? 1 : 0;
 
     $total_counts->{$var_name} = 1;
   }  
@@ -164,7 +168,7 @@ sub stats_table {
                    }),
                    'View associate loci',
                    $_
-                 ) unless /(HGMD|COSMIC)/;
+                 ) unless /(HGMD|COSMIC)/ || $phenotypes{$_}{skip_link};
     }
        
     push @rows, {

--- a/modules/EnsEMBL/Web/Component/StructuralVariation/Phenotype.pm
+++ b/modules/EnsEMBL/Web/Component/StructuralVariation/Phenotype.pm
@@ -73,6 +73,8 @@ sub table_data {
   my $hub        = $self->hub;
   my $object     = $self->object;
   
+  my $skip_phenotypes_link = 'non_specified';
+
   my %phenotypes;
   my %clin_sign;
   my %column_flags;
@@ -83,7 +85,9 @@ sub table_data {
   my $sv_pf = $self->object->Obj->get_all_PhenotypeFeatures();
   foreach my $pf (@$sv_pf) {
     my $phe = $pf->phenotype->description;
-    if (!exists $phenotypes{$phe}) {
+    my $phe_class = $pf->phenotype_class;
+
+    if (!exists $phenotypes{$phe} && $phe_class ne $skip_phenotypes_link) {
       my $phe_url = $hub->url({ type => 'Phenotype', action => 'Locations', ph => $pf->phenotype->dbID, name => $phe });
       $phenotypes{$phe} = { disease => qq{<a href="$phe_url" title="View associate loci"><b>$phe</b></a>} };
     }
@@ -108,6 +112,7 @@ sub table_data {
       next if ($sva->seq_region_start==0 || $sva->seq_region_end==0);
       
       my $phe = ($sva->phenotype) ? $sva->phenotype->description : undef;
+      my $phe_class = $sva->phenotype_class;
 
        # Ontology data
       ($terms, $accessions) = $self->get_ontology_data($sva,$phe,$terms,$accessions);
@@ -133,6 +138,8 @@ sub table_data {
             disease    => qq{<a href="$phe_url" title="View associate loci"><b>$phe</b></a>},
             s_evidence => $sva->object_id
           };
+          $phenotypes{$phe}{disease}=$phe if ($phe_class eq $skip_phenotypes_link);
+
         }
       }
     }

--- a/modules/EnsEMBL/Web/Component/Variation/Phenotype.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Phenotype.pm
@@ -168,12 +168,11 @@ sub table_data {
     }
 
     my $id                   = $pf->{'_phenotype_id'};
-    my $phenotype_class      = $pf->{'_phenotype_class_attrib'};
+    my $phenotype_class      = $pf->phenotype_class;
     my $pf_id                = $pf->dbID;
     my $source_name          = $pf->source_name;
     my $study_name           = $pf->study ? $pf->study->name : '';
-    my $disease_url          = "";
-    $disease_url             = $hub->url({ type => 'Phenotype', action => 'Locations', ph => $id, name => $disorder }) unless $phenotype_class eq $skip_phenotypes_link;
+    my $disease_url          = $hub->url({ type => 'Phenotype', action => 'Locations', ph => $id, name => $disorder });
     my $external_id          = ($pf->external_id) ? $pf->external_id : $study_name;
     my $external_reference   = $self->external_reference_link($pf->external_reference) || $pf->external_reference; # use raw value if can't be made into a link
     my $associated_studies   = $pf->associated_studies; # List of Study objects
@@ -285,7 +284,7 @@ sub table_data {
     }
     # Associate loci link
     if ($bm_flag == 0) {
-      $disease = qq{<a href="$disease_url" title="View associate loci">$disease</a>} unless ($disease =~ /HGMD/);
+      $disease = qq{<a href="$disease_url" title="View associate loci">$disease</a>} unless ($disease =~ /HGMD/ || $phenotype_class eq $skip_phenotypes_link);
     }
 
     # Stats column

--- a/modules/EnsEMBL/Web/Component/Variation/Phenotype.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Phenotype.pm
@@ -148,6 +148,7 @@ sub table_data {
   my $variation_names = 'variation_names';
   my @stats_col = ('p_value','odds_ratio','beta_coef');
   my $submitter_max_length = 20;
+  my $skip_phenotypes_link = 'non_specified';
 
   foreach my $pf (@$external_data) {
 
@@ -167,10 +168,12 @@ sub table_data {
     }
 
     my $id                   = $pf->{'_phenotype_id'};
+    my $phenotype_class      = $pf->{'_phenotype_class_attrib'};
     my $pf_id                = $pf->dbID;
     my $source_name          = $pf->source_name;
     my $study_name           = $pf->study ? $pf->study->name : '';
-    my $disease_url          = $hub->url({ type => 'Phenotype', action => 'Locations', ph => $id, name => $disorder });
+    my $disease_url          = "";
+    $disease_url             = $hub->url({ type => 'Phenotype', action => 'Locations', ph => $id, name => $disorder }) unless $phenotype_class eq $skip_phenotypes_link;
     my $external_id          = ($pf->external_id) ? $pf->external_id : $study_name;
     my $external_reference   = $self->external_reference_link($pf->external_reference) || $pf->external_reference; # use raw value if can't be made into a link
     my $associated_studies   = $pf->associated_studies; # List of Study objects


### PR DESCRIPTION
## Description

_Using one or more sentences, describe the proposed changes and the reason for making them._
Listed phenotypes link out to a view displaying all loci with this phenotypes. This link should be removed for the phenotypes that are of type 'non_specified'.

## Views affected

_List the website view(s) that you know are affected by this change._
_If possible please provide a URL that shows the change. For Ensembl developers this could be your sandbox._

Gene, variation, structural variation phenotypes view.

example phenotype: "ClinVar: phenotype not specified"
Gene phenotypes view:

- e100: http://www.ensembl.org/Homo_sapiens/Gene/Phenotype?db=core;g=ENSG00000182372;r=8:1755778-1801711;source=dbSNP;v=rs184988046;vdb=variation;vf=144518072
- e101: http://ves-hx2-76.ebi.ac.uk:6080/Homo_sapiens/Gene/Phenotype?db=core;g=ENSG00000182372;r=8:1755778-1801711;source=dbSNP;v=rs184988046;vdb=variation;vf=144518072

Fixed for Variation: http://ves-hx2-76.ebi.ac.uk:6080/Homo_sapiens/Variation/Phenotype?db=core;r=8:1770872-1771872;v=rs184988046;vdb=variation;vf=144518072

Fixed for Structural Variation: http://ves-hx2-76.ebi.ac.uk:6080/Homo_sapiens/StructuralVariation/Phenotype?db=core;r=X:154030127-154031213;sv=nsv1197401;svf=123066747;vdb=variation

## Possible complications

None expected.

## Merge conflicts

None.

## Related JIRA Issues (EBI developers only)

ENSVAR-2926