### PR TITLE
Add links for GEM-J pops and terms of use

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -371,6 +371,8 @@ ESP                         = http://evs.gs.washington.edu/EVS/PopStatsServlet?s
 ESP_HOME                    = http://evs.gs.washington.edu/EVS/ 
 EVA_STUDY                   = https://www.ebi.ac.uk/eva/?eva-study=
 GEFOS                       = http://www.gefos.org 
+GEM_J_POP                   = https://togovar.biosciencedbc.jp/doc/datasets/gem_j_wga
+GEM_J_POP_USE               = https://togovar.biosciencedbc.jp/doc/datasets/gem_j_wga#terms
 GIANT                       = http://www.broadinstitute.org/collaboration/giant/index.php/Main_Page
 HAPMAP                      = http://www.hapmap.org/cgi-perl/secure/gbrowse/snp_details/hapmap?class=SNP;name=###ID###
 HBVAR                       = http://globin.bx.psu.edu/cgi-bin/hbvar/query_vars3?mode=output&display_format=page&i=###ID### 

--- a/modules/EnsEMBL/Web/Component/Variation.pm
+++ b/modules/EnsEMBL/Web/Component/Variation.pm
@@ -68,6 +68,9 @@ sub pop_url {
   elsif ($pop_name =~ /ALFA/i) {
     $pop_url = $hub->get_ExtURL('ALFA_POP');
   }
+  elsif ($pop_name =~ /GEM-J/i) {
+    $pop_url = $hub->get_ExtURL('GEM_J_POP');
+  }
   elsif ($pop_name =~ /^NextGen/i) {
     $pop_url = $hub->get_ExtURL('NEXTGEN_POP');
   }

--- a/modules/EnsEMBL/Web/Component/Variation/PopulationGenotypes.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/PopulationGenotypes.pm
@@ -511,6 +511,11 @@ sub generic_group_link {
     if ($pop_use_url) {
       $terms = sprintf(' (<a href="%s" rel="external">Terms of Use</a>)', $pop_use_url);
     }
+  } elsif ($project_name =~ /gem-j/i) {
+    $pop_use_url = $self->hub->get_ExtURL('GEM_J_POP_USE');
+    if ($pop_use_url) {
+      $terms = sprintf(' (<a href="%s" rel="external">Terms of Use</a>)', $pop_use_url);
+    }
   }
 
   $project_name = ($project_name =~ /(project|consortium|ncbi alfa)/i) ? "<b>$project_name</b> " : '';


### PR DESCRIPTION
## Requirements

GEM-J frequency data from VCF hs been included in the population genetics page for release/103

A description of the populations and terrms of use for this new data is needed for release/103

## Description

The links have been added to DEFAULTS.ini

The code changes for population url and terms of use is similar to that done for NCBI ALFA #785 

## Views affected

Population Genetics view - At the bottom of the table for GEM-J
http://ves-hx2-76.ebi.ac.uk:5050/Homo_sapiens/Variation/Population?db=core;r=1:230709548-230710548;v=rs699;vdb=variation;vf=179#gem-j_anchor


## Possible complications

None identified as conditions are for GEM-J


## Merge conflicts

Tested on sandbox, branched from master

## Related JIRA Issues (EBI developers only)
ENSINT-520   New human frequency data GEM-J
ENSVAR-3413 Integrate GEM-J
ENSVAR-3771 GEM-J Add terms of use
