### PR TITLE
Update eQTL track info text

### DIFF
--- a/modules/EnsEMBL/Web/ImageConfig/generegview.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/generegview.pm
@@ -75,7 +75,7 @@ sub init_cacheable {
     my $tissue_readable = $tissue;
     $tissue_readable =~ s/_/ /g;
     my $manplot_desc = qq(
-      Complete set of eQTL correlation statistics as computed on $tissue_readable samples. Provided to Ensembl by the EBI eQTL catalog (www.ebi.ac.uk/eqtl)
+      Complete set of eQTL correlation statistics as computed on $tissue_readable samples. Provided to Ensembl by the EBI eQTL catalog (<a href="https://www.ebi.ac.uk/eqtl" target="_blank">www.ebi.ac.uk/eqtl</a>)
     );
     $self->add_track('functional_gene_expression',"reg_manplot_$tissue","$tissue_readable eQTLs",'reg_manplot',{
       tissue => $tissue,

--- a/modules/EnsEMBL/Web/ImageConfig/generegview.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/generegview.pm
@@ -75,11 +75,7 @@ sub init_cacheable {
     my $tissue_readable = $tissue;
     $tissue_readable =~ s/_/ /g;
     my $manplot_desc = qq(
-      Complete set of eQTL correlation statistics as computed by the GTEx consortium on $tissue_readable samples.
-      Provided to Ensembl by the EBI eQTL catalog.
-      The GTEx Consortium. Science. 8 May 2015: Vol 348 no. 6235 pp 648-660.
-      DOI: <a href="https://doi.org/10.1126/science.1262110">10.1126/science.1262110</a>.
-      PMID: <a href="http://www.ncbi.nlm.nih.gov/pubmed/25954001">25954001</a>
+      Complete set of eQTL correlation statistics as computed on $tissue_readable samples. Provided to Ensembl by the EBI eQTL catalog (www.ebi.ac.uk/eqtl)
     );
     $self->add_track('functional_gene_expression',"reg_manplot_$tissue","$tissue_readable eQTLs",'reg_manplot',{
       tissue => $tissue,


### PR DESCRIPTION
## Description
Updated the track info from:
"Complete set of eQTL correlation statistics as computed by the GTEx consortium on<platelet> samples. Provided to Ensembl by the EBI eQTL catalog. The GTEx Consortium. Science. 8 May 2015: Vol 348 no. 6235 pp 648-660. DOI: 10.1126/science.1262110. PMID: 25954001"

To:

"Complete set of eQTL correlation statistics as computed on <platelet> samples. Provided to Ensembl by the EBI eQTL catalog (www.ebi.ac.uk/eqtl)"


## Views affected
http://ves-hx2-75.ebi.ac.uk:42229/Homo_sapiens/Gene/Regulation?g=ENSG00000139618;r=13:32315086-32400268

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6116
