### PR TITLE
Update the helptext for the eQTL track popup

### DIFF
--- a/modules/EnsEMBL/Web/ImageConfig/generegview.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/generegview.pm
@@ -66,7 +66,9 @@ sub init_cacheable {
     $tissue_readable =~ s/_/ /g;
     my $manplot_desc = qq(
       Complete set of eQTL correlation statistics as computed by the GTEx consortium on $tissue_readable samples.
-      The GTEx Consortium. Science. 8 May 2015: Vol 348 no. 6235 pp 648-660. DOI: 10.1126/science. PMID: 1262110.
+      The GTEx Consortium. Science. 8 May 2015: Vol 348 no. 6235 pp 648-660.
+      DOI: <a href="https://doi.org/10.1126/science.1262110">10.1126/science.1262110</a>.
+      PMID: <a href="http://www.ncbi.nlm.nih.gov/pubmed/25954001">25954001</a>
     );
     $self->add_track('functional_gene_expression',"reg_manplot_$tissue","$tissue_readable GTEX eQTLs",'reg_manplot',{
       tissue => $tissue,


### PR DESCRIPTION

## Description

The PR fixes an incorrect DOI in the description popup for the eQTL track,
 (see [http://www.ensembl.org/Homo_sapiens/Gene/Regulation?db=core;g=ENSG00000248746;r=11:66546395-66563334](http://www.ensembl.org/Homo_sapiens/Gene/Regulation?db=core;g=ENSG00000248746;r=11:66546395-66563334)), and converts the DOI and PMID into links.

## Views affected

Helptext popup for eQTL track.

## Possible complications

Should be none. Text fix only.

## Merge conflicts

None.

## Related JIRA Issues (EBI developers only)

[https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5896](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5896)
