### PR TITLE
add option to disable phylogentic view

### DIFF
--- a/modules/EnsEMBL/Web/Component/Info/VariationGallery.pm
+++ b/modules/EnsEMBL/Web/Component/Info/VariationGallery.pm
@@ -233,6 +233,7 @@ sub _get_pages {
     my $has_strains     = $variation_db->{'#STRAINS'} if $variation_db;
     my $has_LD          = ($variation_db && $variation_db->{'DEFAULT_LD_POP'}) ? 1 : 0;
     my $has_papers      = $object->count_citations ? 1 : 0; 
+    my $has_variation_source_db = $variation_db->{meta_info}->{1}->{'variation_source.database'}->[0];
 
     return {'Region in Detail' => {
                                   'link_to'   => {'type'    => 'Location',
@@ -265,8 +266,9 @@ sub _get_pages {
                                                     'action'  => 'Compara_Alignments',
                                                     'v'      => $v,
                                                     },
-                                  'img'     => 'variation_phylogenetic',
-                                  'caption' => 'Multiple species alignment of the 20bp around your variant',
+                                  'img'      => 'variation_phylogenetic',
+                                  'caption'  => 'Multiple species alignment of the 20bp around your variant',
+                                  'disabled' => !$has_variation_source_db,
                                   },
           'Gene Sequence' => {
                                   'link_to'       => {'type'  => 'Gene',

--- a/modules/EnsEMBL/Web/Component/Info/VariationGallery.pm
+++ b/modules/EnsEMBL/Web/Component/Info/VariationGallery.pm
@@ -233,7 +233,7 @@ sub _get_pages {
     my $has_strains     = $variation_db->{'#STRAINS'} if $variation_db;
     my $has_LD          = ($variation_db && $variation_db->{'DEFAULT_LD_POP'}) ? 1 : 0;
     my $has_papers      = $object->count_citations ? 1 : 0; 
-    my $has_variation_source_db = $variation_db->{meta_info}->{1}->{'variation_source.database'}->[0];
+    my $has_variation_source_db = $object->has_variation_source_db ? 1 : 0;
 
     return {'Region in Detail' => {
                                   'link_to'   => {'type'    => 'Location',

--- a/modules/EnsEMBL/Web/Component/Variation/Explore.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Explore.pm
@@ -74,7 +74,7 @@ sub content {
     $pheno_count = $avail->{'has_ega'}
   }
 
-  if ($avail->{'has_alignments'}) {
+  if ($avail->{'has_alignments'} && $avail->{'has_variation_source_db'}) {
     $phylo_url = $hub->url({'action' => 'Compara_Alignments'});
   }
 

--- a/modules/EnsEMBL/Web/Configuration/Variation.pm
+++ b/modules/EnsEMBL/Web/Configuration/Variation.pm
@@ -108,7 +108,7 @@ sub populate_tree {
       selector EnsEMBL::Web::Component::Compara_AlignSliceSelector
       alignment EnsEMBL::Web::Component::Variation::Compara_Alignments
     )],
-    { 'availability' => 'variation database:compara has_alignments', 'concise' => 'Phylogenetic Context' }
+    { 'availability' => 'variation has_variation_source_db database:compara has_alignments', 'concise' => 'Phylogenetic Context' }
   );
   $self->create_node('Citations', 'Citations',
     [qw( alignment EnsEMBL::Web::Component::Variation::Publication  )],

--- a/modules/EnsEMBL/Web/Object/Variation.pm
+++ b/modules/EnsEMBL/Web/Object/Variation.pm
@@ -62,6 +62,7 @@ sub availability {
       $availability->{'not_somatic'} = !$obj->has_somatic_source;
       $availability->{'is_coding'}   = $self->is_coding_variant;
       $availability->{'has_pdbe'}    = $self->has_pdbe_analysis();
+      $availability->{'has_variation_source_db'} = $self->has_variation_source_db();
     }
     
     $self->{'_availability'} = $availability;
@@ -94,6 +95,13 @@ sub is_coding_variant {
 sub has_pdbe_analysis {
   my $self = shift;
   return ($self->table_info($self->get_db, 'protein_feature')->{'analyses'}{'sifts_import'}) ? 1 : 0;
+}
+
+sub has_variation_source_db {
+  my $self = shift;
+  my $hub   = $self->hub;
+  my $variation_db  = $hub->species_defs->databases->{'DATABASE_VARIATION'};
+  return $variation_db->{meta_info}->{1}->{'variation_source.database'}->[0];
 }
 
 sub counts {


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

The phylogenetic context view is broken for species with their main data source being VCF which are Atlantic salmon and vervet. After spending time to investigate the cause I could only confirm that it is related to API code which deals with VCF variants and only affects the two mentioned species. There is not enough time to investigate further which is why we decided to disable the view for the two species.

## Views affected

- [Phylogenetic context disabled for species with VCF data source
](http://ves-hx2-76.ebi.ac.uk:5040/Chlorocebus_sabaeus/Variation/Explore?align=757;db=core;r=11:6824747-6825747;v=11:6825247:G_A:PRJEB22989;vdb=variation;vf=11:6825247:G_A:PRJEB22989)
- [Phylogenetic context for species with database data source
](http://ves-hx2-76.ebi.ac.uk:5040/Equus_caballus/Variation/Explore?db=core;r=1:29948886-29949886;v=rs68637648;vdb=variation;vf=15065609)

## Possible complications
The view was always broken for species with VCF data source.

## Merge conflicts

This PR is against postreleasefix/102 and should go into master and release/102. At his point we are expecting to disable the views also for 103.

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6080