### PR TITLE
get alignment from hub

### DIFF
--- a/htdocs/components/15_ComparaAlignSliceSelector.js
+++ b/htdocs/components/15_ComparaAlignSliceSelector.js
@@ -14,6 +14,7 @@ Ensembl.Panel.ComparaAlignSliceSelector = Ensembl.Panel.extend({
     panel.elLk.go = $('form a.alignment-go', panel.el);
     panel.configUrl = $('input.compara_config_url', panel.el).val();
     panel.updateComponent = $('input.update_component', panel.el).val();
+    Ensembl.updateURL({'align' : panel.elLk.selectedInput.val()});
   },
 
   updateAlignmentSpeciesSelection: function(node) {

--- a/modules/EnsEMBL/Web/Command/DataExport/Output.pm
+++ b/modules/EnsEMBL/Web/Command/DataExport/Output.pm
@@ -103,7 +103,7 @@ sub process {
       my %align_formats = EnsEMBL::Web::Constants::ALIGNMENT_FORMATS;
       my $in_bioperl    = grep { lc($_) eq lc($format) } keys %align_formats;
       ## Alignments and trees are handled by external writers
-      if (($hub->param('align') && lc($format) ne 'rtf')
+      if (($hub->get_alignment_id && lc($format) ne 'rtf')
           || (ref($component) =~ /Paralog/ && $in_bioperl && lc($format) ne 'fasta')) {
         my %tree_formats  = EnsEMBL::Web::Constants::TREE_FORMATS;
         my $is_tree       = grep { lc($_) eq lc($format) } keys %tree_formats;
@@ -346,7 +346,7 @@ sub write_emboss {
 sub write_alignment {
   my ($self, $component) = @_;
   my $hub     = $self->hub;
-  my $align = $hub->param('align');
+  my $align = $hub->get_alignment_id;
   my ($alignment, $result);
   my $flag = $align ? undef : 'sequence';
   my $data = $component->get_export_data($flag);
@@ -385,7 +385,7 @@ sub write_alignment {
 
         $alignment = $self->object->get_alignments({
           'slice'     => $data->slice,
-          'align'     => $hub->param('align'),
+          'align'     => $align,
           'species'   => $hub->species,
           'type'      => $hub->param('data_type'),
           'component' => $hub->param('data_action'), 


### PR DESCRIPTION
## Description

Alignment ID for compara alignments view is stored in sessions. It used to be passed in the url as param "align" before we implemented sessions. You could still pass it via url which gets priority over sessions. Sequence export code only looked at alignment ID from url param. Hub.pm has a method to get alignment id correctly which should be used in this case.

http://ves-hx-78.ebi.ac.uk:9000/index.html

## Views affected

Sequence alignment exports

## Possible complications

Nothing that I am aware of.

## Merge conflicts

N/A

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEBREL-1125
https://helpdesk.ebi.ac.uk/Ticket/Display.html?id=492456
