### PR TITLE
Initialise randomness for each worker thread.

### DIFF
--- a/modules/EnsEMBL/Web/Apache/Handlers.pm
+++ b/modules/EnsEMBL/Web/Apache/Handlers.pm
@@ -331,7 +331,8 @@ sub childInitHandler {
   ## This handler gets called by Apache when initialising an Apache child process
   ## @param APR::Pool object
   ## @param Apache2::ServerRec server object
-  ## This handler only adds an entry to the logs
+  ## This handler only adds an entry to the logs and initialises randomness.
+  srand;
   warn sprintf "[%s] Child initialised: %d\n", time_str, $$ if $SiteDefs::ENSEMBL_DEBUG_HANDLER_ERRORS;
 
   return OK;


### PR DESCRIPTION
## Description

TextSequence race possible on all species: common in Basenji.
    
Initialise randomness in each thread.
    
Manifests as broken or never loading textsequences.

## Views affected

Text sequences.

## Possible complications

Look out for broken text sequences leading to missing or duplicated blocks of sequence, particularly on pages (if any exist) with multiple, independent sequences on the page. No real reason to suspect this will happen, but that's the general area this fix is within.

These kinds of issues are also a likely effect of the original bug and are likely to not be reliably reproducible.

I'm not an expert on this area of code but I don't know who is these days.

## Merge conflicts

None

## Related JIRA Issues (EBI developers only)

@Ben-Ensembl on slack.