### PR TITLE
Fix TSL popup issue on transcript table.

### DIFF
--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -308,8 +308,8 @@ sub transcript_table {
         }
         if ($trans_attribs->{$tsi}{'TSL'}) {
           my $tsl = uc($trans_attribs->{$tsi}{'TSL'} =~ s/^tsl([^\s]+).*$/$1/gr);
-          push @flags, helptip("TSL:$tsl", get_glossary_entry($hub, "TSL:$tsl").get_glossary_entry($hub, 'TSL'));
-        }
+          push @flags, helptip("TSL:$tsl", get_glossary_entry($hub, "TSL $tsl").get_glossary_entry($hub, 'Transcript support level'));
+	}
       }
       if ($trans_gencode->{$tsi}) {
         if ($trans_gencode->{$tsi}{'gencode_basic'}) {


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description
@ens-ma7 's explained the cause of this issue in the related Jira ticket:
_Since we moved the help system to using the EBI glossary (https://www.ebi.ac.uk/ols/api/ontologies/ensemblglossary/terms?size=500 ), the key for retrieving the help content for TSL has changed. Instead of TSL:1 it is now "TSL 1" and for TSL it is "Transcript support level"._

## Views affected

Transcript table TSL popup:
http://www.ensembl.org/Homo_sapiens/Gene/Summary?g=ENSG00000139618;r=13:32315086-32400268

## Possible complications
_

## Merge conflicts
_

## Related JIRA Issues (EBI developers only)

_ Sandbox link is added to the following ticket:
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5684
