### PR TITLE
Restore zmenu exon rank in gene summary.

### DIFF
--- a/htdocs/components/15_ImageMap.js
+++ b/htdocs/components/15_ImageMap.js
@@ -193,6 +193,7 @@ Ensembl.Panel.ImageMap = Ensembl.Panel.Content.extend({
   initImagePanning: function () {
     var panel = this;
     if (this.elLk.boundaries.length && this.draggables.length) {
+      if(this.draggables[0].a.klass.noscroll) return;
       this.elLk.dragSwitch = this.elLk.toolbars.first().append([
         '<div class="scroll-switch">',
           '<span>Drag/Select:</span>',

--- a/modules/EnsEMBL/Draw/GlyphSet/draggable.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/draggable.pm
@@ -57,13 +57,15 @@ sub _init {
     $container->seq_region_name, $start, $end, $container->strand
   );
   
+  my $noscroll = $self->{'my_config'}->{'data'}->{'noscroll'}? ' noscroll' : '';
+  
   my @common = (
     'y'     => $A,
     'style' => 'fill',
     'z'     => -10,
     'href'  => $href,
     'alt' => 'Click and drag to select a region',
-    'class' => 'drag' . ($self->get_parameter('multi') ? ' multi' : $self->get_parameter('compara') ? ' align' : '')
+    'class' => 'drag' . $noscroll . ($self->get_parameter('multi') ? ' multi' : $self->get_parameter('compara') ? ' align' : '')
   );
   
   $self->join_tag($glyph, 'draggable', { 'x' => $A, @common });

--- a/modules/EnsEMBL/Web/ImageConfig/gene_summary.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/gene_summary.pm
@@ -55,6 +55,7 @@ sub init_cacheable {
   $self->add_tracks('other',
     [ 'scalebar',  '', 'scalebar',  { display => 'normal', strand => 'b', name => 'Scale bar', description => 'Shows the scalebar' }],
     [ 'ruler',     '', 'ruler',     { display => 'normal', strand => 'b', name => 'Ruler',     description => 'Shows the length of the region being displayed' }],
+    [ 'draggable', '', 'draggable', { display => 'normal', strand => 'b', menu => 'no', noscroll => 'true' }], #draggable selections without panning
   );
 
   $self->add_tracks('information',


### PR DESCRIPTION
## Description

This PR restores exon rank information line in the zmenu when a gene is clicked in the Gene Summary view.
The zmenu exon info depends on the `draggable` pseudo-track that was removed in a [previous PR](https://github.com/Ensembl/ensembl-webcode/pull/825) because the scroll (image panning) functionality does not work in Gene Summary view.
This PR restores the `draggable` track (with region selection and exon rank info)  but adds a flag (`noscroll`) that disables image scrolling (and the drag/scroll toolbar switch with it).

## Views affected

Gene Summary view: [sandbox link](http://wp-np2-1d.ebi.ac.uk:1610/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000139618;r=13:32315086-32400268).  

## Possible complications

Some other views use the draggable track (e.g.  Location view: [sandbox link](http://wp-np2-1d.ebi.ac.uk:1610/Homo_sapiens/Location/View?db=core;g=ENSG00000139618;r=13:32287461-32376049)), but only Gene Summary currently makes use of the `noscroll` flag.

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6273
