### PR TITLE
[ON HOLD] Fix strain orthologues downloads

### DIFF
--- a/modules/EnsEMBL/Web/Command/DataExport/Output.pm
+++ b/modules/EnsEMBL/Web/Command/DataExport/Output.pm
@@ -50,6 +50,7 @@ sub process {
   my $error;
   my $format = $hub->param('format');
 
+
   ## Clean up parameters to remove chosen format from name (see Component::DataExport)
   foreach ($hub->param) {
     if ($_ =~ /_$format$/) {
@@ -64,7 +65,7 @@ sub process {
  
   ## Make filename safe
   ($filename = $hub->param('name')) =~ s/ |-/_/g;
- 
+
   ## Compress file by default
   $extension   = $format_info->{'ext'};
   $compression = $hub->param('compression');
@@ -82,9 +83,12 @@ sub process {
     ($component, $error) = $self->object->create_component;
 
     # Override the options saved in viewconfig by the one selected by the user in the form (these settings are not saved to session since we don't call session->store afterwards)
-    my $view_config = $hub->param('data_type') ? $hub->get_viewconfig({component => $component->id, type => $hub->param('data_type'), cache => 1}) : undef;
-    for ($view_config ? $view_config->field_order : ()) {
-      $view_config->set($_, $hub->param(sprintf '%s_%s', $_, $format) || 'off');
+    if( $component->id ne 'ComparaOrthologs'){
+      my $view_config = $hub->param('data_type') ? $hub->get_viewconfig({component => $component->id, type => $hub->param('data_type'), cache => 1}) : undef;
+
+      for ($view_config ? $view_config->field_order : ()) {
+        $view_config->set($_, $hub->param(sprintf '%s_%s', $_, $format) || 'off');
+      }
     }
 
     $file = EnsEMBL::Web::File::User->new(
@@ -350,6 +354,8 @@ sub write_alignment {
   my ($alignment, $result);
   my $flag = $align ? undef : 'sequence';
   my $data = $component->get_export_data($flag);
+  
+
   if (!$data) {
     $result->{'error'} = ['No data returned'];
   }

--- a/modules/EnsEMBL/Web/Command/DataExport/Output.pm
+++ b/modules/EnsEMBL/Web/Command/DataExport/Output.pm
@@ -50,7 +50,6 @@ sub process {
   my $error;
   my $format = $hub->param('format');
 
-
   ## Clean up parameters to remove chosen format from name (see Component::DataExport)
   foreach ($hub->param) {
     if ($_ =~ /_$format$/) {
@@ -65,7 +64,6 @@ sub process {
  
   ## Make filename safe
   ($filename = $hub->param('name')) =~ s/ |-/_/g;
-
   ## Compress file by default
   $extension   = $format_info->{'ext'};
   $compression = $hub->param('compression');
@@ -354,8 +352,6 @@ sub write_alignment {
   my ($alignment, $result);
   my $flag = $align ? undef : 'sequence';
   my $data = $component->get_export_data($flag);
-  
-
   if (!$data) {
     $result->{'error'} = ['No data returned'];
   }

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -438,6 +438,7 @@ sub buttons {
 
     ## Add any species settings
     foreach (grep { /^species_/ } $self->param) {
+      next unless $hub->action ne 'Strain_Compara_Ortholog' || $_ =~ lc($hub->species);
       $params->{$_} = $self->param($_);
     }
 


### PR DESCRIPTION
## Description

- Fixed the issue with breed orthologues downloads where it was working the same way as for the reference species.

The issue was with the following line:
https://github.com/Ensembl/ensembl-webcode/pull/791/files#diff-39a1865bcf5a112d5bb6d3e05f7c9c4fb0fd7791324c77ad8d36cdd63cf1a0c5R85
where it was adding all the available species to $hub->params


## Views affected

http://ves-hx2-75.ebi.ac.uk:42229/Sus_scrofa/Gene/Strain_Compara_Ortholog?db=core;g=ENSSSCG00000004244;r=1:42729112-42896283

http://ves-hx2-75.ebi.ac.uk:42229/Sus_scrofa/Gene/Compara_Ortholog?db=core;g=ENSSSCG00000004244;r=1:42729112-42896283

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5895
https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-4069