### PR TITLE
Bugfix: update deprecated Ensembl FuncGen API methods

### DIFF
--- a/modules/EnsEMBL/Web/Component/Regulation/Evidence.pm
+++ b/modules/EnsEMBL/Web/Component/Regulation/Evidence.pm
@@ -54,7 +54,7 @@ sub content {
     foreach my $experiment (sort keys %$experiments) {
       my $peak_calling = $experiments->{$experiment};
       next unless (ref($peak_calling) =~ /PeakCalling/);
-      my $feature_type = $peak_calling->fetch_FeatureType;
+      my $feature_type = $peak_calling->get_FeatureType;
       my $feature_name = $feature_type->name;
     
       my $source_link = $self->hub->url({
@@ -69,7 +69,7 @@ sub content {
         cell     => $cell_line,
         source   => sprintf(q(<a href="%s">%s</a>),
                   $source_link,
-                  $peak_calling->fetch_source_label),
+                  $peak_calling->get_source_label),
       };
     }
   }

--- a/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
@@ -358,7 +358,7 @@ sub content {
 
         my $row = {
             rf        => sprintf('<a href="%s">%s</a>', $url, $rfv->regulatory_feature->stable_id),
-            ftype     => $rf->feature_type->so_name,
+            ftype     => $rf->feature_type->so_term,
             allele    => $r_allele,
             type      => $type || '-',
             coverage  => $reg_length_label.$regulation_overlap

--- a/modules/EnsEMBL/Web/Factory/Feature.pm
+++ b/modules/EnsEMBL/Web/Factory/Feature.pm
@@ -159,12 +159,12 @@ sub _create_ProbeFeatures_linked_transcripts {
     my $id = $self->param('id');
     my $probe_set_adaptor = $db_adaptor->get_ProbeSetAdaptor;
     my $probe_set = shift @{$probe_set_adaptor->fetch_all_by_name($id)};
-    @db_entries = $probe_set ? @{$probe_set->fetch_all_ProbeSetTranscriptMappings} : ();
+    @db_entries = $probe_set ? @{$probe_set->get_all_ProbeSetTranscriptMappings} : ();
   } else {
     my $probe_adaptor = $db_adaptor->get_ProbeAdaptor;
     @probe_objs = @{$probe_adaptor->fetch_all_by_name($self->param('id'))};
     foreach my $probe (@probe_objs) {
-      my @entries = @{$probe->fetch_all_ProbeTranscriptMappings};
+      my @entries = @{$probe->get_all_ProbeTranscriptMappings};
       push(@db_entries, @entries);
     }
   }

--- a/modules/EnsEMBL/Web/Object/Experiment.pm
+++ b/modules/EnsEMBL/Web/Object/Experiment.pm
@@ -93,7 +93,7 @@ sub new {
   # Get info for all feature sets and pack it in an array of hashes
   foreach my $peak_calling (@$peak_callings) {
   
-    my $experiment = $peak_calling->fetch_Experiment;
+    my $experiment = $peak_calling->get_Experiment;
 
     if (! defined $experiment) {
       #warn "Failed to get Experiment for FeatureSet:\t".$peak_calling->name;
@@ -104,9 +104,9 @@ sub new {
     $experiment_group     = undef unless $experiment_group->is_project;
     my $project_name      = $experiment_group ? $experiment_group->name : '';
     my $source_info       = $experiment->_source_info; # returns [[source_label, source_link], [source_label, source_link], ...]
-    my $epigenome         = $peak_calling->fetch_Epigenome;
+    my $epigenome         = $peak_calling->get_Epigenome;
     my $epigenome_name    = $epigenome->short_name;
-    my $feature_type      = $peak_calling->fetch_FeatureType;
+    my $feature_type      = $peak_calling->get_FeatureType;
     my $evidence_label    = $feature_type->evidence_type_label;
 
     my $binding_matrices  = [];

--- a/modules/EnsEMBL/Web/Object/Slice.pm
+++ b/modules/EnsEMBL/Web/Object/Slice.pm
@@ -487,10 +487,10 @@ sub get_table_data {
 
   foreach my $peak_calling (@{$all_peak_calling||[]}) {
 
-    my $ftype       = $peak_calling->fetch_FeatureType;
+    my $ftype       = $peak_calling->get_FeatureType;
     my $ftype_name  = $ftype->name;
 
-    my $epigenome   = $peak_calling->fetch_Epigenome;
+    my $epigenome   = $peak_calling->get_Epigenome;
     my $cell_line   = $epigenome->short_name;
 
     $data->{$cell_line}{$ftype_name} = $peak_calling;

--- a/modules/EnsEMBL/Web/Object/Transcript.pm
+++ b/modules/EnsEMBL/Web/Object/Transcript.pm
@@ -1102,7 +1102,7 @@ sub get_oligo_probe_data {
   PROBE:
   foreach my $current_probe_transcript_mapping (@$probe_transcript_mapping) {
   
-    my $probe       = $current_probe_transcript_mapping->fetch_Probe;
+    my $probe       = $current_probe_transcript_mapping->get_Probe;
     my $description = $current_probe_transcript_mapping->description;
     
     my $array_chip = $probe->array_chip;
@@ -1137,7 +1137,7 @@ sub get_oligo_probe_data {
   
   foreach my $current_probe_set_transcript_mapping (@$probe_set_transcript_mapping) {
   
-    my $probe_set   = $current_probe_set_transcript_mapping->fetch_ProbeSet;
+    my $probe_set   = $current_probe_set_transcript_mapping->get_ProbeSet;
     my $description = $current_probe_set_transcript_mapping->description;
     
     my $probe_set_name = $probe_set->name;

--- a/modules/EnsEMBL/Web/ZMenu/FeatureEvidence.pm
+++ b/modules/EnsEMBL/Web/ZMenu/FeatureEvidence.pm
@@ -43,14 +43,14 @@ sub content {
 
   my $summit   = $peak->summit || 'undetermined';
   
-  $self->caption($peak_calling->fetch_FeatureType->evidence_type_label);
+  $self->caption($peak_calling->get_FeatureType->evidence_type_label);
   
   $self->add_entry({
     type  => 'Feature',
     label => $peak_calling->display_label
   });
 
-  my $source_label = $peak_calling->fetch_source_label;
+  my $source_label = $peak_calling->get_source_label;
 
   if(defined $source_label){
 


### PR DESCRIPTION
## Description

This bugfix updates the deprecated methods from Ensembl Regulation (Funcgen) API that are used in webcode and listed for removal in 104:
https://github.com/Ensembl/ensembl-funcgen/blob/release/104/DEPRECATED.md
New method names sourced from the API documentation: http://www.ensembl.org/info/docs/Doxygen/funcgen-api/annotated.html

## Views affected

Example URLs using the affected methods: 
- http://wp-np2-1d.ebi.ac.uk:1610/Homo_sapiens/Transcript/Oligos?db=core;g=ENSG00000128573;r=7:114414997-114693768;t=ENST00000403559
- http://wp-np2-1d.ebi.ac.uk:1610/Homo_sapiens/Regulation/Evidence?db=funcgen;fdb=funcgen;r=13:32313600-32318001;rf=ENSR00000060894
- http://wp-np2-1d.ebi.ac.uk:1620/Zea_mays/Transcript/Oligos?db=core;g=Zm00001eb113460;r=2:230473563-230476257;t=Zm00001eb113460_T001

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6215
