### PR TITLE
Update tooltip to include * alleles (overlapping deletion)

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/PopulationGenotypes.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/PopulationGenotypes.pm
@@ -309,7 +309,7 @@ sub format_table {
       if($freq_data->{$pop_id}{'missing_alleles'} && scalar keys %{$freq_data->{$pop_id}{'missing_alleles'}}) {
         $allele_content .= sprintf(
           '<span style="float:right" class="_ht sprite info_icon" title="%s has data not shown for the following alleles: <ul>%s</ul>'.
-          'These alleles are not defined in %s but may be present in co-located variants listed above."></span>',
+          'These alleles are not defined in %s but may be present in overlapping variants."></span>',
           $pop_info->{'Name'},
           join("", map {"<li>$_</li>"} sort {$a cmp $b} keys %{$freq_data->{$pop_id}{'missing_alleles'}}),
           $self->object->name,


### PR DESCRIPTION
## Requirements

Update of tooltip to cover * allele (alleles missing due to overlapping deletions)

## Description

VCFs can include * alleles (allele missing due to overlapping deletion)
Tooltip updated to include these alleles


## Views affected

Population Genetics view - info button. When allele is in VCF but not one of alleles of variant definition

See GEM-J frequency, click info buttons 
http://ves-hx2-76.ebi.ac.uk:5050/Homo_sapiens/Variation/Population?db=core;r=1:8044972-8045972;v=rs1293885450;vdb=variation;vf=507101856#gem-j_anchor


## Possible complications

None, a documentation change

## Merge conflicts

Tested on sandbox, branched from master

## Related JIRA Issues (EBI developers only)

ENSVAR-3769 - Update Web frequency tooltip for variant alleles only in VCF
