### PR TITLE
Bugfix104/breed with variation db

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Explore.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Explore.pm
@@ -40,7 +40,7 @@ sub content {
   my ($seq_url, $gt_url, $pop_url, $geno_url, $context_url, $ld_url, $pheno_url, $phylo_url, $cit_url, $prot_url);
   my ($gt_count, $pop_count, $geno_count, $pheno_count, $cit_count);
 
-  if ($avail->{'has_locations'}) {
+  if ($avail->{'has_locations'} && $avail->{'has_alignments'}) {
     $seq_url      = $hub->url({'action' => 'Sequence'});
     $context_url  = $hub->url({'action' => 'Context'});
   }

--- a/modules/EnsEMBL/Web/Configuration/Variation.pm
+++ b/modules/EnsEMBL/Web/Configuration/Variation.pm
@@ -53,7 +53,7 @@ sub populate_tree {
   
   my $context_menu = $self->create_node('Context', 'Genomic context',
     [qw( context EnsEMBL::Web::Component::Variation::Context )],
-    { 'availability' => 'variation has_locations', 'concise' => 'Context' }
+    { 'availability' => 'variation has_locations database:compara has_alignments', 'concise' => 'Context' }
   );
   
   $context_menu->append($self->create_node('Mappings', 'Genes and regulation',


### PR DESCRIPTION
## Description
Ovis aries texel sheep changed from being reference assembly to being stored as a breed. We have a variation database for the sheep breed Ovis aries texel. Since the species moved from being the reference we noticed a problem displaying the genomic context on the variant summary page.
This is caused because the compara database doesn't seem to store alignments for breeds. At least adding a check for existence of alignments disables the view and stops showing the error message.

## Views affected
[Variant summary page](http://ves-hx2-76.ebi.ac.uk:5040/Ovis_aries/Variation/Explore?db=core;r=5:22842506-23602012;v=rs606196144;vdb=variation;vf=52873957): genomic context icon and side menue entry need to be disabled for sheep texel.

## Possible complications
This has been tested for our other species to see that the genomic context is shown for them: e.g. [mouse](http://ves-hx2-76.ebi.ac.uk:5040/Mus_musculus/Variation/Explore?db=core;r=2:3226318-3227318;v=rs27096498;vdb=variation;vf=49096501), [vervet](http://ves-hx2-76.ebi.ac.uk:5040/Chlorocebus_sabaeus/Variation/Context?db=core;r=11:6824747-6825747;v=11:6825247:G_A:PRJEB22989;vdb=variation;vf=11:6825247:G_A:PRJEB22989)

## Merge conflicts
None

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6251

