### PR TITLE
update impact for regulatory_region_ablation to modifier

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/ConsequenceTable.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/ConsequenceTable.pm
@@ -263,7 +263,7 @@ sub render {
       'colour'  => 'a52a2a', 
       'desc'    => 'A feature ablation whereby the deleted region includes a regulatory region', 
       'acc'     => '0001894', 
-      'impact'  => 'MODERATE',
+      'impact'  => 'MODIFIER',
     },
     {
       'term'    => 'regulatory_region_amplification', 


### PR DESCRIPTION
## Requirements
- this should go live with the 105 release

## Description
- resolve conflicting import reporting for regulatory_region_ablation variants. VEP reports [modifier](https://github.com/Ensembl/ensembl-variation/blob/master/modules/Bio/EnsEMBL/Variation/Utils/Constants.pm#L971) and docs say [moderate](https://www.ensembl.org/info/genome/variation/prediction/predicted_data.html)

## Views affected
- https://www.ensembl.org/info/genome/variation/prediction/predicted_data.html

## Possible complications
- None

## Merge conflicts
- None

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-2977
