### PR TITLE
Add Ensembl 2021 publication

### DIFF
--- a/htdocs/info/about/publications.html
+++ b/htdocs/info/about/publications.html
@@ -69,6 +69,7 @@ main Ensembl site is being continuously updated (currently release
           Jane E Loveland, Fergal J Martin, Jonathan M Mudge, Joanella Morales, Emily Perry, Magali Ruffier, 
           John Tate, David Thybert, Stephen J Trevanion, Fiona Cunningham, Andrew D Yates, Daniel R Zerbino, Paul Flicek<br />
           <strong>Ensembl 2021.</strong><br />
+          <i>Nucleic Acids Res.</i> 2021, vol. 49(1):884–891<br />
           PubMed PMID: 33137190.</br >
           <a href="https://doi.org/10.1093/nar/gkaa942">doi:10.1093/nar/gkaa942</a>
         </p>

--- a/htdocs/info/about/publications.html
+++ b/htdocs/info/about/publications.html
@@ -53,6 +53,28 @@ main Ensembl site is being continuously updated (currently release
       </li>
 
       <li id="current_ensembl">
+        <p id="Nucleic_Acids_Res_2021">
+          Kevin L Howe, Premanand Achuthan, James Allen, Jamie Allen, Jorge Alvarez-Jarreta, 
+          M Ridwan Amode, Irina M Armean, Andrey G Azov, Ruth Bennett, Jyothish Bhai, Konstantinos Billis, 
+          Sanjay Boddu, Mehrnaz Charkhchi, Carla Cummins, Luca Da Rin Fioretto, Claire Davidson, 
+          Kamalkumar Dodiya, Bilal El Houdaigui, Reham Fatima, Astrid Gall, Carlos Garcia Giron, 
+          Tiago Grego, Cristina Guijarro-Clarke, Leanne Haggerty, Anmol Hemrom, Thibaut Hourlier, 
+          Osagie G Izuogu, Thomas Juettemann, Vinay Kaikala, Mike Kay, Ilias Lavidas, Tuan Le, Diana Lemos, 
+          Jose Gonzalez Martinez, José Carlos Marugán, Thomas Maurel, Aoife C McMahon, Shamika Mohanan, 
+          Benjamin Moore, Matthieu Muffato, Denye N Oheh, Dimitrios Paraschas, Anne Parker, Andrew Parton, 
+          Irina Prosovetskaia, Manoj P Sakthivel, Ahamed I Abdul Salam, Bianca M Schmitt, Helen Schuilenburg, 
+          Dan Sheppard, Emily Steed, Michal Szpak, Marek Szuba, Kieron Taylor, Anja Thormann, 
+          Glen Threadgold, Brandon Walts, Andrea Winterbottom, Marc Chakiachvili, Ameya Chaubal, 
+          Nishadi De Silva, Bethany Flint, Adam Frankish, Sarah E Hunt, Garth R IIsley, Nick Langridge, 
+          Jane E Loveland, Fergal J Martin, Jonathan M Mudge, Joanella Morales, Emily Perry, Magali Ruffier, 
+          John Tate, David Thybert, Stephen J Trevanion, Fiona Cunningham, Andrew D Yates, Daniel R Zerbino, Paul Flicek<br />
+          <strong>Ensembl 2021.</strong><br />
+          PubMed PMID: 33137190.</br >
+          <a href="https://doi.org/10.1093/nar/gkaa942">doi:10.1093/nar/gkaa942</a>
+        </p>
+      </li>
+
+      <li>
         <p id="Nucleic_Acids_Res_2020">
           Andrew D Yates, Premanand Achuthan, Wasiu Akanni, James Allen, Jamie Allen, 
           Jorge Alvarez-Jarreta, M Ridwan Amode, Irina M Armean, Andrey G Azov, Ruth Bennett, 


### PR DESCRIPTION
## Description

This PR will add the the [Ensembl 2021 paper](https://doi.org/10.1093/nar/gkaa942) to the citations list in the publications page.

## Views affected

- Current site: https://www.ensembl.org/info/about/publications.html
- Sandbox: http://wp-np2-1d.ebi.ac.uk:1610/info/about/publications.html

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6191
