### PR TITLE
[ENSWEB-5419] Enable supertrees for mice strains

### DIFF
--- a/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
@@ -110,7 +110,7 @@ sub form_fields {
     'label' => 'Show super-tree',
     'name'  => 'super_tree',
     'value' => 'on',
-  } unless ($self->species =~/Mus/ && $self->hub->species_defs->IS_STRAIN_OF); ###HACK (TO BE REMOVED) hide option for all mouse strains
+  };
 
   my @groups = ($self->hub->param('strain') || $self->hub->species_defs->IS_STRAIN_OF) ? () : $self->_groups; #hide these options for strain view or strain species
 

--- a/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
@@ -171,7 +171,7 @@ sub content {
         link  => $hub->url({
           species  => $hub->species_defs->production_name_mapping($link_gene->genome_db->name),
           type     => 'Gene',
-          action   => 'Compara_Tree',
+          action   => $hub->referer->{ENSEMBL_ACTION},
           __clear  => 1,
           g        => $link_gene->stable_id,
         })


### PR DESCRIPTION
## Description

Mice supertrees are now available and thus we need to remove the hack we used to hide the supertrees option in configuration.

## Views affected

Genetrees in general as there is a change in "Switch to supertree url" link in the supertree zmenu

Check it in sandbox:
Strain: 
http://ves-hx-78.ebi.ac.uk:9000/Mus_musculus_129S1_SvImJ/Gene/Strain_Compara_Tree?g=MGP_129S1SvImJ_G0016104;r=1:65277845-65279914;t=MGP_129S1SvImJ_T0020282

Breed:
http://ves-hx-78.ebi.ac.uk:9000/Sus_scrofa_bamei/Gene/Strain_Compara_Tree?g=ENSSSCG00050037595;r=LUXV01057655.1:1521438-1532941

## Merge conflicts
N/A

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5419?filter=-1

