### PR TITLE
Use correct speciesdefs property in compara alignments species selector

### DIFF
--- a/modules/EnsEMBL/Web/JSONServer/SpeciesSelector/Compara_Alignments.pm
+++ b/modules/EnsEMBL/Web/JSONServer/SpeciesSelector/Compara_Alignments.pm
@@ -71,7 +71,7 @@ sub json_fetch_species {
       $prod_name = encode_entities($prod_name);
       my $t_child = {};
       $t_child->{key}        = join '_', ('species', $row->{id}, lc($prod_name));
-      $t_child->{title}      = encode_entities($ancestral ? '--Ancestral_sequences--' : $species_info->{$url_name}->{common});
+      $t_child->{title}      = encode_entities($ancestral ? '--Ancestral_sequences--' : $species_info->{$url_name}->{display_name});
       $t_child->{value}      = $row->{id};
       $t_child->{scientific_name} = $prod_name;
       $t_child->{img_url}    = $sd->ENSEMBL_IMAGE_ROOT . '/species/' . $url_name . '.png';


### PR DESCRIPTION
## Description
Fix of a bug in Compara species selector panel.

The bug presents as follows (notice no strain name in the list of mouse species):

![image](https://user-images.githubusercontent.com/6834224/89083290-76c73080-d388-11ea-9bd9-b26f7821e681.png)

While this is what is expected (currently in production for e100):

![image](https://user-images.githubusercontent.com/6834224/89083472-8fcfe180-d388-11ea-8f16-69d23dc0e0e5.png)

### Cause of bug
The code in the compara module uses the "common name" of a species rather than its "display name":

```
$t_child->{title}      = encode_entities($ancestral ? '--Ancestral_sequences--' : $species_info->{$url_name}->{common});
```

`$species_info->{$url_name}->{common});` refers to [this line](https://github.com/Ensembl/ensembl-webcode/blob/release/100/modules/EnsEMBL/Web/Hub.pm#L354) in Hub:

```
'common'            => $species_defs->get_config($_, 'SPECIES_COMMON_NAME'),
```

In ConfigPacker for release 100, "SPECIES_COMMON_NAME" field was populated with the value of `species.display_name` meta key from the database. This, however, got changed in https://github.com/Ensembl/ensembl-webcode/commit/34e718b92bdabe316cc3636c66ab0c20f8ad141d, where `SPECIES_COMMON_NAME` started receiving the value of `species.common_name` meta key, and a new property, `SPECIES_DISPLAY_NAME`, was introduced to keep the value of `species.display_name` meta key:

![image](https://user-images.githubusercontent.com/6834224/89086962-6d3ec800-d38a-11ea-807b-78987898e93f.png)

Which resulted in Compara module using the wrong value.

## Views affected
Compara alignments view.

**Sandbox:** http://ves-hx2-76.ebi.ac.uk:8410/Mus_musculus/Location/Compara_Alignments/Image?align=835;db=core;r=4%3A136366473-136547301;time=1596020339619.619 — click on Select another alignment next to "18 murinae Cactus"

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5900