### PR TITLE
Add links for NCBI ALFA pops and terms of use.

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -334,6 +334,8 @@ ZFIN_XPAT                   = http://zfin.org/cgi-bin/webdriver?MIval=aa-xpatsel
 
 ## Variation only
 1KG_POP                     = http://www.1000genomes.org/faq/which-populations-are-part-your-study
+ALFA_POP                    = https://www.ncbi.nlm.nih.gov/snp/docs/gsr/alfa/
+ALFA_POP_USE                = https://www.ncbi.nlm.nih.gov/snp/docs/gsr/terms_of_use/
 ALLELE_REGISTRY             = http://reg.genome.network
 ALLELE_REGISTRY_DISPLAY     = http://reg.clinicalgenome.org/redmine/projects/registry/genboree_registry/by_caid?caid=###ID###
 ALLELE_REGISTRY_TEST        = http://reg.test.genome.network

--- a/modules/EnsEMBL/Web/Component/Variation.pm
+++ b/modules/EnsEMBL/Web/Component/Variation.pm
@@ -65,6 +65,9 @@ sub pop_url {
   if($pop_name =~ /^1000GENOMES/) {
     $pop_url = $hub->get_ExtURL('1KG_POP', $pop_label);
   }
+  elsif ($pop_name =~ /ALFA/i) {
+    $pop_url = $hub->get_ExtURL('ALFA_POP');
+  }
   elsif ($pop_name =~ /^NextGen/i) {
     $pop_url = $hub->get_ExtURL('NEXTGEN_POP');
   }

--- a/modules/EnsEMBL/Web/Component/Variation/PopulationGenotypes.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/PopulationGenotypes.pm
@@ -504,7 +504,7 @@ sub generic_group_link {
   $title =~ /^(.+)\s*\(\d+\)/;
   my $project_name = ($1) ? $1 : $title;
 
-  my $terms;
+  my $terms = '';
   my $pop_use_url;
   if ($project_name =~ /ncbi alfa/i) {
     $pop_use_url = $self->hub->get_ExtURL('ALFA_POP_USE');

--- a/modules/EnsEMBL/Web/Component/Variation/PopulationGenotypes.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/PopulationGenotypes.pm
@@ -504,9 +504,18 @@ sub generic_group_link {
   $title =~ /^(.+)\s*\(\d+\)/;
   my $project_name = ($1) ? $1 : $title;
 
-  $project_name = ($project_name =~ /(project|consortium)/i) ? "<b>$project_name</b> " : '';
-  
-  return sprintf('<div style="clear:both"></div><p><a href="%s" rel="external">More information about the %spopulations</a></p>', $pop_url, $project_name);
+  my $terms;
+  my $pop_use_url;
+  if ($project_name =~ /ncbi alfa/i) {
+    $pop_use_url = $self->hub->get_ExtURL('ALFA_POP_USE');
+    if ($pop_use_url) {
+      $terms = sprintf(' (<a href="%s" rel="external">Terms of Use</a>)', $pop_use_url);
+    }
+  }
+
+  $project_name = ($project_name =~ /(project|consortium|ncbi alfa)/i) ? "<b>$project_name</b> " : '';
+
+  return sprintf('<div style="clear:both"></div><p><a href="%s" rel="external">More information about the %spopulations</a>%s</p>', $pop_url, $project_name, $terms);
 }
 
 sub format_allele_genotype_content {


### PR DESCRIPTION
## Requirements

NCBI ALFA frequency data from VCF  has been included in population genetics pages for release/102

A description of the populations and terms of use  for this new data is needed for release/102

## Description

The links have been added to DEFAULTS.ini. The population url is similar to that done for 1000Genomes.
New code to include "Terms of use"


## Views affected

Population Genetics view - At the bottom of the table for NCBI ALFA

http://ves-hx2-76.ebi.ac.uk:5050/Homo_sapiens/Variation/Population?db=core;r=1:230709548-230710548;v=rs699;vdb=variation;vf=179#ncbialfa_anchor

## Possible complications

None identified as conditions are for ALFA NCBI

## Merge conflicts

Tested  on sandbox, branched from master.

## Related JIRA Issues (EBI developers only)

ENSVAR-3485 - ALFA usage
ENSVAR-3340 - Adding ALFA data
