### PR TITLE
Fix strain orthologues downloads

### DIFF
--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -888,11 +888,12 @@ sub get_homologue_alignments {
   my $type        = shift || 'ENSEMBL_ORTHOLOGUES';
   my $database    = $self->database($compara_db);
   my $hub         = $self->hub;
+  my $strain_tree = $hub->species_defs->get_config($hub->species,'RELATED_TAXON') if($hub->param('data_action') =~ /strain_/i);
   my $msa;
 
   if ($database) {  
     my $member  = $self->get_compara_Member($compara_db);
-    my $tree    = $self->get_GeneTree($compara_db, 1);
+    my $tree    = $self->get_GeneTree($compara_db, 1, $strain_tree);
     my @params  = ($member, $type);
     my $species = [];
     foreach (grep { /species_/ } $hub->param) {

--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -891,8 +891,8 @@ sub get_homologue_alignments {
   my $msa;
 
   if ($database) {  
-    my $member  = $database->get_GeneMemberAdaptor->fetch_by_stable_id($self->Obj->stable_id);
-    my $tree    = $database->get_GeneTreeAdaptor->fetch_default_for_Member($member);
+    my $member  = $self->get_compara_Member($compara_db);
+    my $tree    = $self->get_GeneTree($compara_db, 1);
     my @params  = ($member, $type);
     my $species = [];
     foreach (grep { /species_/ } $hub->param) {


### PR DESCRIPTION
## Description

(Supersedes #791)

Downloading data (with "Download orthologues" button) from the Strains' Orthologues view currently returns the orthologues of the main species set, not of the strains. This PR is to fix that and return the orthologues of the strains instead.

- The definition of `my $strain_tree` is inspired from https://github.com/Ensembl/ensembl-webcode/blob/release/102/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm#L41 . It seems to work with just the test of `$hub->param('data_action')` and I don't know if the rest (`|| $self->hub->species_defs->IS_STRAIN_OF || $self->hub->param('strain')`) would be needed too.
- I have made the function call the existing `get_compara_Member` and `get_GeneTree` to avoid duplicating code / functionality. It looks like these two functions cache the data to speed up further calls. I imagine it's not a bad thing to have in the export view, but I'd like to double-check.

## Views affected

- Orthologues table for the Strains
  - http://ves-hx2-76.ebi.ac.uk:5080/Mus_musculus/Gene/Strain_Compara_Ortholog?g=ENSMUSG00000017167;r=11:101170523-101190724 is fixed
  - http://ves-hx2-76.ebi.ac.uk:5080/Mus_musculus/Gene/Compara_Ortholog?g=ENSMUSG00000017167;r=11:101170523-101190724 still works

## Possible complications

None expected.

## Merge conflicts

None expected.

## Related JIRA Issues (EBI developers only)

- https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5895
- https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-4069
