### PR TITLE
Update transcript table

### DIFF
--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -331,7 +331,8 @@ sub transcript_table {
           if (my $mane_attrib = $trans_attribs->{$tsi}{$MANE_attrib_code}) {
             my ($mane_name, $refseq_id) = @{$mane_attrib};
             $refseq_url  = $hub->get_ExtURL_link($refseq_id, 'REFSEQ_MRNA', $refseq_id);
-            push @flags, helptip($mane_name, get_glossary_entry($hub, $MANE_attrib_codes{$MANE_attrib_code}));
+            my $flagtip = helptip($mane_name, get_glossary_entry($hub, $MANE_attrib_codes{$MANE_attrib_code}));
+            $MANE_attrib_code eq  'MANE_Select'? unshift @flags, $flagtip : push @flags, $flagtip;
           }
         }
 


### PR DESCRIPTION
## Description

Updates flag order in the transcript table (set 'MANE Select' as the first one).

## Views affected

Example sandbox URL with a long transcript table:
http://wp-np2-1d.ebi.ac.uk:1610/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000198947;r=X:31097677-33339609

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6094
