### PR TITLE
Add  PharmGKB URL

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -394,6 +394,7 @@ ORDO                        = http://www.orpha.net/ORDO/###ID###
 ORPHANET                    = http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=###ID###
 PAHDB                       = http://www.pahdb.mcgill.ca/PahdbSearch.php?SearchValue=###ID###&SearchField=mut_name&SearchOrderedField=id_mut&SearchAscDesc=ASC&Submit=Submit&MenuSelection=Mutation
 PHARMGKB                    = https://www.pharmgkb.org/rsid/###ID###
+PHARMGKB_VARIANT            = https://www.pharmgkb.org/variant/###ID###
 PHENCODE                    = http://phencode.bx.psu.edu/cgi-bin/phencode/phencode?build=hg19&id=###ID### 
 QUICK_GO_IMP                = http://www.ebi.ac.uk/QuickGO/annotations?goId=###ID###&evidence=IMP&geneProductId=###PR_ID###
 RGD_SEARCH                  = https://rgd.mcw.edu/rgdweb/elasticResults.html?category=###TYPE###&term=###ID###


### PR DESCRIPTION
## Description

Add PharmGKB external URL to be used in web VEP e103.

## Views affected

None

## Possible complications

None

## Merge conflicts

None

## Related JIRA Issues (EBI developers only)

None
