### PR TITLE
Fix genes in upper pane that are not linkable

### DIFF
--- a/modules/EnsEMBL/Web/ZMenu/Gene.pm
+++ b/modules/EnsEMBL/Web/ZMenu/Gene.pm
@@ -54,13 +54,14 @@ sub _content {
       type  => 'Gene Symbol',
       label => $gene_desc
     });
-
-    $self->add_entry({
-      type  => 'Gene ID',
-      label => $object->stable_id,
-      link  => $hub->url({ type => 'Gene', action => 'Summary' })
-    });
   }
+  
+  $self->add_entry({
+    type  => 'Gene ID',
+    label => $object->stable_id,
+    link  => $hub->url({ type => 'Gene', action => 'Summary' })
+  });
+
   
   $self->add_entry({
     type  => 'Location',


### PR DESCRIPTION
## Description

Fixed the issue with the genes in upper pane that are not linkable. As per the code before this change, the stableId does not getting displayed when the gene description is missing which I think shouldn't be the case.

## Views affected

http://ves-hx2-75.ebi.ac.uk:42228/Camarhynchus_parvulus_GCA_902806625.1/Location/Overview?db=core;r=2:1-152240728;region=2

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6141
