### PR TITLE
Update transcript table to display uniprot isoform

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -574,7 +574,6 @@ UNIPROT                  = http://www.uniprot.org/uniprot/###ID###
 UNIPROTKB/SWISS-PROT        = http://www.uniprot.org/uniprot/###ID###
 UNIPROTKB/TREMBL            = http://www.uniprot.org/uniprot/###ID###
 UNIPROT/VARSPLIC            = http://www.uniprot.org/uniprot/###ID###
-UNIPROT_ISOFORM          = http://www.uniprot.org/uniprot/###ID###
 UNISTS                   = http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=search&db=unists&term=###ID###
 VB_ARRAY                    =
 VEGA                     = http://vega.sanger.ac.uk/

--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -322,6 +322,7 @@ UNIPARC                     = http://www.uniprot.org/uniparc/###ID###
 UNIPATHWAY                  = http://www.grenoble.prabi.fr/obiwarehouse/unipathway/upa?upid=###ID###
 UNIPROT/SPTREMBL            = http://www.uniprot.org/uniprot/###ID###
 UNIPROT/SWISSPROT           = http://www.uniprot.org/uniprot/###ID###
+UNIPROT_ISOFORM             = http://www.uniprot.org/uniprot/###ID###
 VEGA_GENE                   = http://vega.sanger.ac.uk/###SPECIES###/Gene/Summary?g=###ID###
 VEGA_TRANSCRIPT             = http://vega.sanger.ac.uk/###SPECIES###/Transcript/Summary?t=###ID###
 VEGA_TRANSLATION            = http://vega.sanger.ac.uk/###SPECIES###/Transcript/ProteinSummary?peptide=###ID###
@@ -573,6 +574,7 @@ UNIPROT                  = http://www.uniprot.org/uniprot/###ID###
 UNIPROTKB/SWISS-PROT        = http://www.uniprot.org/uniprot/###ID###
 UNIPROTKB/TREMBL            = http://www.uniprot.org/uniprot/###ID###
 UNIPROT/VARSPLIC            = http://www.uniprot.org/uniprot/###ID###
+UNIPROT_ISOFORM          = http://www.uniprot.org/uniprot/###ID###
 UNISTS                   = http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=search&db=unists&term=###ID###
 VB_ARRAY                    =
 VEGA                     = http://vega.sanger.ac.uk/

--- a/modules/EnsEMBL/Web/Component/Gene/GeneSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GeneSummary.pm
@@ -93,7 +93,7 @@ sub content {
   }
 
   my $uniprot_match_title = 'UniProt match';
-  my $uniprot_match_description = get_glossary_entry($self->hub, 'Uniprot_match');
+  my $uniprot_match_description = get_glossary_entry($self->hub, 'UniProt Match');
   
   # add Uniprot info
   if (scalar @Uniprot_isoform) {

--- a/modules/EnsEMBL/Web/Component/Gene/GeneSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GeneSummary.pm
@@ -24,8 +24,6 @@ use strict;
 use EnsEMBL::Web::Document::Image::R2R;
 use EnsEMBL::Web::Utils::Bioschemas qw(create_bioschema add_species_bioschema);
 
-use EnsEMBL::Web::Utils::FormatText qw(get_glossary_entry);
-
 use base qw(EnsEMBL::Web::Component::Gene);
 
 sub _init {
@@ -35,20 +33,20 @@ sub _init {
 }
 
 sub content {
-  my $self            = shift;
-  my $hub             = $self->hub;
-  my $object          = $self->object;
-  my $gene            = $object->gene;
-  my $species_defs    = $hub->species_defs;
-  my $table           = $self->new_twocol;
-  my $sub_type        = $species_defs->ENSEMBL_SUBTYPE;
-  my @CCDS            = @{$object->Obj->get_all_DBLinks('CCDS')};
-  my @Uniprot         = @{$object->Obj->get_all_DBLinks('Uniprot/SWISSPROT')};
-  my $db              = $object->get_db;
-  my $alt_genes       = $self->_matches('alternative_genes', 'Alternative Genes', 'ALT_GENE', 'show_version'); #gets all xrefs, sorts them and stores them on the object. Returns HTML only for ALT_GENES
-  my $ensembl_select  = $gene->get_all_Attributes('Ensembl_select')->[0] ? $gene->get_all_Attributes('Ensembl_select')->[0]->value : '';
-  my $display_xref    = $gene->display_xref;
-  my ($link_url)      = $display_xref ? $self->get_gene_display_link($gene, $display_xref) : ();
+  my $self          = shift;
+  my $hub           = $self->hub;
+  my $object        = $self->object;
+  my $gene          = $object->gene;
+  my $species_defs  = $hub->species_defs;
+  my $table         = $self->new_twocol;
+  my $sub_type      = $species_defs->ENSEMBL_SUBTYPE;
+  my @CCDS          = @{$object->Obj->get_all_DBLinks('CCDS')};
+  my @Uniprot       = @{$object->Obj->get_all_DBLinks('Uniprot/SWISSPROT')};
+  my $db            = $object->get_db;
+  my $alt_genes     = $self->_matches('alternative_genes', 'Alternative Genes', 'ALT_GENE', 'show_version'); #gets all xrefs, sorts them and stores them on the object. Returns HTML only for ALT_GENES
+  my $ensembl_select = $gene->get_all_Attributes('Ensembl_select')->[0] ? $gene->get_all_Attributes('Ensembl_select')->[0]->value : '';
+  my $display_xref  = $gene->display_xref;
+  my ($link_url)    = $display_xref ? $self->get_gene_display_link($gene, $display_xref) : ();
 
   if ($display_xref) {
     $table->add_row('Name', $link_url
@@ -91,9 +89,12 @@ sub content {
     $table->add_row('CCDS', sprintf($template, $sp_name, join ', ', map $hub->get_ExtURL_link($_, 'CCDS', $_), @CCDS));
   }
 
-  my %temp = map { $_->primary_id, 1 } @Uniprot;	    my %temp = map { $_->primary_id, 1 } @Uniprot;
-    @Uniprot = sort keys %temp;	    @Uniprot = sort keys %temp;
+  # add Uniprot info
+  if (scalar @Uniprot) {
+    my %temp = map { $_->primary_id, 1 } @Uniprot;
+    @Uniprot = sort keys %temp;
     $table->add_row('UniProtKB', sprintf('<p>This gene has proteins that correspond to the following UniProtKB identifiers: %s</p>', join ', ', map $hub->get_ExtURL_link($_, 'Uniprot/SWISSPROT', $_), @Uniprot));
+  }
 
   ## add RefSeq match info where appropriate
   if ($hub->species eq 'Homo_sapiens' && $sub_type ne 'GRCh37') {

--- a/modules/EnsEMBL/Web/Component/Gene/GeneSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GeneSummary.pm
@@ -44,7 +44,6 @@ sub content {
   my $sub_type        = $species_defs->ENSEMBL_SUBTYPE;
   my @CCDS            = @{$object->Obj->get_all_DBLinks('CCDS')};
   my @Uniprot         = @{$object->Obj->get_all_DBLinks('Uniprot/SWISSPROT')};
-  my @Uniprot_isoform = @{$object->Obj->get_all_DBLinks('Uniprot_isoform')};
   my $db              = $object->get_db;
   my $alt_genes       = $self->_matches('alternative_genes', 'Alternative Genes', 'ALT_GENE', 'show_version'); #gets all xrefs, sorts them and stores them on the object. Returns HTML only for ALT_GENES
   my $ensembl_select  = $gene->get_all_Attributes('Ensembl_select')->[0] ? $gene->get_all_Attributes('Ensembl_select')->[0]->value : '';
@@ -92,19 +91,9 @@ sub content {
     $table->add_row('CCDS', sprintf($template, $sp_name, join ', ', map $hub->get_ExtURL_link($_, 'CCDS', $_), @CCDS));
   }
 
-  my $uniprot_match_title = 'UniProt match';
-  my $uniprot_match_description = get_glossary_entry($self->hub, 'UniProt Match');
-  
-  # add Uniprot info
-  if (scalar @Uniprot_isoform) {
-    my %temp = map { $_->primary_id, 1 } @Uniprot_isoform;
-    @Uniprot_isoform = sort keys %temp;
-    $table->add_row($uniprot_match_title, sprintf('<p>%s: %s</p>', $uniprot_match_description, join ', ', map $hub->get_ExtURL_link($_, 'Uniprot_isoform', $_), @Uniprot_isoform));
-  } elsif( scalar @Uniprot){
-    my %temp = map { $_->primary_id, 1 } @Uniprot;
-    @Uniprot = sort keys %temp;
-    $table->add_row($uniprot_match_title, sprintf('<p>%s: %s</p>', $uniprot_match_description, join ', ', map $hub->get_ExtURL_link($_, 'Uniprot/SWISSPROT', $_), @Uniprot));
-  }
+  my %temp = map { $_->primary_id, 1 } @Uniprot;	    my %temp = map { $_->primary_id, 1 } @Uniprot;
+    @Uniprot = sort keys %temp;	    @Uniprot = sort keys %temp;
+    $table->add_row('UniProtKB', sprintf('<p>This gene has proteins that correspond to the following UniProtKB identifiers: %s</p>', join ', ', map $hub->get_ExtURL_link($_, 'Uniprot/SWISSPROT', $_), @Uniprot));
 
   ## add RefSeq match info where appropriate
   if ($hub->species eq 'Homo_sapiens' && $sub_type ne 'GRCh37') {

--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -250,12 +250,19 @@ sub transcript_table {
 
     push @columns, { key => 'ccds', sort => 'html', label => 'CCDS', class => '_ht' } if $species =~ /^Homo_sapiens|Mus_musculus/;
     my @rows;
-   
+
     my %extra_links = (
-      uniprot => { match => "^UniProt/[SWISSPROT|SPTREMBL]", name => "UniProt", order => 0 },
+      uniprot => { 
+        first_match => "Uniprot_isoform", 
+        second_match => "^UniProt/[SWISSPROT|SPTREMBL]", 
+        name => "UniProt Match", 
+        order => 0,
+        title => get_glossary_entry($hub, 'Uniprot_match')
+      },
     );
+
     if ($species eq 'Homo_sapiens' && $sub_type eq 'GRCh37' ) {
-      $extra_links{refseq} = { match => "^RefSeq", name => "RefSeq", order => 1, title => "RefSeq transcripts with sequence similarity and genomic overlap"};
+      $extra_links{refseq} = { first_match => "^RefSeq", name => "RefSeq", order => 1, title => "RefSeq transcripts with sequence similarity and genomic overlap"};
     }
     my %any_extras;
  
@@ -294,7 +301,14 @@ sub transcript_table {
         $ccds = join ', ', map $hub->get_ExtURL_link($_, 'CCDS', $_), @CCDS;
       }
       foreach my $k (keys %extra_links) {
-        if(my @links = grep {$_->status ne 'PRED' } grep { $_->dbname =~ /$extra_links{$k}->{'match'}/i } @$dblinks) {
+        
+        my @links = grep {$_->status ne 'PRED' } grep { $_->dbname =~ /$extra_links{$k}->{'first_match'}/i } @$dblinks;
+
+        if(!@links && $extra_links{$k}->{'second_match'}){
+          @links = grep {$_->status ne 'PRED' } grep { $_->dbname =~ /$extra_links{$k}->{'second_match'}/i } @$dblinks;
+        }
+
+        if(@links) {
           my %T = map { $_->primary_id => $_->dbname } @links;
           my $cell = '';
           my $i = 0;

--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -257,7 +257,7 @@ sub transcript_table {
         second_match => "^UniProt/[SWISSPROT|SPTREMBL]", 
         name => "UniProt Match", 
         order => 0,
-        title => get_glossary_entry($hub, 'Uniprot_match')
+        title => get_glossary_entry($hub, 'UniProt Match')
       },
     );
 


### PR DESCRIPTION
## Description

- Renamed the column name to `UniProt Match`
- `UniProt Match` column will no display the informs if they exist and shows the gene level links if not.
- Added external link entry to DEFAULTS.ini to `UNIPROT_ISOFORM`

## Views affected

http://ves-hx2-75.ebi.ac.uk:42228/Homo_sapiens/Gene/Summary?g=ENSG00000159840;r=7:143381295-143391111

http://ves-hx2-75.ebi.ac.uk:42228/Homo_sapiens/Gene/Matches?g=ENSG00000159840;r=7:143381295-143391111

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5877
