### PR TITLE
fix species selector bug due to recent changes in SpeciesDefs

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -200,6 +200,7 @@ our @ENSEMBL_CONF_DIRS               = ("$ENSEMBL_WEBROOT/conf");               
 our @ENSEMBL_HTDOCS_DIRS             = ($ENSEMBL_DOCROOT, "$ENSEMBL_SERVERROOT/biomart-perl/htdocs");  # locates static content
 our $ENSEMBL_TAXONOMY_DIVISION_FILE  = ("$ENSEMBL_DOCROOT/e_divisions.json");
 our $DEFAULT_SPECIES_IMG_DIR         = 'htdocs/i/species';
+our $SPECIES_IMAGE_DIR               = defer { $SiteDefs::ENSEMBL_SERVERROOT.'/public-plugins/ensembl/'. $SiteDefs::DEFAULT_SPECIES_IMG_DIR };
 ###############################################################################
 
 

--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -200,7 +200,6 @@ our @ENSEMBL_CONF_DIRS               = ("$ENSEMBL_WEBROOT/conf");               
 our @ENSEMBL_HTDOCS_DIRS             = ($ENSEMBL_DOCROOT, "$ENSEMBL_SERVERROOT/biomart-perl/htdocs");  # locates static content
 our $ENSEMBL_TAXONOMY_DIVISION_FILE  = ("$ENSEMBL_DOCROOT/e_divisions.json");
 our $DEFAULT_SPECIES_IMG_DIR         = 'htdocs/i/species';
-our $SPECIES_IMAGE_DIR               = defer { $SiteDefs::ENSEMBL_SERVERROOT.'/public-plugins/ensembl/'. $SiteDefs::DEFAULT_SPECIES_IMG_DIR };
 ###############################################################################
 
 

--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -821,8 +821,6 @@ sub _parse {
       }
     }
   }
-  # Used for grouping same species with different assemblies in species selector
-  $tree->{'SPECIES_ASSEMBLY_MAP'} = $species_to_assembly;
 
   ## Compile strain info into a single structure
   while (my($k, $v) = each (%$species_to_strains)) {
@@ -896,8 +894,8 @@ sub _parse {
                                                     $common_name : $scientific_name; 
 
         # Populate taxonomy division using e_divisions.json template
-        push @{$species_to_assembly->{$common_name}}, $config_packer->tree->{'ASSEMBLY_VERSION'};
-        my $taxonomy = $config_packer->tree->{TAXONOMY};
+        push @{$species_to_assembly->{$common_name}}, $tree->{$url}->{'ASSEMBLY_VERSION'};
+        my $taxonomy = $tree->{$url}->{TAXONOMY};
         my $children = [];
         my $other_species_children = [];
         my @other_species = grep { $_->{key} =~ m/other_species/ } @{$tree->{'ENSEMBL_TAXONOMY_DIVISION'}->{child_nodes}};
@@ -973,6 +971,10 @@ sub _parse {
       warn "!!! SPECIES $prodname has no URL defined";
     }
   } 
+
+  # Used for grouping same species with different assemblies in species selector
+  $tree->{'SPECIES_ASSEMBLY_MAP'} = $species_to_assembly;
+
   $tree->{'MULTI'}{'ENSEMBL_DATASETS'} = $datasets;
   #warn ">>> NEW KEYS: ".Dumper($tree);
 


### PR DESCRIPTION
## Description

Species selector not adding species to its proper clade.
Reason is that it SPECIES_IMAGE_DIR is not set. This was added for RR site and is undef for the current site there by not setting the SPECIES_IMAGE variable.

## Views affected

Species selector in BLAST, Alignments and AlignSlice

## Possible complications

Need to check why $config_packer->tree->{ASEEMBLY_VERSION} is not available here https://github.com/Ensembl/ensembl-webcode/compare/hotfix-sp-selector?expand=1#diff-93e79820da11cca1db9ee8ce3e7b1811L899

We will have to cherry pick this to master branch because I couldn't do it in postreleasefix/100 branch as this RR SPECIES_IMAGE addition commit is only available in master and release/100. This created a fix for release/100

## Merge conflicts

No

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5873
