### PR TITLE
Fix links to trackhub help pages

### DIFF
--- a/htdocs/info/website/upload/index.html
+++ b/htdocs/info/website/upload/index.html
@@ -10,7 +10,7 @@
 
 <ul>
 <li><a href="#addtrack">How to add custom tracks</a></li>
-<li><a href="/info/website/adding_trackhubs.html">How to add track hubs</a></li>
+<li><a href="/info/website/trackhubs/adding_trackhubs.html">How to add track hubs</a></li>
 <li><a href="#formats">Supported file formats</a></li>
 <li><a href="#samples">Sample data files</a></li>
 <li><a href="#access">Data access and security</a></li>
@@ -81,7 +81,7 @@ Use either <a href="coords.html">chromosome</a> or (finished)
 <li><a href="wig.html">WIG</a>
   <ul>
   <li><a href="large.html#bw-format">bigWig</a></li>
-  <li><a href="info/website/trackhub_support.html#grouping">TrackHubs with multiWigs</a></li>
+  <li><a href="/info/website/trackhubs/trackhub_support.html#grouping">TrackHubs with multiWigs</a></li>
   </ul>
 </li>
 </ul>

--- a/modules/EnsEMBL/Web/Component/UserData.pm
+++ b/modules/EnsEMBL/Web/Component/UserData.pm
@@ -109,7 +109,7 @@ sub userdata_form {
   my $message         = qq(<p>
 Please note that track hubs and indexed files (BAM, BigBed, etc) do not work with certain
 cloud services, including <b>Google Drive</b> and <b>Dropbox</b>. Please see our 
-<a href="/info/website/trackhub_support.html">support page</a> for more information.
+<a href="/info/website/trackhubs/trackhub_support.html">support page</a> for more information.
 </p>);
 
 


### PR DESCRIPTION
## Description
Fix some links that got broken outdated after the refactoring in [this commit](https://github.com/Ensembl/ensembl-webcode/commit/0ca6abecd7efffd8da223e7e93b702a3f91c7e4d). 

### List of links (in production):
- on [Adding Custom Tracks page](http://www.ensembl.org/info/website/upload/index.html): links "How to add track hubs" and  "TrackHubs with multiWigs"
- in the Custom Tracks popup, Personal Data tab, link to "support page":

![image](https://user-images.githubusercontent.com/6834224/92291910-b5fe1980-ef12-11ea-8091-764cb81d4f70.png)

## Sandbox with fixes
http://ves-hx2-76.ebi.ac.uk:8410/

## Question
There is a link to the page that was deleted in [this commit](https://github.com/Ensembl/ensembl-webcode/commit/0ca6abecd7efffd8da223e7e93b702a3f91c7e4d) on the [Adding Track Hubs to Ensembl page](http://www.ensembl.org/info/website/trackhubs/adding_trackhubs.html) (link text: "search the Trackhub registry itself"). What should we do with it?

