### PR TITLE
Fix screen command

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -35,8 +35,8 @@ use Sys::Hostname::Long;
 ###############################################################################
 ## Ensembl Version and release dates (these get updated every release)
 our $ENSEMBL_VERSION        = 102;            # Ensembl release number
-our $ARCHIVE_VERSION        = 'Sep2020';     # Archive site for this version
-our $ENSEMBL_RELEASE_DATE   = 'September 2020'; # As it would appear in the copyright/footer
+our $ARCHIVE_VERSION        = 'Nov2020';     # Archive site for this version
+our $ENSEMBL_RELEASE_DATE   = 'November 2020'; # As it would appear in the copyright/footer
 ###############################################################################
 
 

--- a/htdocs/components/10_SpeciesList.js
+++ b/htdocs/components/10_SpeciesList.js
@@ -34,6 +34,7 @@ Ensembl.Panel.SpeciesList = Ensembl.Panel.extend({
     this.refreshURL       = this.params['ajax_refresh_url'];
     this.saveURL          = this.params['ajax_save_url'];
     this.displayLimit     = this.params['display_limit'];
+    this.favText          = this.params['fave_text'];
     this.taxonOrder       = this.params['taxon_order'];
     this.taxonLabels      = this.params['taxon_labels'];
 
@@ -184,12 +185,13 @@ Ensembl.Panel.SpeciesList = Ensembl.Panel.extend({
     var optgroups     = $();
     var favSpecies    = $.map(this.allSpecies, function(sp) { return sp.favourite ? sp: null } );
     var sortedSpecies = this.allSpecies.slice(0).sort(function (a, b) { return a.common > b.common ? 1 : -1 });
+    var favText       = this.favText;
 
     // favourites group
     $.each(favSpecies, function(i, species) {
       var optgroup = optgroups.filter('.favourites');
       if (!optgroup.length) {
-        optgroup = $('<optgroup class="favourites" label="Favourites"></optgroup>');
+        optgroup = $('<optgroup class="favourites" label="' + favText + '"></optgroup>');
         optgroups = optgroups.add(optgroup);
       }
       panel.addOption(optgroup, species, true);

--- a/modules/EnsEMBL/Web/Configuration/Gene.pm
+++ b/modules/EnsEMBL/Web/Configuration/Gene.pm
@@ -125,22 +125,22 @@ sub populate_tree {
   
   $compara_menu->append($pl_node);
   
-  #my $fam_node = $self->create_node('Family', 'Ensembl protein families',
-  #  [qw( family EnsEMBL::Web::Component::Gene::Family )],
-  #  { 'availability' => 'family not_strain', 'concise' => 'Ensembl protein families' }
-  #);
+  my $fam_node = $self->create_node('Family', 'Ensembl protein families',
+    [qw( family EnsEMBL::Web::Component::Gene::Family )],
+    { 'availability' => 'family not_strain', 'concise' => 'Ensembl protein families' }
+  );
   
-  #$fam_node->append($self->create_subnode('Family/Genes', uc($species_defs->get_config($hub->species, 'SPECIES_DISPLAY_NAME')) . ' genes in this family',
-  #  [qw( genes EnsEMBL::Web::Component::Gene::FamilyGenes )],
-  #  { 'availability'  => 'family not_strain', 'no_menu_entry' => 1 }
-  #));
+  $fam_node->append($self->create_subnode('Family/Genes', uc($species_defs->get_config($hub->species, 'SPECIES_DISPLAY_NAME')) . ' genes in this family',
+    [qw( genes EnsEMBL::Web::Component::Gene::FamilyGenes )],
+    { 'availability'  => 'family not_strain', 'no_menu_entry' => 1 }
+  ));
 
-  #$fam_node->append($self->create_subnode('Family/Alignments', 'Multiple alignments in this family',
-  #  [qw( jalview EnsEMBL::Web::Component::Gene::FamilyAlignments )],
-  #  { 'availability'  => 'family database:compara core not_strain', 'no_menu_entry' => 1 }
-  #));
+  $fam_node->append($self->create_subnode('Family/Alignments', 'Multiple alignments in this family',
+    [qw( jalview EnsEMBL::Web::Component::Gene::FamilyAlignments )],
+    { 'availability'  => 'family database:compara core not_strain', 'no_menu_entry' => 1 }
+  ));
   
-  #$compara_menu->append($fam_node);
+  $compara_menu->append($fam_node);
   
   # Compara menu for strain (strain menu available on main species but collapse, main menu not available/grey out/collapse on strain page)
   # The node key (Strain_) is used by Component.pm to determine if it is a strain link on the main species page, so be CAREFUL when changing this  

--- a/modules/EnsEMBL/Web/Data/Bio/LRG.pm
+++ b/modules/EnsEMBL/Web/Data/Bio/LRG.pm
@@ -57,6 +57,7 @@ sub convert_to_drawing_parameters {
     # get the LRG's HGNC name
     my $lrg_sr_name = $lrg->seq_region_name;
     my $gene = (grep $_->stable_id eq $lrg_sr_name, @{$lrg->get_all_Genes_by_type('LRG_gene')})[0];
+    next unless $gene;
     my $hgnc_name = $gene->display_xref->display_id();
 
     if (ref($lrg) =~ /UnmappedObject/) {

--- a/modules/EnsEMBL/Web/Document/Element/SpeciesBar.pm
+++ b/modules/EnsEMBL/Web/Document/Element/SpeciesBar.pm
@@ -111,8 +111,9 @@ sub species_list {
   my ($all_species, $fav_species);
   
   if ($self->{'favourite_species'}) {
+    my $fave_text = $self->hub->species_defs->FAVOURITES_SYNONYM || 'Favourite';
     $fav_species .= qq{<li><a class="constant" href="$_->[0]">$_->[1]</a></li>} for @{$self->{'favourite_species'}};
-    $fav_species  = qq{<h4>Favourite species</h4><ul>$fav_species</ul><div style="clear: both;padding:1px 0;background:none"></div>};
+    $fav_species  = qq{<h4>$fave_text species</h4><ul>$fav_species</ul><div style="clear: both;padding:1px 0;background:none"></div>};
   }
   
   # Ok, this is slightly mental. Basically, we're building a 3 column structure with floated <li>'s.

--- a/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
@@ -112,9 +112,10 @@ Each directory on <a href="$ftp" rel="external">$ftp_domain</a> contains a
   );
 
   $title{$_} = encode_entities($title{$_}) for keys %title;
+  my $fave_title = $self->hub->species_defs->FAVOURITES_SYNONYM || 'Favourite';
   
   $columns = [
-    { key => 'fave',    title => 'Favourite',                    align => 'left',   width => '5%',  sort => 'html',
+    { key => 'fave',    title => $fave_title,                    align => 'left',   width => '5%',  sort => 'html',
                         label => '<img src="/i/16/star.png" />'},
     { key => 'species', title => 'Species',                      align => 'left',   width => '10%', sort => 'html' },
     { key => 'dna',     title => 'DNA (FASTA)',                  align => 'center', width => '10%', sort => 'none' },

--- a/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
@@ -200,8 +200,8 @@ Each directory on <a href="$ftp" rel="external">$ftp_domain</a> contains a
     my $sp_name   = $sp->{'dir'};
 
     ## Add collection directory for relevant NV divisions
-    my $dataset   = $hub->species_defs->get_config($sp_url, 'SPECIES_DATASET');
-    my $sp_dir    = $dataset ? lc($dataset).'_collection/' : '';
+    my $dataset   = lc($hub->species_defs->get_config($sp_url, 'SPECIES_DATASET'));
+    my $sp_dir    = ($dataset && $dataset ne $sp_name) ? $dataset.'_collection/' : '';
     $sp_dir      .= $sp_name;
 
     ## Vertebrate-specific - append scientific name if display name is common name 

--- a/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
@@ -200,7 +200,7 @@ Each directory on <a href="$ftp" rel="external">$ftp_domain</a> contains a
     my $sp_name   = $sp->{'dir'};
 
     ## Add collection directory for relevant NV divisions
-    my $dataset   = $hub->species_defs->get_config($sp_name, 'SPECIES_DATASET');
+    my $dataset   = $hub->species_defs->get_config($sp_url, 'SPECIES_DATASET');
     my $sp_dir    = $dataset ? lc($dataset).'_collection/' : '';
     $sp_dir      .= $sp_name;
 

--- a/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
@@ -197,7 +197,12 @@ Each directory on <a href="$ftp" rel="external">$ftp_domain</a> contains a
 
   foreach my $sp (@$all_species) {
     my $sp_url    = $sp->{'url'};
-    my $sp_dir    = $sp->{'dir'};
+    my $sp_name   = $sp->{'dir'};
+
+    ## Add collection directory for relevant NV divisions
+    my $dataset   = $hub->species_defs->get_config($sp_name, 'SPECIES_DATASET');
+    my $sp_dir    = ($dataset && $dataset eq $sp_name) ? '' : lc($dataset).'_collection/';
+    $sp_dir      .= $sp_name;
 
     ## Vertebrate-specific - append scientific name if display name is common name 
     my $display_name  = $sp->{'display_name'};

--- a/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
@@ -201,7 +201,7 @@ Each directory on <a href="$ftp" rel="external">$ftp_domain</a> contains a
 
     ## Add collection directory for relevant NV divisions
     my $dataset   = $hub->species_defs->get_config($sp_name, 'SPECIES_DATASET');
-    my $sp_dir    = ($dataset && $dataset eq $sp_name) ? '' : lc($dataset).'_collection/';
+    my $sp_dir    = $dataset ? lc($dataset).'_collection/' : '';
     $sp_dir      .= $sp_name;
 
     ## Vertebrate-specific - append scientific name if display name is common name 

--- a/modules/EnsEMBL/Web/Document/HTML/GenomeList.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/GenomeList.pm
@@ -69,11 +69,14 @@ sub _get_dom_tree {
 
   my @ok_species = $sd->valid_species;
   my $sitename  = $self->hub->species_defs->ENSEMBL_SITETYPE;
+  my $fave_text = $self->hub->species_defs->FAVOURITES_SYNONYM || 'Favourite';
+
   if (scalar @ok_species > 1) {
     my $list_html = $self->get_list_html();
+    my $fave_plural = $self->hub->species_defs->FAVOURITES_SYNONYM || 'Favourites';
 
     my $sort_html = qq(<p>For easy access to commonly used genomes, drag from the bottom list to the top one</p>
-        <p><strong>Favourites</strong></p>
+        <p><strong>$fave_plural</strong></p>
           <ul class="_favourites"></ul>
         <p><a href="#Done" class="button _list_done">Done</a>
           <a href="#Reset" class="button _list_reset">Restore default list</a></p>
@@ -100,7 +103,7 @@ sub _get_dom_tree {
               'class'       => 'column-two fave-genomes',
               'children'    => [{
                         'node_name'   => 'h3',
-                        'inner_HTML'  => "Favourite genomes $edit_icon",
+                        'inner_HTML'  => "$fave_text genomes $edit_icon",
                       }, {
                         'node_name'   => 'div',
                         'class'       => [qw(_species_sort_container reorder_species clear hidden)],
@@ -144,6 +147,11 @@ sub _get_dom_tree {
                         'class'       => 'js_param',
                         'name'        => 'display_limit',
                         'value'       => SPECIES_DISPLAY_LIMIT
+                      }, {
+                        'node_name'   => 'inputhidden',
+                        'class'       => 'js_param',
+                        'name'        => 'fave_text',
+                        'value'       => $fave_text
                       }, {
                         'node_name'   => 'inputhidden',
                         'class'       => 'js_param json',

--- a/modules/EnsEMBL/Web/Document/HTML/HomeSearch.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/HomeSearch.pm
@@ -170,8 +170,10 @@ sub render {
     }
     ## If more than one species, show favourites
     if (scalar keys %species > 1) {
-        push @$values, map({ $sortable{$_} ? {'value' => $_, 'caption' => $sortable{$_}, 'group' => 'Favourite species'} : ()} @$favourites);
-        push @$values, {'value' => '', 'caption' => '---', 'disabled' => 1};
+      my $group_label = $self->hub->species_defs->FAVOURITES_SYNONYM || 'Favourite';
+      $group_label   .= ' species';
+      push @$values, map({ $sortable{$_} ? {'value' => $_, 'caption' => $sortable{$_}, 'group' => $group_label} : ()} @$favourites);
+      push @$values, {'value' => '', 'caption' => '---', 'disabled' => 1};
     }
     push @$values, map({'value' => $species{$_}, 'caption' => $_}, sort { uc $a cmp uc $b } keys %species);
 

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -1081,7 +1081,7 @@ sub add_regulation_features {
     $db_tables          = $self->databases->{'DATABASE_FUNCGEN'}{'tables'};
   }
 
-  my $methylation = $db_tables->{$key};
+  my $methylation = $db_tables->{'methylation'};
   foreach my $k (sort { lc $methylation->{$a}{'name'} cmp lc $methylation->{$b}{'name'} } keys %$methylation) {
     (my $name = $methylation->{$k}{'name'}) =~ s/_/ /g;
     $methylation_menu->append_child($self->create_track_node('methylation_'.$k, $name, {
@@ -1093,7 +1093,7 @@ sub add_regulation_features {
         display      => 'off',
         default_display => 'compact',
         renderers       => [ qw(off Off compact On) ],
-        glyphset        => 'fg_'.$key,
+        glyphset        => 'fg_methylation',
         colourset    => 'seq',
     }));
   }

--- a/utils/solr_replication.sh
+++ b/utils/solr_replication.sh
@@ -191,7 +191,7 @@ if [[ $new_data == "y" ]] ; then
 
   echo -e "\n $((step+=1)). Replicate data using a script."
   echo -e "\t ssh ens_adm02@ves-hx2-70"
-  echo -e "\n\t NOTE: Run below in a screen session (screen -s solr-replication)"
+  echo -e "\n\t NOTE: Run below in a screen session (screen -S solr-replication)"
   echo -e "\t cd /nfs/public/release/ensweb-software/ensembl-solr/sync"
   echo -e "\t #dry run - should only recognise the servers [${machines_array[@]}] showing message 'NEEDSYNCH'"
   echo -e "\t ./sync_indexes.pl -reltype ebi-$replicate_release_type --maxshards 3 --dry"


### PR DESCRIPTION

## Description

The `solr_replication.sh` script outputs a `screen` command (`screen -s solr-replication`) which can be used to host a long-running solr synchronisation process. The command that is printed uses the `-s` option (lowercase "S"), which is for setting the shell in a new session. I think it's actually intending to set the name of the new session, which is `-S` (capital "S"). This PR changes `-s` to `-S`.

## Possible complications

None

## Merge conflicts

None

## Related JIRA Issues (EBI developers only)

NA
