### PR TITLE
Allow configurable storage limits.

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -78,6 +78,8 @@ our $ENSEMBL_PROXY_PORT           = undef;                              # Port u
 our $ENSEMBL_LONGPROCESS_MINTIME  = 10;                                 # Warn extra info to logs if a process takes more than given time in seconds to serve request
 our $ENSEMBL_MAX_PROCESS_SIZE     = 1024 * 1024;                        # Value for Apache2::SizeLimit::MAX_PROCESS_SIZE
 our $ENSEMBL_MAIL_SERVER          = 'mail.mydomain.org';                # Mail server to be used for sending emails from the web server
+our $STORABLE_RECURSION_LIMIT     = 20474;				# Because recent defaults have become increasingly strange.
+our $STORABLE_RECURSION_LIMIT_HASH = 12278;				# Because recent defaults have become increasingly strange.
 ###############################################################################
 
 

--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -78,8 +78,8 @@ our $ENSEMBL_PROXY_PORT           = undef;                              # Port u
 our $ENSEMBL_LONGPROCESS_MINTIME  = 10;                                 # Warn extra info to logs if a process takes more than given time in seconds to serve request
 our $ENSEMBL_MAX_PROCESS_SIZE     = 1024 * 1024;                        # Value for Apache2::SizeLimit::MAX_PROCESS_SIZE
 our $ENSEMBL_MAIL_SERVER          = 'mail.mydomain.org';                # Mail server to be used for sending emails from the web server
-our $STORABLE_RECURSION_LIMIT     = 20474;				# Because recent defaults have become increasingly strange.
-our $STORABLE_RECURSION_LIMIT_HASH = 12278;				# Because recent defaults have become increasingly strange.
+our $STORABLE_RECURSION_LIMIT     = 20474;				# see perl5 bug GitHub #16780; those new deafults are too small for ensembl
+our $STORABLE_RECURSION_LIMIT_HASH = 12278;				# see perl5 bug GitHub #16780; those new deafults are too small for ensembl
 ###############################################################################
 
 

--- a/modules/EnsEMBL/Web/Apache/Handlers.pm
+++ b/modules/EnsEMBL/Web/Apache/Handlers.pm
@@ -332,8 +332,6 @@ sub childInitHandler {
   ## This handler gets called by Apache when initialising an Apache child process
   ## @param APR::Pool object
   ## @param Apache2::ServerRec server object
-  # Storable defaults are now too small. Ideally these would be configurable,
-  # perhaps in SiteDefs.
   $Storable::recursion_limit = $SiteDefs::STORABLE_RECURSION_LIMIT;
   $Storable::recursion_limit_hash = $SiteDefs::STORABLE_RECURSION_LIMIT_HASH;
   srand;

--- a/modules/EnsEMBL/Web/Apache/Handlers.pm
+++ b/modules/EnsEMBL/Web/Apache/Handlers.pm
@@ -334,8 +334,8 @@ sub childInitHandler {
   ## @param Apache2::ServerRec server object
   # Storable defaults are now too small. Ideally these would be configurable,
   # perhaps in SiteDefs.
-  $Storable::recursion_limit = 20474;
-  $Storable::recursion_limit_hash = 12278;
+  $Storable::recursion_limit = $SiteDefs::STORABLE_RECURSION_LIMIT;
+  $Storable::recursion_limit_hash = $SiteDefs::STORABLE_RECURSION_LIMIT_HASH;
   srand;
   warn sprintf "[%s] Child initialised: %d\n", time_str, $$ if $SiteDefs::ENSEMBL_DEBUG_HANDLER_ERRORS;
 


### PR DESCRIPTION
## Description

We sometimes store very large data objects with Storable, a standard perl way of serialising and deserialising data. This means that we care about two built-in limits in Storable which limit the size of such objects to help programs which mistakenly try to serialise large objects. These two globals used to be configured at the module's build-time for the machine it is built on. At some point in the release sequence for Storable this was stopped (perhaps only in the vendor's branch, homebrew) and fixed, very low limits were instituted instead -- far too low for our uses.

Our new sharedsw build for CentOS7 upgraded Storable to the point where we were affected by this. This meant that "things" broke on the CentOS7 machines (though any new, theoretical build for RH6 would also have displayed this behaviour). As an emergency hotfix these two variables were set manually to the previous values (ie the ones displayed on the RH6 machines) which seem like sensible defaults. But, for speed of writing the patch, these were just set as hardwired.

Now there's some time to do it properly, this patch moves these values to be configurable in SiteDefs. Potentially, people have very different machines to us and would want their own values (though the new default values seem sensible across a host of machine sizes, so the reality is that few will think it worth it).

The main "thing" found going wrong without the hotfix were various trackhub breakages, particularly the inability to attach Blueprint. Note, though, that this patch simply replaces the hacky hotfix with a clean fix with the same functionality and behaviour.

This fix has been tested on a sandbox by adding a warn after the commit to print the values used for these globals both with and without this patch (this warn was then removed). At the same time it was verified that the bluprint hub attachment succeeded/failed as expected when this patch took effect.

## Views affected

Certainly region in detail (when handling hubs), probably many other pages in corner cases.

## Possible complications

This is a global patch to a library config so isn't well localised. But its effect is strictly to broaden the number of calls which do not error.

One possible exception to this is someone who is running ensembl on a very large and relying on much larger autoconfigured values for these settings and is using an old perl version. They would have seen a bug when they eventually upgraded perl (and so Storable) anyway and with this patch they can simply add their previous values to their SiteDefs. I think it's unlikely that such a combination exists outside EBI, but this is what we should recommend.

This issue is well-known in the perl community so we won't be on a limb doing this.

## Merge conflicts

As this is like-for-like for behaviour it is fine for this to be only on master and not go live for a release or two. There are currently no conflicts.

## Related JIRA Issues (EBI developers only)

ENSWEB-6237