### PR TITLE
move precache default species to precache plugin Sitedefs

### DIFF
--- a/modules/EnsEMBL/Web/Query/Generic/Base.pm
+++ b/modules/EnsEMBL/Web/Query/Generic/Base.pm
@@ -91,7 +91,7 @@ sub loop_species {
   my ($self,$args,$subpart) = @_;
 
   my @out;
-  foreach my $sp (qw(Homo_sapiens Mus_musculus Danio_rerio)) {
+  foreach my $sp (@{$SiteDefs::PRECACHE_DEFAULT_SPECIES}) {
     next if ($subpart->{'species'}||$sp) ne $sp;
     my %out = %$args;
     $out{'species'} = $sp;


### PR DESCRIPTION

## Description

This PR is related to one in ebi-plugins. So Both should be merged together.
Precache runs for a set of species and this should be configurable in Sitedefs.

## Views affected

N/A

## Possible complications

There shouldn't be any complications as this is used only for precache run.

## Merge conflicts

N/A

## Related JIRA Issues (EBI developers only)

No JIRA unfortunately.