### PR TITLE
Add option to disable tools on mirrors

### DIFF
--- a/conf/httpd.conf
+++ b/conf/httpd.conf
@@ -134,6 +134,7 @@ RewriteEngine on
 RedirectMatch 404 ^/sitemaps/.*$
 # Tools redirect
 RewriteCond "%{REQUEST_URI}" ".*Tools/.*"
+RewriteCond /nfs/ensembl_tmp/tools_down !-f
 RewriteRule /(.*) http://www.ensembl.org/$1 [P]
 RewriteCond "%{REQUEST_URI}" ".*/Config/Blast/.*"
 RewriteRule /(.*) http://www.ensembl.org/$1 [P]

--- a/conf/httpd.conf
+++ b/conf/httpd.conf
@@ -134,7 +134,7 @@ RewriteEngine on
 RedirectMatch 404 ^/sitemaps/.*$
 # Tools redirect
 RewriteCond "%{REQUEST_URI}" ".*Tools/.*"
-RewriteCond /nfs/ensembl_tmp/tools_down !-f
+RewriteCond /nfs/services/nobackup/ensweb/tools_down !-f
 RewriteRule /(.*) http://www.ensembl.org/$1 [P]
 RewriteCond "%{REQUEST_URI}" ".*/Config/Blast/.*"
 RewriteRule /(.*) http://www.ensembl.org/$1 [P]
@@ -142,7 +142,7 @@ RewriteRule /(.*) http://www.ensembl.org/$1 [P]
 # Disable tools on mirror when tools_down file is present
 RewriteCond "%{REQUEST_URI}" ".*Tools/.*"
 RewriteCond "%{REQUEST_URI}" "!.*/Tools/Down.*"
-RewriteCond /nfs/ensembl_tmp/tools_down -f
+RewriteCond /nfs/services/nobackup/ensweb/tools_down -f
 RewriteRule ^(.*)$ /Tools/Down [R]
 
 # Blocking naughty robots.

--- a/conf/httpd.conf
+++ b/conf/httpd.conf
@@ -138,6 +138,12 @@ RewriteRule /(.*) http://www.ensembl.org/$1 [P]
 RewriteCond "%{REQUEST_URI}" ".*/Config/Blast/.*"
 RewriteRule /(.*) http://www.ensembl.org/$1 [P]
 
+# Disable tools on mirror when tools_down file is present
+RewriteCond "%{REQUEST_URI}" ".*Tools/.*"
+RewriteCond "%{REQUEST_URI}" "!.*/Tools/Down.*"
+RewriteCond /nfs/ensembl_tmp/tools_down -f
+RewriteRule ^(.*)$ /Tools/Down [R]
+
 # Blocking naughty robots.
 # You need both of these for each bot.
 # Don't block the loadbalancer by accident!


### PR DESCRIPTION
## Description

- Added the code back to disable tools on mirrors using the following commits:
-- https://github.com/Ensembl/ensembl-webcode/commit/03bab3dc#diff-67c427902d6bb8985d728ab4d2f1ec075564d3f61960969f4777e33ba1f914a7R108
-- https://github.com/Ensembl/ebi-plugins/commit/b5b7fa2d16a79cee89f1476652727a2a5c22157d

- To disable, we need to create the file `tools_down` in the location: `/nfs/services/nobackup/ensweb/` on the mirrors.

**NOTE:** This needs to be merged along with the following PR:
https://github.com/Ensembl/ebi-plugins/pull/80

## Views affected

http://ves-hx2-75.ebi.ac.uk:42229/info/docs/tools/index.html

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5595
