### PR TITLE
TextSequence race possible on all species: common in Basenji.

### DIFF
--- a/htdocs/components/02_PanelManager.js
+++ b/htdocs/components/02_PanelManager.js
@@ -148,7 +148,7 @@ Ensembl.PanelManager.extend({
    * Creates the panels in the Ensembl object, adds to the panels registry and initializes it
    */
   createPanel: function (id, type, params) {
-    if (this.panels[id]) {
+    if (this.panels[id] && !this.panels[id].multi) {
       this.destroyPanel(id, 'cleanup');
     }
     if (type) {

--- a/htdocs/components/15_TextSequence.js
+++ b/htdocs/components/15_TextSequence.js
@@ -23,6 +23,7 @@ Ensembl.Panel.TextSequence = Ensembl.Panel.Content.extend({
   },
   
   init: function () {
+    this.multi = true;
     var panel = this;
     this.base();
     


### PR DESCRIPTION
## Description

TextSequence race possible on all species: common in Basenji.
    
Allow multiple instances of certain panels to avoid destructor being called before another instance calls the constructor.
    
Manifests as broken or never loading textsequences.


## Views affected

Text sequences.

## Possible complications

Look out for broken text sequences leading to missing or duplicated blocks of sequence, particularly on pages (if any exist) with multiple, independent sequences on the page. No real reason to suspect this will happen, but that's the general area this fix is within.

These kinds of issues are also a likely effect of the original bug and are likely to not be reliably reproducible.

I'm not an expert on this area of code but I don't know who is these days.

## Merge conflicts

None

## Related JIRA Issues (EBI developers only)

@Ben-Ensembl on slack.