### PR TITLE
Update configuration to disable image scrolling in gene summary page.

### DIFF
--- a/modules/EnsEMBL/Web/ImageConfig/gene_summary.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/gene_summary.pm
@@ -55,7 +55,6 @@ sub init_cacheable {
   $self->add_tracks('other',
     [ 'scalebar',  '', 'scalebar',  { display => 'normal', strand => 'b', name => 'Scale bar', description => 'Shows the scalebar' }],
     [ 'ruler',     '', 'ruler',     { display => 'normal', strand => 'b', name => 'Ruler',     description => 'Shows the length of the region being displayed' }],
-    [ 'draggable', '', 'draggable', { display => 'normal', strand => 'b', menu => 'no' }],
   );
 
   $self->add_tracks('information',


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description
That the graphical representation of the gene transcripts in the gene summary page, cannot be scrolled (using the "Drag/Scroll to a region" option). The view never updates after dragging

## Views affected
http://www.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000135960;r=2:108894471-108989372
http://ves-hx2-75.ebi.ac.uk:8790/Homo_sapiens/Gene/Summary?g=ENSG00000139618;r=13:32336210-32441392;db=core
## Possible complications

There's a possibility that this configuration is used by another image.

## Merge conflicts
-

## Related JIRA Issues (EBI developers only)
 https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5679
