### PR TITLE
Disable refseq transcript link when biotype is tRNA & IG_*

### DIFF
--- a/modules/EnsEMBL/Web/ZMenu/Transcript/RefSeq.pm
+++ b/modules/EnsEMBL/Web/ZMenu/Transcript/RefSeq.pm
@@ -69,15 +69,8 @@ sub content {
   #remove standard links to transcript pages and replace with one to NCBI
   $self->delete_entry_by_type('Transcript');
   $self->delete_entry_by_value($transcript_link);
-  if ($biotype =~ m/tRNA/ or $biotype =~ m/IG_/){
-    $self->add_entry({
-    type     => 'RefSeq transcript',
-    label    => $transcript_xref,
-    abs_url  => 1,
-      position => 2,
-    });
-  }
-  else
+
+  unless ($biotype =~ m/tRNA/ or $biotype =~ m/IG_/)
   {
     $self->add_entry({
       type     => 'RefSeq transcript',

--- a/modules/EnsEMBL/Web/ZMenu/Transcript/RefSeq.pm
+++ b/modules/EnsEMBL/Web/ZMenu/Transcript/RefSeq.pm
@@ -69,27 +69,25 @@ sub content {
   #remove standard links to transcript pages and replace with one to NCBI
   $self->delete_entry_by_type('Transcript');
   $self->delete_entry_by_value($transcript_link);
-if ($biotype =~ m/tRNA/ or $biotype =~ m/IG_/){
+  if ($biotype =~ m/tRNA/ or $biotype =~ m/IG_/){
     $self->add_entry({
     type     => 'RefSeq transcript',
     label    => $transcript_xref,
     abs_url  => 1,
-    position => 2,
-  });
-}
-else
-{
-  $self->add_entry({
-    type     => 'RefSeq transcript',
-    label    => $transcript_xref,
-    link     => $hub->get_ExtURL_link($transcript_xref, 'REFSEQ_MRNA_PREDICTED', $transcript_xref),
-    abs_url  => 1,
-    position => 2,
-  });
-}
+      position => 2,
+    });
+  }
+  else
+  {
+    $self->add_entry({
+      type     => 'RefSeq transcript',
+      label    => $transcript_xref,
+      link     => $hub->get_ExtURL_link($transcript_xref, 'REFSEQ_MRNA_PREDICTED', $transcript_xref),
+      abs_url  => 1,
+      position => 2,
+    });
+  }
  
-use Data::Dumper; warn Dumper($biotype=~ m/tRNA/);
-use Data::Dumper; warn Dumper(rindex $biotype,"tRNA",0);
   if ($translation) {
     my $translation_id = $translation->stable_id;
     $self->delete_entry_by_type('Protein');

--- a/modules/EnsEMBL/Web/ZMenu/Transcript/RefSeq.pm
+++ b/modules/EnsEMBL/Web/ZMenu/Transcript/RefSeq.pm
@@ -69,7 +69,16 @@ sub content {
   #remove standard links to transcript pages and replace with one to NCBI
   $self->delete_entry_by_type('Transcript');
   $self->delete_entry_by_value($transcript_link);
-
+if ($biotype =~ m/tRNA/ or $biotype =~ m/IG_/){
+    $self->add_entry({
+    type     => 'RefSeq transcript',
+    label    => $transcript_xref,
+    abs_url  => 1,
+    position => 2,
+  });
+}
+else
+{
   $self->add_entry({
     type     => 'RefSeq transcript',
     label    => $transcript_xref,
@@ -77,7 +86,10 @@ sub content {
     abs_url  => 1,
     position => 2,
   });
-
+}
+ 
+use Data::Dumper; warn Dumper($biotype=~ m/tRNA/);
+use Data::Dumper; warn Dumper(rindex $biotype,"tRNA",0);
   if ($translation) {
     my $translation_id = $translation->stable_id;
     $self->delete_entry_by_type('Protein');


### PR DESCRIPTION

## Description

ZMenus for RefSeq GFF track in region in detail whe then track is configured to be expanded include a transcript xref to NCBI. This is broken for IG and tRNA genes due to a data bug. We need to remove this link for such transcripts.
when the biotype of the transcript begins "IG_" or equals "tRNA" then there should be no link in the zmenu.


## Views affected
http://ves-hx2-75.ebi.ac.uk:8790/Ovis_aries_rambouillet/Location/View?r=1:127570169-127570240;db=core
https://www.ensembl.org/Ovis_aries_rambouillet/Location/View?r=1:127570169-127570240;db=core

Enable RefSeq track in Configure this page. Update renderer to expanded. click on transcript and then note that when clicking on RefSeq transcript link you get to the wrong transcript
## Possible complications


## Merge conflicts

-

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6322
