### PR TITLE
Add support for single-species compara dbs

### DIFF
--- a/modules/EnsEMBL/Web/DBHub.pm
+++ b/modules/EnsEMBL/Web/DBHub.pm
@@ -69,7 +69,7 @@ sub database {
   ## @param (String) Species (if not the default one)
   my $self = shift;
 
-  if ($_[0] && $_[0] =~ /compara/) {
+  if ($_[0] && $_[0] =~ /compara/ && !$self->species_defs->SINGLE_SPECIES_COMPARA) {
     return Bio::EnsEMBL::Registry->get_DBAdaptor('multi', $_[0], 1);
   } elsif ($_[0] && $_[0] =~ /go/) {
     return $self->databases->get_databases('go')->{'go'};

--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -752,16 +752,13 @@ sub get_homologies {
   $homology_source      = 'ENSEMBL_HOMOLOGUES' unless defined $homology_source;
   $homology_description = 'ortholog' unless defined $homology_description;
   
-  my $geneid   = $self->stable_id;
   my $database = $self->database($compara_db);
-  my %homologues;
-
   return unless $database;
 
-  my $query_member   = $database->get_GeneMemberAdaptor->fetch_by_stable_id($geneid);
-
+  my $query_member   = $database->get_GeneMemberAdaptor->fetch_by_stable_id($self->stable_id);
   return unless defined $query_member;
   
+  my %homologues;
   my $homology_adaptor = $database->get_HomologyAdaptor;
   my $homologies_array = $homology_adaptor->fetch_all_by_Member($query_member); # It is faster to get all the Homologues and discard undesired entries than to do fetch_all_by_Member_method_link_type
 

--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -680,38 +680,6 @@ sub get_alternative_locations {
   return \@alt_locs;
 }
 
-sub get_desc_mapping {
-### Returns descriptions for ortholog types.
-### TODO - get this info from compara API
-  my ($self, $match_type) = @_;
-  my %desc_mapping;
-
-  my %orth_mapping = (
-      ortholog_one2one          => '1 to 1 orthologue',
-      apparent_ortholog_one2one => '1 to 1 orthologue (apparent)',
-      ortholog_one2many         => '1 to many orthologue',
-      ortholog_many2many        => 'many to many orthologue',
-      possible_ortholog         => 'possible orthologue',
-  );
-  my %para_mapping = (
-      within_species_paralog    => 'paralogue (within species)',
-      other_paralog             => 'other paralogue (within species)',
-      putative_gene_split       => 'putative gene split',
-      contiguous_gene_split     => 'contiguous gene split',
-  );
-
-  if ($match_type eq 'Orthologue') {
-    %desc_mapping = %orth_mapping;
-  }
-  elsif ($match_type eq 'Paralogue') {
-    %desc_mapping = %para_mapping;
-  }
-  else {
-    %desc_mapping = (%orth_mapping, %para_mapping);
-  }
-  return %desc_mapping;
-}
-
 sub get_homology_matches {
   my ($self, $homology_source, $homology_description, $disallowed_homology, $compara_db) = @_;
   #warn ">>> MATCHING $homology_source, $homology_description BUT NOT $disallowed_homology";
@@ -732,9 +700,6 @@ sub get_homology_matches {
     my $adaptor_call = $self->param('gene_adaptor') || 'get_GeneAdaptor';
     my %homology_list;
 
-    # Convert descriptions into more readable form
-    my %desc_mapping = $self->get_desc_mapping;
-    
     foreach my $display_spp (keys %$homologues) {
       my $order = 0;
       

--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -758,7 +758,6 @@ sub get_homologies {
   my $query_member   = $database->get_GeneMemberAdaptor->fetch_by_stable_id($self->stable_id);
   return unless defined $query_member;
   
-  my %homologues;
   my $homology_adaptor = $database->get_HomologyAdaptor;
   my $homologies_array = $homology_adaptor->fetch_all_by_Member($query_member); # It is faster to get all the Homologues and discard undesired entries than to do fetch_all_by_Member_method_link_type
 

--- a/modules/EnsEMBL/Web/PureHub.pm
+++ b/modules/EnsEMBL/Web/PureHub.pm
@@ -62,7 +62,7 @@ sub database {
   my ($self,$species,$db) = @_;
 
   $db ||= 'core';
-  if($db =~ /compara/) {
+  if($db =~ /compara/ && !$self->sd->SINGLE_SPECIES_COMPARA) {
     $species = 'multi';
   }
   croak "No species specified getting '$db'" unless $species;

--- a/modules/EnsEMBL/Web/Query/Availability/Gene.pm
+++ b/modules/EnsEMBL/Web/Query/Availability/Gene.pm
@@ -53,8 +53,8 @@ sub _count_homologues {
   my $sth   = $dbc->prepare($sql);
   $sth->execute($gmID);
 
-  my @results = @{$sth->fetchall_arrayref||[]};
-  return $results[0]->[0] || 0; 
+  my $results = $sth->fetchall_arrayref;
+  return ($results && scalar @$results) ?  $results->[0][0] : 0; 
 }
 
 sub _count_go {

--- a/modules/EnsEMBL/Web/Query/Availability/Gene.pm
+++ b/modules/EnsEMBL/Web/Query/Availability/Gene.pm
@@ -44,6 +44,19 @@ sub fixup {
   $self->SUPER::fixup();
 }
 
+sub _count_homologues {
+  my ($self, $member, $args) = @_;
+
+  my $dbc   = $self->database_dbc($args->{'species'},'compara');
+  my $gmID  = $member->gene_member_id;
+  my $sql   = 'select count(*) from homology_member where gene_member_id = ?';
+  my $sth   = $dbc->prepare($sql);
+  $sth->execute($gmID);
+
+  my @results = @{$sth->fetchall_arrayref||[]};
+  return $results[0]->[0] || 0; 
+}
+
 sub _count_go {
   my ($self,$args,$out) = @_;
 
@@ -209,6 +222,9 @@ sub _counts {
     $out->{'paralogs'} = $member->number_of_paralogues;
     $out->{'strain_paralogs'} =  $self->sd_config($args,'RELATED_TAXON') ? $member->number_of_paralogues($self->sd_config($args,'RELATED_TAXON')) : 0;
     $out->{'families'} = $member->number_of_families;
+    if ($self->sd_config($args,'SINGLE_SPECIES_COMPARA')) {
+      $out->{'homologs'} = $self->_count_homologues($member, $args);
+    }
   }
   my $alignments = $self->_count_alignments($args);
   $out->{'alignments'} = $alignments->{'all'} if $args->{'type'} eq 'core';
@@ -270,7 +286,7 @@ sub get {
   $out->{'family_count'} = $counts->{'families'};
   $out->{'not_rnaseq'} = $args->{'type'} ne 'rnaseq';
   for (qw(
-    transcripts alignments paralogs strain_paralogs orthologs strain_orthologs similarity_matches
+    transcripts alignments paralogs strain_paralogs orthologs strain_orthologs homologs similarity_matches
     operons structural_variation pairwise_alignments
   )) {
     $out->{"has_$_"} = $counts->{$_};

--- a/modules/EnsEMBL/Web/Query/Generic/Availability.pm
+++ b/modules/EnsEMBL/Web/Query/Generic/Availability.pm
@@ -58,7 +58,8 @@ sub pancompara_db_adaptor {
 sub compara_member {
   my ($self,$args) = @_;
 
-  return $self->source('Adaptors')->compara_member($args->{'gene'}->stable_id);
+  ## Pass current species in case this site has single-species compara
+  return $self->source('Adaptors')->compara_member($args->{'gene'}->stable_id, $args->{'species'});
 }
 
 sub pancompara_member {

--- a/modules/EnsEMBL/Web/QueryStore/Source/Adaptors.pm
+++ b/modules/EnsEMBL/Web/QueryStore/Source/Adaptors.pm
@@ -37,9 +37,15 @@ sub _database {
   my ($self,$species,$db) = @_;
 
   $db ||= 'core';
-  if($db =~ /compara/) {
-    $species = 'multi';
+
+  ## Rapid site has both single-species and multi-species compara
+  if ($self->{_sd}->SINGLE_SPECIES_COMPARA) { 
+    $species = 'multi' if $db =~ /compara_pan/;
   }
+  else {
+    $species = 'multi' if $db =~ /compara/;
+  }
+
   my $dbc = EnsEMBL::Web::DBSQL::DBConnection->new($species,$self->{'_sd'});
   if($db eq 'go') {
     return $dbc->get_databases_species($species,'go')->{'go'};
@@ -128,9 +134,10 @@ sub epigenome_by_stableid {
 }
 
 sub compara_member {
-  my ($self,$id) = @_;
+  my ($self,$id, $species) = @_;
 
-  my $gma = $self->_get_adaptor('get_GeneMemberAdaptor','compara');
+  ## Pass species in case this site has single-species compara
+  my $gma = $self->_get_adaptor('get_GeneMemberAdaptor','compara', $species);
   return undef unless $gma;
   return $gma->fetch_by_stable_id($id);
 }

--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -488,9 +488,10 @@ sub _load_in_species_pages {
   return $spp_tree;
 }
 
-sub _load_in_taxonomy_division {
-  my ($self) = @_;
-  my $filename = $SiteDefs::ENSEMBL_TAXONOMY_DIVISION_FILE;
+sub _load_json_config {
+  my ($self, $filename) = @_;
+  return unless $filename;
+
   my $json_text = do {
     open(my $json_fh, "<", $filename)
       or die("Can't open $filename: $!\n");
@@ -631,6 +632,7 @@ sub _expand_database_templates {
   ## Autoconfigure databases
   unless (exists $tree->{'databases'} && exists $tree->{'databases'}{'DATABASE_CORE'}) {
     my @db_types = qw(CORE CDNA OTHERFEATURES RNASEQ FUNCGEN VARIATION);
+    push @db_types, 'COMPARA' if $SiteDefs::SINGLE_SPECIES_COMPARA;
     my $db_details = {
                       'HOST'    => $HOST,
                       'PORT'    => $PORT,
@@ -646,7 +648,8 @@ sub _expand_database_templates {
         my $non_vert_version = $SiteDefs::SITE_RELEASE_VERSION;
         $db_name = sprintf('%s_%s', $filename, lc($_));
         $db_name .= '_'.$non_vert_version if $non_vert_version;                                 
-        $db_name .= sprintf('_%s_%s', $SiteDefs::ENSEMBL_VERSION, $species_version);
+        $db_name .= $_ eq 'COMPARA' ? sprintf('_%s', $SiteDefs::ENSEMBL_VERSION)
+                                    : sprintf('_%s_%s', $SiteDefs::ENSEMBL_VERSION, $species_version);
       }
       ## Does this database exist?
       $db_details->{'NAME'} = $db_name;
@@ -804,7 +807,7 @@ sub _parse {
   $self->_info_line('Filesystem', 'Trawled web tree');
   # Load taxonomy division json for species selector
   $self->_info_log('Loading', 'Loading taxonomy division json file');
-  $tree->{'ENSEMBL_TAXONOMY_DIVISION'} = $self->_load_in_taxonomy_division;
+  $tree->{'ENSEMBL_TAXONOMY_DIVISION'} = $self->_load_json_config($SiteDefs::ENSEMBL_TAXONOMY_DIVISION_FILE);
   
   # Load species lists, if not present in SiteDefs
   unless (scalar @{$SiteDefs::PRODUCTION_NAMES||[]}) {
@@ -841,19 +844,24 @@ sub _parse {
   my $species_to_strains = {};
   my $species_to_assembly = {};
 
+  ## Get favourites from file (rapid release only atm)
+  my $favourites = $self->_read_species_list_file('FAVOURITES')||[]; 
+  ## Also override primary & secondary species
+  if (scalar @$favourites) {
+    $SiteDefs::ENSEMBL_PRIMARY_SPECIES = $favourites->[0];
+    $SiteDefs::ENSEMBL_SECONDARY_SPECIES = $favourites->[1];
+  }
+
   # Loop over each tree and make further manipulations
   foreach my $species (@$SiteDefs::PRODUCTION_NAMES, 'MULTI') {
     $config_packer->species($species);
     $config_packer->munge('config_tree');
     $self->_info_line('munging', "$species config");
 
-    ## Configure favourites if not in DEFAULTS.ini (rapid release)
+    ## Configure favourites if not in DEFAULTS.ini 
     unless ($config_packer->tree->{'DEFAULT_FAVOURITES'}) {
-      my $favourites = $self->_read_species_list_file('FAVOURITES'); 
-      warn "!!! NO FAVOURITES CONFIGURED" unless scalar @{$favourites||[]};
+      warn "!!! NO FAVOURITES CONFIGURED" unless scalar @$favourites};
       $config_packer->tree->{'DEFAULT_FAVOURITES'} = $favourites;
-      $config_packer->tree->{'ENSEMBL_PRIMARY_SPECIES'} = $favourites->[0];
-      $config_packer->tree->{'ENSEMBL_SECONDARY_SPECIES'} = $favourites->[1];
     }
 
     # Replace any placeholder text in sample data
@@ -1050,8 +1058,9 @@ sub _parse {
   $tree->{'MULTI'}{'ENSEMBL_DATASETS'} = $datasets;
   #warn ">>> NEW KEYS: ".Dumper($tree);
 
-  ## New species list - currently only used by rapid release
+  ## Species lists - currently only used by rapid release
   $tree->{'MULTI'}{'NEW_SPECIES'} = $self->_read_species_list_file('NEW_SPECIES');
+  $tree->{'MULTI'}{'REFERENCE_LOOKUP'} = $self->_load_json_config($SiteDefs::REFERENCE_LOOKUP_FILE);
 
   ## File format info
   my $format_info = $self->_get_file_format_info($tree);;
@@ -1228,7 +1237,18 @@ sub multi {
 
 sub compara_like_databases {
   my $self = shift;
-  return $self->multi_val('compara_like_databases');
+  if ($self->SINGLE_SPECIES_COMPARA) {
+    my $species = shift;
+    if ($species) {
+      return $self->get_config($species, 'compara_like_databases');
+    }
+    else {
+      return $self->multi_val('compara_like_databases');
+    }
+  }
+  else {
+    return $self->multi_val('compara_like_databases');
+  }
 }
 
 sub multi_val {


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

Add support for single-species compara databases (and also remove some obsolete compara code).

## Views affected

Should only affect the rapid release site, enabling the configuration of the new Homologues view which is found in the ensembl-rapid repository.

## Possible complications

Unlikely, as changes are triggered by the presence of the following configuration in ensembl-rapid:

`$SiteDefs::SINGLE_SPECIES_COMPARA = 1`

## Merge conflicts

Unlikely - the changes are mostly to low-level code.

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6136
