### PR TITLE
Switch Transcript ID and name column

### DIFF
--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -238,8 +238,8 @@ sub transcript_table {
     }   
 
     my @columns = (
-       { key => 'name',       sort => 'string',  label => 'Name', title => 'Transcript name', class => '_ht'},
        { key => 'transcript', sort => 'html',    label => 'Transcript ID', title => 'Stable ID', class => '_ht'},
+       { key => 'name',       sort => 'string',  label => 'Name', title => 'Transcript name', class => '_ht'},
        { key => 'bp_length',  sort => 'numeric', label => 'bp', title => 'Transcript length in base pairs', class => '_ht'},
        { key => 'protein',sort => 'html_numeric',label => 'Protein', title => 'Protein length in amino acids', class => '_ht'},
        { key => 'translation',sort => 'html',    label => 'Translation ID', title => 'Protein information', 'hidden' => 1, class => '_ht'},
@@ -366,7 +366,7 @@ sub transcript_table {
 
       $extras{$_} ||= '-' for(keys %extra_links);
       my $row = {
-        name        => { value => $_->display_xref ? $_->display_xref->display_id : '-', class => 'bold' },
+        name        => { value => $_->display_xref ? $_->display_xref->display_id : '-' },
         transcript  => sprintf('<a href="%s">%s%s</a>', $url, $tsi, $version),
         bp_length   => $transcript_length,
         protein     => $protein_url ? sprintf '<a href="%s" title="View protein">%saa</a>', $protein_url, $protein_length : 'No protein',

--- a/modules/EnsEMBL/Web/Object/Transcript.pm
+++ b/modules/EnsEMBL/Web/Object/Transcript.pm
@@ -353,18 +353,18 @@ sub short_caption {
 
 sub caption {
   my $self = shift;
-  my $heading = $self->type_name.': ';
   my $subhead;
+  my $heading = $self->type_name.': ';
 
   my( $disp_id ) = $self->display_xref;
   my $version    = $self->version ? ".".$self->version : "";
 
   if( $disp_id && $disp_id ne $self->stable_id ) {
-    $heading .= $disp_id;
-    $subhead = $self->stable_id.$version;
+    $subhead = $disp_id;
+    $heading .= $self->stable_id.$version;
   }
   else {
-    $heading .= $self->stable_id.$version;
+    $heading = $self->stable_id.$version;
   }
 
   return [$heading, $subhead];

--- a/modules/EnsEMBL/Web/Object/Transcript.pm
+++ b/modules/EnsEMBL/Web/Object/Transcript.pm
@@ -353,18 +353,15 @@ sub short_caption {
 
 sub caption {
   my $self = shift;
+  
+  my $version = $self->version ? ".".$self->version : "";
+  my $heading = $self->type_name.': '.$self->stable_id.$version;
   my $subhead;
-  my $heading = $self->type_name.': ';
 
   my( $disp_id ) = $self->display_xref;
-  my $version    = $self->version ? ".".$self->version : "";
-
+  
   if( $disp_id && $disp_id ne $self->stable_id ) {
-    $subhead = $disp_id;
-    $heading .= $self->stable_id.$version;
-  }
-  else {
-    $heading = $self->stable_id.$version;
+    $subhead = $disp_id; 
   }
 
   return [$heading, $subhead];


### PR DESCRIPTION
## Description

- Switched transcript ID and name columns
- Removed bolding of names

## Views affected
- http://ves-hx2-75.ebi.ac.uk:42229/Homo_sapiens/Gene/Summary?g=ENSG00000139618;r=13:32315086-32400268
- http://ves-hx2-75.ebi.ac.uk:42229/Homo_sapiens/Transcript/Summary?db=core;g=ENSG00000139618;r=13:32315086-32400268;t=ENST00000544455

## Related JIRA Issues

- https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6331
- https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6332