### PR TITLE
Hide regulation matrix on scroll

### DIFF
--- a/htdocs/components/25_ConfigRegMatrixForm.js
+++ b/htdocs/components/25_ConfigRegMatrixForm.js
@@ -156,6 +156,11 @@ Ensembl.Panel.ConfigRegMatrixForm = Ensembl.Panel.ConfigMatrixForm.extend({
       }
     });
 
+    this.elLk.matrixContainer.on('scroll', function() {
+      panel.el.find('div.matrix-container div.xBoxes.track-on, div.matrix-container div.xBoxes.track-off').removeClass("mClick");
+      panel.trackPopup.hide();
+    });
+
     this.el.find('.view-track, button.showMatrix').on('click', function() {
       if($(this).hasClass('_edit') || !$(this).hasClass('view-track inactive')) {
         panel.addExtraDimensions();

--- a/htdocs/components/25_ConfigTrackHubMatrixForm.js
+++ b/htdocs/components/25_ConfigTrackHubMatrixForm.js
@@ -188,6 +188,11 @@ Ensembl.Panel.ConfigTrackHubMatrixForm = Ensembl.Panel.ConfigMatrixForm.extend({
       }
     });
 
+    this.elLk.filterMatrix.on('scroll', function() {
+      panel.el.find('div.matrix-container div.xBoxes.track-on, div.matrix-container div.xBoxes.track-off').removeClass("mClick");
+      panel.trackPopup.hide();
+    });
+
     this.el.find('.view-track, .view-track-button, button.showMatrix').on('click', function() {
       if($(this).hasClass('_edit') || ($(this).hasClass('view-track') && !$(this).hasClass('inactive')) || ($(this).hasClass('view-track-button') && $(this).hasClass('active'))) {
         panel.addExtraDimensions();

--- a/htdocs/components/25_ConfigTrackHubMatrixForm.js
+++ b/htdocs/components/25_ConfigTrackHubMatrixForm.js
@@ -193,6 +193,11 @@ Ensembl.Panel.ConfigTrackHubMatrixForm = Ensembl.Panel.ConfigMatrixForm.extend({
       panel.trackPopup.hide();
     });
 
+    this.elLk.matrixContainer.on('scroll', function() {
+      panel.el.find('div.matrix-container div.xBoxes.track-on, div.matrix-container div.xBoxes.track-off').removeClass("mClick");
+      panel.trackPopup.hide();
+    });
+
     this.el.find('.view-track, .view-track-button, button.showMatrix').on('click', function() {
       if($(this).hasClass('_edit') || ($(this).hasClass('view-track') && !$(this).hasClass('inactive')) || ($(this).hasClass('view-track-button') && $(this).hasClass('active'))) {
         panel.addExtraDimensions();


### PR DESCRIPTION
## Description

The popup for a regulation matrix cell doesn't move when the whole matrix is scrolled horizontally. This positions it in a different cell which can confuse the user. I have made the popup to hide when horizontally scrolling the matrix.

## Release

102

## Views affected

Regulation matrix

## Possible complications

Since the popup gets hidden when scrolling horizontally, this could result in a bad user experience.

## Related JIRA Issues (EBI developers only)

[ENSWEB-5058](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5058)