### PR TITLE
Fix option on screen command

### DIFF
--- a/utils/solr_replication.sh
+++ b/utils/solr_replication.sh
@@ -191,7 +191,7 @@ if [[ $new_data == "y" ]] ; then
 
   echo -e "\n $((step+=1)). Replicate data using a script."
   echo -e "\t ssh ens_adm02@ves-hx2-70"
-  echo -e "\n\t NOTE: Run below in a screen session (screen -s solr-replication)"
+  echo -e "\n\t NOTE: Run below in a screen session (screen -S solr-replication)"
   echo -e "\t cd /nfs/public/release/ensweb-software/ensembl-solr/sync"
   echo -e "\t #dry run - should only recognise the servers [${machines_array[@]}] showing message 'NEEDSYNCH'"
   echo -e "\t ./sync_indexes.pl -reltype ebi-$replicate_release_type --maxshards 3 --dry"


### PR DESCRIPTION

## Description

The output of `solr_replication.sh` includes a comment that prints a `screen` command. The command uses the `-s` option (lowercase "S"), which is used to set the shell in the new session. Instead, it should use the `-S` option (capital "S"), which is for naming the new session. This PR changes `-s` to `-S`.

## Views affected

NA

## Possible complications

NA

## Merge conflicts

None

## Related JIRA Issues (EBI developers only)

None
