### PR TITLE
Update transcript table

### DIFF
--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -180,28 +180,26 @@ sub transcript_table {
       MANE_Plus_Clinical   => 'MANE Plus Clinical');
 
     my $trans_attribs = {};
-    my $trans_gencode = {};
+    my @attrib_types = ('is_canonical','gencode_basic','appris','TSL','CDS_start_NF','CDS_end_NF');
+    push(@attrib_types, keys %MANE_attrib_codes);
 
     foreach my $trans (@$transcripts) {
-      foreach my $attrib_type ('CDS_start_NF','CDS_end_NF','gencode_basic','TSL','appris',keys %MANE_attrib_codes) {
+      foreach my $attrib_type (@attrib_types) {
         (my $attrib) = @{$trans->get_all_Attributes($attrib_type)};
-        next unless $attrib;
-        if($attrib_type eq 'gencode_basic' && $attrib->value) {
-          $trans_gencode->{$trans->stable_id}{$attrib_type} = $attrib->value;
-        } 
-        elsif ($attrib_type eq 'appris'  && $attrib->value) {
+        next unless $attrib && $attrib->value;
+        if ($attrib_type eq 'appris') {
           ## Assume there is only one APPRIS attribute per transcript
           my $short_code = $attrib->value;
           ## Manually shorten the full attrib values to save space
           $short_code =~ s/ernative//;
           $short_code =~ s/rincipal//;
           $trans_attribs->{$trans->stable_id}{'appris'} = [$short_code, $attrib->value]; 
-          }
-        elsif ((grep {$attrib_type eq $_} keys %MANE_attrib_codes) && $attrib && $attrib->value) {
-          $trans_attribs->{$trans->stable_id}{$attrib_type} = $attrib;
+        }
+        elsif ($MANE_attrib_codes{$attrib_type}) {
+          $trans_attribs->{$trans->stable_id}{$attrib_type} = [$attrib->name, $attrib->value];
         }
         else {
-          $trans_attribs->{$trans->stable_id}{$attrib_type} = $attrib->value if ($attrib && $attrib->value);
+          $trans_attribs->{$trans->stable_id}{$attrib_type} = $attrib->value;
         }
       }
     }
@@ -264,9 +262,16 @@ sub transcript_table {
     if ($species eq 'Homo_sapiens' && $sub_type eq 'GRCh37' ) {
       $extra_links{refseq} = { first_match => "^RefSeq", name => "RefSeq", order => 1, title => "RefSeq transcripts with sequence similarity and genomic overlap"};
     }
+
+    sub sort_transcripts {
+      # Transcript order: is_canonical/MANE_Select => external_name => stable_id
+      return $trans_attribs->{$a->[1]}{'is_canonical'} || $trans_attribs->{$a->[1]}{'MANE_Select'} ? 1 : 
+        $trans_attribs->{$b->[1]}{'is_canonical'} || $trans_attribs->{$b->[1]}{'MANE_Select'} ? -1 :
+        ($a->[0] cmp $b->[0] || $a->[1] cmp $b->[1]);
+    }
+
     my %any_extras;
- 
-    foreach (map { $_->[2] } sort { $a->[0] cmp $b->[0] || $a->[1] cmp $b->[1] } map { [ $_->external_name, $_->stable_id, $_ ] } @$transcripts) {
+    foreach (map { $_->[2] } sort sort_transcripts map { [ $_->external_name, $_->stable_id, $_ ] } @$transcripts) {
       my $transcript_length = $_->length;
       my $version           = $_->version ? ".".$_->version : "";
       my $tsi               = $_->stable_id;
@@ -300,6 +305,7 @@ sub transcript_table {
         @CCDS = sort keys %T;
         $ccds = join ', ', map $hub->get_ExtURL_link($_, 'CCDS', $_), @CCDS;
       }
+
       foreach my $k (keys %extra_links) {
         
         my @links = grep {$_->status ne 'PRED' } grep { $_->dbname =~ /$extra_links{$k}->{'first_match'}/i } @$dblinks;
@@ -320,32 +326,39 @@ sub transcript_table {
           $extras{$k} = $cell;
         }
       }
+
+      # Flag order: is_canonical, MANE_select, MANE_plus_clinical, gencode_basic, appris, TSL, CDS_start_NF, CDS_end_NF
+      my $refseq_url;
       if ($trans_attribs->{$tsi}) {
-        if (my $incomplete = $self->get_CDS_text($trans_attribs->{$tsi})) {
-          push @flags, $incomplete;
+        if ($trans_attribs->{$tsi}{'is_canonical'}) {
+          push @flags, helptip("Canonical", get_glossary_entry($hub, "Canonical transcript"));
         }
+
+        foreach my $MANE_attrib_code (keys %MANE_attrib_codes) {
+          if (my $mane_attrib = $trans_attribs->{$tsi}{$MANE_attrib_code}) {
+            my ($mane_name, $refseq_id) = @{$mane_attrib};
+            $refseq_url  = $hub->get_ExtURL_link($refseq_id, 'REFSEQ_MRNA', $refseq_id);
+            push @flags, helptip($mane_name, get_glossary_entry($hub, $MANE_attrib_codes{$MANE_attrib_code}));
+          }
+        }
+
+        if ($trans_attribs->{$tsi}{'gencode_basic'}) {
+          push @flags, helptip('GENCODE basic', $gencode_desc);
+        }
+
+        if ($trans_attribs->{$tsi}{'appris'}) {
+          my ($code, $key) = @{$trans_attribs->{$tsi}{'appris'}};
+          my $short_code = $code ? ' '.uc($code) : '';
+          push @flags, helptip("APPRIS $short_code","<p>APPRIS $short_code: ".get_glossary_entry($hub, "APPRIS$short_code")."</p><p>".get_glossary_entry($hub, 'APPRIS')."</p>");
+        }
+
         if ($trans_attribs->{$tsi}{'TSL'}) {
           my $tsl = uc($trans_attribs->{$tsi}{'TSL'} =~ s/^tsl([^\s]+).*$/$1/gr);
           push @flags, helptip("TSL:$tsl", "<p>TSL $tsl: ".get_glossary_entry($hub, "TSL $tsl")."</p><p>".get_glossary_entry($hub, 'Transcript support level')."</p>");
-	}
-      }
-      if ($trans_gencode->{$tsi}) {
-        if ($trans_gencode->{$tsi}{'gencode_basic'}) {
-          push @flags, helptip('GENCODE basic', $gencode_desc);
-        }
-      }
-      if ($trans_attribs->{$tsi}{'appris'}) {
-        my ($code, $key) = @{$trans_attribs->{$tsi}{'appris'}};
-        my $short_code = $code ? ' '.uc($code) : '';
-         push @flags, helptip("APPRIS $short_code","<p>APPRIS $short_code: ".get_glossary_entry($hub, "APPRIS$short_code")."</p><p>".get_glossary_entry($hub, 'APPRIS')."</p>");
- 
-      }
-      my $refseq_url;
-      foreach my $MANE_attrib_code (keys %MANE_attrib_codes) {
-        if (my $mane_attrib = $trans_attribs->{$tsi}{$MANE_attrib_code}) {
-          my $refseq_id = $mane_attrib->value;
-          $refseq_url  = $hub->get_ExtURL_link($refseq_id, 'REFSEQ_MRNA', $refseq_id);
-          push @flags, helptip($mane_attrib->name, get_glossary_entry($hub, $MANE_attrib_codes{$MANE_attrib_code}));
+	      }
+
+        if (my $incomplete = $self->get_CDS_text($trans_attribs->{$tsi})) {
+          push @flags, $incomplete;
         }
       }
 

--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -331,7 +331,7 @@ sub transcript_table {
       my $refseq_url;
       if ($trans_attribs->{$tsi}) {
         if ($trans_attribs->{$tsi}{'is_canonical'}) {
-          push @flags, helptip("Canonical", get_glossary_entry($hub, "Canonical transcript"));
+          push @flags, helptip("Ensembl Canonical", get_glossary_entry($hub, "Canonical transcript"));
         }
 
         foreach my $MANE_attrib_code (keys %MANE_attrib_codes) {
@@ -355,7 +355,7 @@ sub transcript_table {
         if ($trans_attribs->{$tsi}{'TSL'}) {
           my $tsl = uc($trans_attribs->{$tsi}{'TSL'} =~ s/^tsl([^\s]+).*$/$1/gr);
           push @flags, helptip("TSL:$tsl", "<p>TSL $tsl: ".get_glossary_entry($hub, "TSL $tsl")."</p><p>".get_glossary_entry($hub, 'Transcript support level')."</p>");
-	      }
+        }
 
         if (my $incomplete = $self->get_CDS_text($trans_attribs->{$tsi})) {
           push @flags, $incomplete;


### PR DESCRIPTION
## Description

Modifications to the transcripts table (in gene summary and transcripts page):
- Added flag for canonical transcripts
- Updated flag order (see the ticket)
- Reordered transcripts (move canonical to the top)
- Some code refactoring

## Views affected

Example sandbox URLs:
- Long transcript table: http://wp-np2-1d.ebi.ac.uk:1610/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000198947;r=X:31097677-33339609

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6094
