### PR TITLE
Bugfix/basenji

### DIFF
--- a/htdocs/components/02_LayoutManager.js
+++ b/htdocs/components/02_LayoutManager.js
@@ -329,7 +329,7 @@ Ensembl.LayoutManager.extend({
     var shouldShowSurvey = Ensembl.cookie.get(cookie_name);
 
     if (shouldShowSurvey !== 'closed') {
-      $('#masthead').after([ "<div class='ebi-survey-message' style='background-color: #FFCC00; height: 40px; text-align: center;padding-top: 15px;position: relative;color: #000000;top: 80px;'>",
+      $('#masthead').after([ "<div class='ebi-survey-message' style='background-color: #FFCC00; height: 40px; text-align: center;padding-top: 15px;position: relative;color: #000000;'>",
           "<span style='font-weight:bold; margin-right: 40px;'>We need your help!</span>",
           "<span style='margin-right: 40px;'>If you’ve ever found our data helpful, please take our impact survey (15 min). Your replies will help keep the data flowing to the scientific community.</span>",
           "<a style='color: white; background-color: #23B123; display: inline-block;padding: 6px 20px;border-radius: 10px;text-decoration: none;' href='https://www.surveymonkey.co.uk/r/EMBL-EBI_Impact_DR' target='_blank'>Take the survey</a>",

--- a/htdocs/components/02_LayoutManager.js
+++ b/htdocs/components/02_LayoutManager.js
@@ -330,8 +330,7 @@ Ensembl.LayoutManager.extend({
 
     if (shouldShowSurvey !== 'closed') {
       $('#masthead').after([ "<div class='ebi-survey-message' style='background-color: #FFCC00; height: 40px; text-align: center;padding-top: 15px;position: relative;color: #000000;'>",
-          "<span style='font-weight:bold; margin-right: 40px;'>We need your help!</span>",
-          "<span style='margin-right: 40px;'>If you’ve ever found our data helpful, please take our impact survey (15 min). Your replies will help keep the data flowing to the scientific community.</span>",
+          "<span style='margin-right: 40px;'>We need your help in understanding the impact of Ensembl in your research. Please take the EMBL-EBI impact survey that includes Ensembl (15 min). Your replies will help keep the data flowing to the scientific community.</span>",
           "<a style='color: white; background-color: #23B123; display: inline-block;padding: 6px 20px;border-radius: 10px;text-decoration: none;' href='https://www.surveymonkey.co.uk/r/EMBL-EBI_Impact_DR' target='_blank'>Take the survey</a>",
           "<span id='ebi-survey-close-button' style='position: absolute; top: 14px; right: 25px;cursor: pointer;font-size:22px;'>",
             "×",

--- a/htdocs/components/02_LayoutManager.js
+++ b/htdocs/components/02_LayoutManager.js
@@ -144,6 +144,7 @@ Ensembl.LayoutManager.extend({
     });
 
     this.showGDPRCookieBanner();
+    this.showEBISurveyBanner();
     this.showTemporaryMessage();
     this.showMirrorMessage();
   },
@@ -314,6 +315,34 @@ Ensembl.LayoutManager.extend({
           Ensembl.cookie.set(cookie_name, Ensembl.gdpr_version, '', true, cookie_for_all_sites);
           $(this).addClass('clicked')
                  .closest('.cookie-message').delay(1000).fadeOut(100);
+      });
+      return true;
+    }
+
+    return false;
+  },
+
+  showEBISurveyBanner: function() {
+
+    var cookie_name = 'ebi_survey';
+    var cookie_for_all_sites = true;
+    var shouldShowSurvey = Ensembl.cookie.get(cookie_name);
+
+    if (shouldShowSurvey !== 'closed') {
+      $('#masthead').after([ "<div class='ebi-survey-message' style='background-color: #FFCC00; height: 40px; text-align: center;padding-top: 15px;position: relative;color: #000000;top: 80px;'>",
+          "<span style='font-weight:bold; margin-right: 40px;'>We need your help!</span>",
+          "<span style='margin-right: 40px;'>If you’ve ever found our data helpful, please take our impact survey (15 min). Your replies will help keep the data flowing to the scientific community.</span>",
+          "<a style='color: white; background-color: #23B123; display: inline-block;padding: 6px 20px;border-radius: 10px;text-decoration: none;' href='https://www.surveymonkey.co.uk/r/EMBL-EBI_Impact_DR' target='_blank'>Take the survey</a>",
+          "<span id='ebi-survey-close-button' style='position: absolute; top: 14px; right: 25px;cursor: pointer;font-size:22px;'>",
+            "×",
+          "</div>",
+        "</div>"
+      ].join(''));
+
+        $('#ebi-survey-close-button').on('click', function (e) {
+          Ensembl.cookie.set(cookie_name, 'closed', 5259600000, true, cookie_for_all_sites);
+          $(this).addClass('clicked')
+                 .closest('.ebi-survey-message').delay(1000).fadeOut(100);
       });
       return true;
     }

--- a/htdocs/components/02_PanelManager.js
+++ b/htdocs/components/02_PanelManager.js
@@ -148,7 +148,7 @@ Ensembl.PanelManager.extend({
    * Creates the panels in the Ensembl object, adds to the panels registry and initializes it
    */
   createPanel: function (id, type, params) {
-    if (this.panels[id]) {
+    if (this.panels[id] && !this.panels[id].multi) {
       this.destroyPanel(id, 'cleanup');
     }
     if (type) {

--- a/htdocs/components/15_TextSequence.js
+++ b/htdocs/components/15_TextSequence.js
@@ -23,6 +23,7 @@ Ensembl.Panel.TextSequence = Ensembl.Panel.Content.extend({
   },
   
   init: function () {
+    this.multi = true;
     var panel = this;
     this.base();
     

--- a/htdocs/components/22_dynamic_content.css
+++ b/htdocs/components/22_dynamic_content.css
@@ -279,3 +279,7 @@ div.cookie-message div.agree-button a.button.clicked{
   padding: 6px 15px 2px 32px!important;
   background-position-x: 8px;
 }
+
+.solr_page_p_page #masthead + .ebi-survey-message {
+  top: 80px;
+}

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -159,8 +159,9 @@ sub content {
       my $species_selected = $set eq 'all' ? 'checked="checked"' : ''; # select all species by default
 
       my $none_title = $set_info->{'none'} ? sprintf('<a href="#list_no_ortho">%d</a>', $set_info->{'none'}) : 0;
+      my $total = $set_info->{'all'} || 0;
       push @rows, {
-        'set'       => "<strong>$set_info->{'title'}</strong> (<i>$set_info->{'all'} species</i>)<br />$set_info->{'desc'}",
+        'set'       => "<strong>$set_info->{'title'}</strong> (<i>$total species</i>)<br />$set_info->{'desc'}",
         'show'      => qq{<input type="checkbox" class="table_filter" title="Check to show these species in table below" name="orthologues" value="$set" $species_selected />},
         '1:1'       => $set_info->{'1-to-1'}       || 0,
         '1:many'    => $set_info->{'1-to-many'}    || 0,

--- a/modules/EnsEMBL/Web/Query/GlyphSet/Transcript.pm
+++ b/modules/EnsEMBL/Web/Query/GlyphSet/Transcript.pm
@@ -182,10 +182,8 @@ sub _get_prediction_transcripts {
   my $slice = $args->{'slice'};
   my $db_alias = $args->{'db'};
   my @out;
-  foreach my $logic_name (@{$args->{'logic_names'}}) {
-    my $logic_name_with_species = $logic_name.'_'.$args->{'species'};
-
-    my @t = @{$slice->get_all_PredictionTranscripts($logic_name_with_species,$db_alias)};
+  foreach my $an (@{$args->{'logic_names'}}) {
+    my @t = @{$slice->get_all_PredictionTranscripts($an,$db_alias)};
     my @g = map { $self->_fake_gene($_) } @t;
     push @out,@g;
   }
@@ -198,19 +196,18 @@ sub _get_genes {
   my $slice          = $args->{'slice'};
   my $analyses       = $args->{'logic_names'};
   my $db_alias       = $args->{'db'};
-  my $species        = $args->{'species'};
 
   if ($analyses->[0] eq 'LRG_import' && !$slice->isa('Bio::EnsEMBL::LRGSlice')) {
     warn "!!! DEPRECATED CODE - please change this track to use GlyphSet::lrg";
     my $lrg_slices = $slice->project('lrg');
     if ($lrg_slices->[0]) {
       my $lrg_slice = $lrg_slices->[0]->to_Slice;
-      return [map @{$lrg_slice->get_all_Genes($_.'_'. $species,$db_alias) || []}, @$analyses];
+      return [map @{$lrg_slice->get_all_Genes($_,$db_alias) || []}, @$analyses];
     }
   } elsif ($slice->isa('Bio::EnsEMBL::LRGSlice') && $analyses->[0] ne 'LRG_import') {
-    return [map @{$slice->feature_Slice->get_all_Genes($_.'_'.$species, $db_alias) || []}, @$analyses];
+    return [map @{$slice->feature_Slice->get_all_Genes($_, $db_alias) || []}, @$analyses];
   } else {
-    return [map @{$slice->get_all_Genes($_.'_'.$species,$db_alias) || []}, @$analyses];
+    return [map @{$slice->get_all_Genes($_,$db_alias) || []}, @$analyses];
   }
 }
 
@@ -387,6 +384,7 @@ sub _is_coding_gene {
 
 sub get {
   my ($self,$args) = @_;
+
   my (@out,$genes);
   if($args->{'prediction'}) {
     $genes = $self->_get_prediction_transcripts($args);

--- a/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
@@ -110,7 +110,7 @@ sub form_fields {
     'label' => 'Show super-tree',
     'name'  => 'super_tree',
     'value' => 'on',
-  } unless ($self->species =~/Mus/ && $self->hub->species_defs->IS_STRAIN_OF); ###HACK (TO BE REMOVED) hide option for all mouse strains
+  };
 
   my @groups = ($self->hub->param('strain') || $self->hub->species_defs->IS_STRAIN_OF) ? () : $self->_groups; #hide these options for strain view or strain species
 

--- a/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
@@ -56,7 +56,7 @@ sub content {
   my $parent_distance = $node->distance_to_parent || 0;
 
   if ($is_leaf and $is_supertree) {
-    my $child = $node->adaptor->fetch_node_by_node_id($node->{_subtree}->root_id);
+    my $child = $node->children->[0] || $node->adaptor->fetch_node_by_node_id($node->{_subtree}->root_id);
     $node->add_tag('species_tree_node_id', $child->get_tagvalue('species_tree_node_id'));
     my $members = $node->adaptor->fetch_all_AlignedMember_by_root_id($child->node_id);
     $node->{_sub_leaves_count} = scalar(@$members);

--- a/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
@@ -171,7 +171,7 @@ sub content {
         link  => $hub->url({
           species  => $hub->species_defs->production_name_mapping($link_gene->genome_db->name),
           type     => 'Gene',
-          action   => 'Compara_Tree',
+          action   => $hub->referer->{ENSEMBL_ACTION},
           __clear  => 1,
           g        => $link_gene->stable_id,
         })


### PR DESCRIPTION
## Description

TextSequence race possible on all species: common in Basenji.
    
Allow multiple instances of certain panels to avoid destructor being called before another instance calls the constructor.
    
Manifests as broken or never loading textsequences.


## Views affected

Text sequences.

## Possible complications

Look out for broken text sequences leading to missing or duplicated blocks of sequence, particularly on pages (if any exist) with multiple, independent sequences on the page. No real reason to suspect this will happen, but that's the general area this fix is within.

These kinds of issues are also a likely effect of the original bug and are likely to not be reliably reproducible.

I'm not an expert on this area of code but I don't know who is these days.

## Merge conflicts

None

## Related JIRA Issues (EBI developers only)

@Ben-Ensembl on slack.