### PR TITLE
Fix broken 'configure trackhub display' button

### DIFF
--- a/htdocs/components/25_ConfigRegMatrixForm.js
+++ b/htdocs/components/25_ConfigRegMatrixForm.js
@@ -157,7 +157,7 @@ Ensembl.Panel.ConfigRegMatrixForm = Ensembl.Panel.ConfigMatrixForm.extend({
     });
 
     this.el.find('.view-track, button.showMatrix').on('click', function() {
-      if($(this).hasClass('_edit') || !$(this).hasClass('view-track inactive')) {
+      if($(this).hasClass('_edit')) {
         panel.addExtraDimensions();
         Ensembl.EventManager.trigger('modalClose');
       }


### PR DESCRIPTION
## Description
The 'Configure trackhub display' button did not work as intended. Instead of showing the 'View tracks' section in the regulation matrix modal, it closes it. This makes it unable for the user to edit the trackhub display as necessary after selecting the tracks.

## Release
102

## Views affected
Regulation matrix

## Possible complications
Don't think there are any as this fix should affect only the regulation matrix.

## Related JIRA Issues (EBI developers only)
[ENSWEB-5740](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5740)
