### PR TITLE
Update Ensembl canonical flag in transcript table

### DIFF
--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -324,7 +324,7 @@ sub transcript_table {
       my $refseq_url;
       if ($trans_attribs->{$tsi}) {
         if ($trans_attribs->{$tsi}{'is_canonical'}) {
-          push @flags, helptip("Ensembl Canonical", get_glossary_entry($hub, "Canonical transcript"));
+          push @flags, helptip("Ensembl Canonical", get_glossary_entry($hub, "Ensembl canonical"));
         }
 
         foreach my $MANE_attrib_code (keys %MANE_attrib_codes) {

--- a/modules/EnsEMBL/Web/Utils/FormatText.pm
+++ b/modules/EnsEMBL/Web/Utils/FormatText.pm
@@ -79,7 +79,7 @@ sub helptip {
   ## @param Display html
   ## @param Tip html
   my ($display_html, $tip_html) = @_;
-  return $tip_html ? sprintf('<span class="ht _ht"><span class="_ht_tip hidden">%s</span>%s</span>', encode_entities($tip_html), $display_html) : $display_html;
+  return $tip_html ? sprintf('<span class="ht _ht"><span class="_ht_tip hidden">%s</span>%s</span>', $tip_html, $display_html) : $display_html;
 }
 
 sub glossary_helptip {


### PR DESCRIPTION
Updates the glossary key for the help tooltip when hovering Ensembl canonical flag.

- Sandbox URL: http://wp-np2-1d.ebi.ac.uk:1610/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000198947;r=X:31097677-33339609
- JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6094

