### PR TITLE
Fix cactus alignment - out of memory error

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -95,7 +95,7 @@ our $ENSEMBL_CONFIG_BUILD             = 0; # Build config on server startup? Set
 our $ENSEMBL_SERVER_SIGNATURE         = "$ENSEMBL_SERVER-$ENSEMBL_SERVERROOT" =~ s/\W+/-/gr; # Unique string representing this machine/server
 our $ENSEMBL_SITETYPE                 = 'Ensembl';
 our $ENSEMBL_HELPDESK_EMAIL           = defer { $ENSEMBL_SERVERADMIN };   # Email address for contact form and help pages
-our $PERL_RLIMIT_AS                   = '2048:4096';                      # linux does not honor RLIMIT_DATA, RLIMIT_AS (address space) will work to limit the size of a process
+our $PERL_RLIMIT_AS                   = '2560:4096';                      # linux does not honor RLIMIT_DATA, RLIMIT_AS (address space) will work to limit the size of a process
 our $ENSEMBL_REST_URL                 = 'http://rest.mydomain.org';       # url to your REST service
 our $CGI_POST_MAX                     = 20 * 1024 * 1024; # 20MB file upload max limit
 our $UPLOAD_SIZELIMIT_WITHOUT_INDEX   = 10 * 1024 * 1024; # 10MB max allowed for url uploads that don't have index files in the same path


### PR DESCRIPTION
## Description

This PR is to fix the error displayed in the following page:
http://www.ensembl.org/Mus_musculus/Location/Compara_Alignments/Image?align=835;db=core;r=4%3A136366473-136547301;time=1596020339619.619

I have increased the PERL_RLIMIT_AS value from `2048` to `2560` to fix this issue.

## Views affected
Temporarily fixed this on staging:
http://staging.ensembl.org/Mus_musculus/Location/Compara_Alignments/Image?align=835;db=core;r=4%3A136366473-136547301;time=1596020339619.619

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5908
