### PR TITLE
Receive stable id as argument

### DIFF
--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -909,12 +909,13 @@ sub get_homologue_alignments {
 sub get_compara_Member {
   my $self       = shift;
   my $compara_db = shift || 'compara';
-  my $cache_key  = "_compara_member_$compara_db";
+  my $stable_id  = shift || $self->stable_id;
+  my $cache_key  = "_compara_member_$compara_db\_$stable_id";
   
   if (!$self->{$cache_key}) {
     my $compara_dba = $self->database($compara_db)              || return;
     my $adaptor     = $compara_dba->get_adaptor('GeneMember')   || return;
-    my $member      = $adaptor->fetch_by_stable_id($self->stable_id);
+    my $member      = $adaptor->fetch_by_stable_id($stable_id);
     
     $self->{$cache_key} = $member if $member;
   }


### PR DESCRIPTION
## Description

Method changed to receive stable_id passed as argument

## Views affected

This is a work related to the pan compara page. But no views will be affected by this change. This is related to a PR in eg-web-common.

## Merge conflicts
N/A

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5635
