### PR TITLE
Retrofit announcement banner

### DIFF
--- a/htdocs/components/99_announcement_banner.css
+++ b/htdocs/components/99_announcement_banner.css
@@ -1,0 +1,33 @@
+/*
+ * Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+ * Copyright [2016-2018] EMBL-European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#announcement-banner {
+    background-color: #0DD;
+    padding: 12px 8px 12px 8px;
+    color: #333;
+    text-align: center;
+}
+
+#announcement-banner p{
+    margin:0;
+    font-weight: bold;
+}
+
+#announcement-banner a{
+    color: #3399FF;
+}

--- a/modules/EnsEMBL/Web/Document/Element/TmpMessage.pm
+++ b/modules/EnsEMBL/Web/Document/Element/TmpMessage.pm
@@ -44,7 +44,7 @@ sub init {
 sub content {
   my $self = shift;
 
-  return $self->{'file'}{'message'} ? $self->dom->create_element('div', {
+  my $popup_message = $self->{'file'}{'message'} ? $self->dom->create_element('div', {
     'id'        => 'tmp_message',
     'children'  => [{
       'node_name'   => 'div',
@@ -71,6 +71,19 @@ sub content {
       'value'       => $self->{'file'}{'position'} || ''
     }]
   })->render : '';
+
+  my $announcement_banner_message = $self->{'file'}{'banner_message'} ? $self->dom->create_element('div', {
+    'id'          => 'announcement-banner',
+    'inner_HTML'  => $self->{'file'}{'banner_message'}
+  })->render : '';
+
+
+  return {
+    'popup_message' => $popup_message,
+    'announcement_banner_message' => $announcement_banner_message 
+  }
+
+
 }
 
 1;

--- a/modules/EnsEMBL/Web/Template/Legacy.pm
+++ b/modules/EnsEMBL/Web/Template/Legacy.pm
@@ -20,7 +20,6 @@ limitations under the License.
 package EnsEMBL::Web::Template::Legacy;
 
 ### Legacy page template, used by standard HTML pages
-
 use parent qw(EnsEMBL::Web::Template);
 
 use HTML::Entities qw(encode_entities);
@@ -117,6 +116,11 @@ sub render_masthead {
   return qq(
   <div id="min_width_container">
     <div id="min_width_holder">
+    
+    <!-- Announcement Banner -->    
+        $elements->{'tmp_message'}->{'announcement_banner_message'}
+    <!-- /Announcement Banner -->
+
       <div id="masthead" class="js_panel$masthead_class">
         <input type="hidden" class="panel_type" value="Masthead" />
         <div class="logo_holder">$elements->{'logo'}</div>
@@ -231,7 +235,7 @@ sub render_page_end {
   <input type="hidden" id="species_common_name" name="species_common_name" value="$species_common_name" />
   <input type="hidden" id="max_region_length" name="max_region_length" value="$max_region_length" />
     $elements->{'modal'}
-    $elements->{'tmp_message'}
+    $elements->{'tmp_message'}->{'popup_message'}
     $elements->{'body_javascript'}
   );
   


### PR DESCRIPTION

## Description

This PR adds an announcement banner to the page header. It's essentially a duplicate of an [old PR](https://github.com/Ensembl/ensembl-webcode/pull/753), which merged a feature branch with the same functionality into postreleasefix/99. 

## Views affected

Masthead

## Related JIRA Issues (EBI developers only)

[ENSWEB-5907](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5907)
