### PR TITLE
Update publications list.

### DIFF
--- a/htdocs/info/about/publications.html
+++ b/htdocs/info/about/publications.html
@@ -262,7 +262,7 @@ main Ensembl site is being continuously updated (currently release
   <p>
     Daniel R Zerbino, Steven P Wilder, Nathan Johnson, Thomas Juettemann and Paul R Flicek<br />
     <strong>The Ensembl Regulatory Build</strong><br />
-    <em>Genome Biology</em> 16:56<br />
+    <em>Genome Biology</em> (2015) 16:56<br />
     <a href="http://dx.doi.org/doi:10.1186/s13059-015-0621-5" rel="external">doi:10.1186/s13059-015-0621-5</a>
   </p> 
 </li>
@@ -369,6 +369,7 @@ Amonida Zadissa and Stephen M. J. Searle<br />
 rel="external">doi:10.1093/nar/gkr991</a>
 </p>
 </li>
+
 <li id="Nucleic_Acids_Res_2011">
 <p>
 Paul Flicek, M. Ridwan Amode, Daniel Barrell, Kathryn Beal, 
@@ -392,21 +393,21 @@ rel="external">doi:10.1093/nar/gkq1064</a>
 </p>
 </li>
 
+<li id="Biomart_2011">
+  <p>
+  Kinsella RJ, K&auml;h&auml;ri A, Haider S, Zamora J, Proctor G, Spudich G,
+  Almeida-King J, Staines D, Derwent P, Kerhornou A, Kersey P, Flicek P.
+  <strong>Ensembl BioMarts: a hub for data retrieval across taxonomic space.</strong><br />
+  <em>Database (Oxford).</em> Vol. 2011 
+  <a rel="external" href="http://www.ncbi.nlm.nih.gov/pubmed/21785142">Published online</a> Jul 23, 2011
+  </p>
+</li>
+
 <li>
 <p>McLaren W, Pritchard B, Rios D, Chen Y, Flicek P, Cunningham F.<br>
 <strong>Deriving the consequences of genomic variants with the Ensembl API and SNP Effect Predictor.</strong><br>
 <em>BMC Bioinformatics</em>26(16):2069-70(2010)<br>
 <a href="http://dx.doi.org/10.1093/bioinformatics/btq330" rel="external">doi:10.1093/bioinformatics/btq330 </a>
-</p>
-</li>
-
-<li id="Biomart_2011">
-<p>
-Kinsella RJ, K&auml;h&auml;ri A, Haider S, Zamora J, Proctor G, Spudich G,
-Almeida-King J, Staines D, Derwent P, Kerhornou A, Kersey P, Flicek P.
-<strong>Ensembl BioMarts: a hub for data retrieval across taxonomic space.</strong><br />
-<em>Database (Oxford).</em> Vol. 2011 
-<a rel="external" href="http://www.ncbi.nlm.nih.gov/pubmed/21785142">Published online</a> Jul 23, 2011
 </p>
 </li>
 

--- a/htdocs/info/about/publications.html
+++ b/htdocs/info/about/publications.html
@@ -35,23 +35,6 @@ main Ensembl site is being continuously updated (currently release
 <h2>Publications</h2>
 
 <ul>
-      <li id="current_variation">
-        Sarah E Hunt, William McLaren, Laurent Gil, Anja Thormann, Helen Schuilenburg, Dan Sheppard, Andrew Parton,
-        Irina M Armean, Stephen J Trevanion, Paul Flicek, Fiona Cunningham<br />
-        <strong>Ensembl variation resources</strong><br />
-        <i>Database</i> Volume 2018<br />
-        <a href="https://doi.org/10.1093/database/bay119" rel="external">doi:10.1093/database/bay119</a>
-      </li>
-
-      <li id="current_haplosaurus">
-        William Spooner, William McLaren, Timothy Slidel, Donna K. Finch, Robin Butler, Jamie Campbell, Laura Eghobamien,
-        David Rider, Christine Mione Kiefer, Matthew J. Robinson, Colin Hardman, Fiona Cunningham, Tristan Vaughan,
-        Paul Flicek and Catherine Chaillan Huntington<br />
-        <strong>Haplosaurus computes protein haplotypes for use in precision drug design.</strong><br />
-        <i>Nature Communications</i> 9:4128(2018)<br />
-        <a href="https://doi.org/10.1038/s41467-018-06542-1" rel="external">doi:10.1038/s41467-018-06542-1</a>
-      </li>
-
       <li id="current_ensembl">
         <p id="Nucleic_Acids_Res_2021">
           Kevin L Howe, Premanand Achuthan, James Allen, Jamie Allen, Jorge Alvarez-Jarreta, 
@@ -119,7 +102,25 @@ main Ensembl site is being continuously updated (currently release
           <strong>Ensembl 2019.</strong><br />
           PubMed PMID: 30407521.</br >
           <a href="https://doi.org/10.1093/nar/gky1113">doi:10.1093/nar/gky1113</a>
-          </li>
+        </p>
+      </li>
+
+      <li id="current_variation">
+        Sarah E Hunt, William McLaren, Laurent Gil, Anja Thormann, Helen Schuilenburg, Dan Sheppard, Andrew Parton,
+        Irina M Armean, Stephen J Trevanion, Paul Flicek, Fiona Cunningham<br />
+        <strong>Ensembl variation resources</strong><br />
+        <i>Database</i> Volume 2018<br />
+        <a href="https://doi.org/10.1093/database/bay119" rel="external">doi:10.1093/database/bay119</a>
+      </li>
+
+      <li id="current_haplosaurus">
+        William Spooner, William McLaren, Timothy Slidel, Donna K. Finch, Robin Butler, Jamie Campbell, Laura Eghobamien,
+        David Rider, Christine Mione Kiefer, Matthew J. Robinson, Colin Hardman, Fiona Cunningham, Tristan Vaughan,
+        Paul Flicek and Catherine Chaillan Huntington<br />
+        <strong>Haplosaurus computes protein haplotypes for use in precision drug design.</strong><br />
+        <i>Nature Communications</i> 9:4128(2018)<br />
+        <a href="https://doi.org/10.1038/s41467-018-06542-1" rel="external">doi:10.1038/s41467-018-06542-1</a>
+      </li>
 
       <li>
         <p id="Nucleic_Acids_Res_2018">
@@ -137,10 +138,11 @@ main Ensembl site is being continuously updated (currently release
           Stephen J. Trevanion, Bronwen L. Aken, Fiona Cunningham, Andrew Yates,
           Paul Flicek<br />
           <strong>Ensembl 2018.</strong><br />
-          <!--<em>Nucleic Acids Res.</em> 2017 45 Database issue:.<br />-->
+          <em>Nucleic Acids Res.</em> 2018 46 Database issue:D754–D761.<br />
           PubMed PMID: 29155950.</br >
           <a href="https://doi.org/10.1093/nar/gkx1098">doi:10.1093/nar/gkx1098</a>
-          </li>
+        </p>
+      </li>
 
       <li>
         <p id="Nucleic_Acids_Res_2017">
@@ -159,7 +161,8 @@ main Ensembl site is being continuously updated (currently release
           <em>Nucleic Acids Res.</em> 2017 45 Database issue:D635-D642.<br />
           PubMed PMID: 27899575; PubMed CentralPMCID: PMC5210575.</br >
           <a href="http://dx.doi.org/10.1093/nar/gkw1104">doi:10.1093/nar/gkw1104</a>
-          </li>
+        </p>
+      </li>
 
    <li id="Core_2017">
         <p>Magali Ruffier, Andreas Kähäri, Monika Komorowska, Stephen Keenan, Matthew Laird, Ian Longden, Glenn Proctor, Steve Searle, Daniel Staines, Kieron Taylor, Alessandro Vullo, Andrew Yates, Daniel Zerbino, Paul Flicek</br/>
@@ -187,23 +190,24 @@ main Ensembl site is being continuously updated (currently release
 
 
   <li id="current_vep">
-  <p id="VEP">William McLaren, Laurent Gil, Sarah Hunt, Harpreet Riat, Graham Ritchie, 
+    <p id="VEP">William McLaren, Laurent Gil, Sarah Hunt, Harpreet Riat, Graham Ritchie, 
       Anja Thormann, Paul Flicek, Fiona Cunningham<br />
       <b>The Ensembl Variant Effect Predictor</b><br />
       <i>Genome Biology</i> 2016, 17:122,<br />
       <a href="http://www.genomebiology.com/2016/17/1/122">doi: 10.1186/s13059-016-0974-4</a>
-  </p>
+    </p>
   </li>
 
-      <li id="ncRNA_trees_2016">
-        <p>
-          Miguel Pignatelli, Albert J. Vilella, Matthieu Muffato, Leo Gordon,
-          Simon White, Paul Flicek, Javier Herrero<br />
-          <strong>ncRNA orthologies in the vertebrate lineage.</strong><br />
-          <em>Database (Oxford)</em> 2016 pii:bav127.<br />
-          PubMed PMID: 26896847; PubMed Central PMCID: PMC4761110<br />
-          <a href="http://dx.doi.org/10.1093/database/bav127">doi:10.1093/database/bav127</a>.
-      </li>
+  <li id="ncRNA_trees_2016">
+    <p>
+      Miguel Pignatelli, Albert J. Vilella, Matthieu Muffato, Leo Gordon,
+      Simon White, Paul Flicek, Javier Herrero<br />
+      <strong>ncRNA orthologies in the vertebrate lineage.</strong><br />
+      <em>Database (Oxford)</em> 2016 pii:bav127.<br />
+      PubMed PMID: 26896847; PubMed Central PMCID: PMC4761110<br />
+      <a href="http://dx.doi.org/10.1093/database/bav127">doi:10.1093/database/bav127</a>.
+    </p>
+  </li>
 
       <li id="Comparative_genomics_resources_2016">
         <p>
@@ -215,6 +219,7 @@ main Ensembl site is being continuously updated (currently release
           <em>Database (Oxford)</em> 2016 pii:bav096.<br />
           PubMed PMID: 26896847; PubMed Central PMCID: PMC4761110<br />
           <a href="http://dx.doi.org/10.1093/database/bav096">doi:10.1093/database/bav096</a>.
+        </p>
       </li>
 
       <li id="Regulation_resources_2016">
@@ -228,6 +233,7 @@ main Ensembl site is being continuously updated (currently release
           <em>Database (Oxford)</em> 2016 pii:bav119.<br />
               PubMed PMID: 26888907; PubMed Central PMCID: PMC4756621.<br />
               <a href="http://dx.doi.org/10.1093/database/bav119">doi:10.1093/database/bav119</a>.
+        </p>
       </li>
 
       <li id="Nucleic_Acids_Res_2016">
@@ -249,7 +255,8 @@ main Ensembl site is being continuously updated (currently release
           <em>Nucleic Acids Res.</em> 2016 44 Database issue:D710-6.<br />
           PubMed PMID: 26687719; PubMed CentralPMCID: PMC4702834.</br >
           <a href="http://dx.doi.org/10.1093/nar/gkv1157">doi:10.1093/nar/gkv1157</a>
-          </li>
+        </p>
+      </li>
 
 <li id="Regulatory_Build_2015">
   <p>
@@ -577,7 +584,8 @@ Giulietta Spudich, Xos&eacute; M. Fern&aacute;ndez-Su&aacute;rez and
 Ewan Birney<br />
 <strong>Genome Browsing with Ensembl: a practical
 overview</strong><br />
-<em>Brief Funct Genomic Proteomic</em>, 2007 Sept; 6: 202-219</p>
+<em>Brief Funct Genomic Proteomic</em>, 2007 Sept; 6: 202-219
+</p>
 </li>
 
 


### PR DESCRIPTION
## Description

This PR updates the publication list page:
- Publications are now in chronological order
- Update Ensembl 2017 citation
- Add missing </p> tags

## Views affected

- Current site: https://www.ensembl.org/info/about/publications.html
- Sandbox: http://wp-np2-1d.ebi.ac.uk:1610/info/about/publications.html

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6191
