### PR TITLE
Replace deprecated method with get_ref_length

### DIFF
--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -761,7 +761,7 @@ sub species_stats {
   });
   $summary->add_row({
       'name' => '<b>Base Pairs</b>',
-      'stat' => $self->thousandify($genome_container->get_total_length()),
+      'stat' => $self->thousandify($genome_container->get_ref_length()),
   }) unless $no_stats;
   my $header = glossary_helptip($self->hub, 'Golden Path Length', 'Golden path length');
   $summary->add_row({


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

During sandbox web server testing, I came across a call to the deprecated (and removed) method `get_total_length`, which is currently in use at `ensembl-webcode/modules/EnsEMBL/Web/Component/Shared.pm`. This PR replaces the call to this method with the recommended replacement method, `get_ref_length`.

I came across this when my test web server consistently failed to load the Whole Genome Display web page for each species, and the error pointed towards this deprecated method. This web page now appears to load as normal with this fix in place.  

This PR is being submitted against `postreleasefix/102`, as discussed with @ens-ap5.

## Views affected

The Whole Genome Display page loads as normal with this fix. Please see JIRA ticket below for error example.

## Possible complications

None I'm aware of.

## Merge conflicts

N/A

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-3621
