### PR TITLE
Variation summary page - uri escape

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -25,6 +25,7 @@ use strict;
 use EnsEMBL::Web::Utils::FormatText qw(helptip);
 use Encode qw(encode decode);
 use HTML::Entities;
+use URI::Escape qw(uri_unescape);
 
 use base qw(EnsEMBL::Web::Component::Variation);
 
@@ -370,7 +371,7 @@ sub synonyms {
            $url_id =~ s/\./#/;
         $url_ids{$id} = $url_id;
       }
-      @urls = map { s/%23/#/; $_ } map $hub->get_ExtURL_link($_, 'OMIM', $url_ids{$_}), @ids;
+      @urls = map { uri_unescape($_) } map $hub->get_ExtURL_link($_, 'OMIM', $url_ids{$_}), @ids;
     }
     elsif ($db =~ /clinvar/i) {
       foreach (@ids) {


### PR DESCRIPTION
## Description

Convert the URL with `uri_unescape` instead of manually replacing the characters. 

## Views affected

Variation synonyms on the variant summary page.
Sandbox: http://ves-hx2-76.ebi.ac.uk:7040/Homo_sapiens/Variation/Explore?db=core;r=1:230709548-230710548;v=rs699;vdb=variation;vf=94 

## Possible complications

None

## Merge conflicts

No conflicts

## Related JIRA Issues (EBI developers only)

ENSVAR-3882 
