### PR TITLE
Feature/sd refactor

### DIFF
--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -540,6 +540,8 @@ sub _read_species_list_file {
 
 sub _get_cow_defaults {
 ## Copy-on-write hash (only used by NV)
+## Note: use method instead of an 'our' variable, as the latter can be a pain
+## when shared across plugins
   return {};
 }
 
@@ -1572,11 +1574,17 @@ sub production_name_mapping {
 ### As the name said, the function maps the production name with the species URL, 
 ### @param production_name - species production name
 ### Return string = the corresponding species.url name which is the name web uses for URL and other code
+### Fall back to production name if not found - mostly for pan-compara
   my ($self, $production_name) = @_;
+  my $mapping_name = $production_name;
   
   foreach ($self->valid_species) {
-    return $self->get_config($_, 'SPECIES_URL') if($self->get_config($_, 'SPECIES_PRODUCTION_NAME') eq lc($production_name));
+    if ($self->get_config($_, 'SPECIES_PRODUCTION_NAME') eq lc($production_name)) {
+    $mapping_name = $self->get_config($_, 'SPECIES_URL');
+    last;
   }
+
+  return $mapping_name;
 }
 
 sub assembly_lookup {

--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -552,7 +552,7 @@ sub _read_in_ini_file {
   
   ## Avoid deep-copying in NV divisions, to reduce size of packed files
   ## See https://github.com/EnsemblGenomes/eg-web-common/commit/f702ab75235e66d7e9a979864b858fe0f88485f7
-  my $cow_from_defaults = $self->get_cow_defaults;
+  my $cow_from_defaults = $self->_get_cow_defaults;
   
   foreach my $confdir (@SiteDefs::ENSEMBL_CONF_DIRS) {
     if (-e "$confdir/ini-files/$filename.ini") {

--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -943,10 +943,12 @@ sub _parse {
   ## Merge collection info into the species hash
   foreach my $prodname (@$SiteDefs::PRODUCTION_NAMES) {
     next unless $tree->{$prodname};
-    my @db_species = @{$tree->{$prodname}->{DB_SPECIES}};
-    my $species_lookup = { map {$_ => 1} @db_species };
-    foreach my $sp (@db_species) {
-      $self->_merge_species_tree( $tree->{$sp}, $tree->{$prodname}, $species_lookup);
+    my @db_species = @{$tree->{$prodname}->{DB_SPECIES}||[]};
+    if (scalar @db_species) {
+      my $species_lookup = { map {$_ => 1} @db_species };
+      foreach my $sp (@db_species) {
+        $self->_merge_species_tree( $tree->{$sp}, $tree->{$prodname}, $species_lookup);
+      }
     }
   }
 

--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -1579,7 +1579,7 @@ sub production_name_mapping {
   my $mapping_name = $production_name;
   
   foreach ($self->valid_species) {
-    if ($self->get_config($_, 'SPECIES_PRODUCTION_NAME') eq lc($production_name)) {
+    if ($self->get_config($_, 'SPECIES_PRODUCTION_NAME') eq $production_name) {
       $mapping_name = $self->get_config($_, 'SPECIES_URL');
       last;
     }

--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -538,7 +538,7 @@ sub _read_species_list_file {
   return $spp_list;
 }
 
-sub _get_cow_defaults {
+sub _get_deepcopy_defaults {
 ## Copy-on-write hash (only used by NV)
 ## Note: use method instead of an 'our' variable, as the latter can be a pain
 ## when shared across plugins
@@ -552,7 +552,7 @@ sub _read_in_ini_file {
   
   ## Avoid deep-copying in NV divisions, to reduce size of packed files
   ## See https://github.com/EnsemblGenomes/eg-web-common/commit/f702ab75235e66d7e9a979864b858fe0f88485f7
-  my $cow_from_defaults = $self->_get_cow_defaults;
+  my $deepcopy_defaults = $self->_get_deepcopy_defaults;
   
   foreach my $confdir (@SiteDefs::ENSEMBL_CONF_DIRS) {
     if (-e "$confdir/ini-files/$filename.ini") {
@@ -580,7 +580,7 @@ sub _read_in_ini_file {
         if (/^\[\s*(\w+)\s*\]/) { # New section - i.e. [ ... ]
           $current_section = $1;
 
-          if ( defined $defaults->{$current_section} && exists $cow_from_defaults->{$current_section} ) {
+          if ( defined $defaults->{$current_section} && exists $deepcopy_defaults->{$current_section} ) {
             $tree->{$current_section} = $defaults->{$current_section};
             $defaults_used = 1;
           }

--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -1580,8 +1580,9 @@ sub production_name_mapping {
   
   foreach ($self->valid_species) {
     if ($self->get_config($_, 'SPECIES_PRODUCTION_NAME') eq lc($production_name)) {
-    $mapping_name = $self->get_config($_, 'SPECIES_URL');
-    last;
+      $mapping_name = $self->get_config($_, 'SPECIES_URL');
+      last;
+    }
   }
 
   return $mapping_name;


### PR DESCRIPTION
## Requirements

## Description

Final improvements to SpeciesDefs, removing as much duplicate code as possible.

1. Building of ENSEMBL_TAXONOMY_DIVISION factored out into a separate method, as not used by NV (overridden with empty method in eg-web-common)
2. Moved NV-specific deep-copying code into ensembl-webcode so that I can get rid of the giant _parse method in eg-web-common

See also the corresponding PR in eg-web-common.

## Views affected

1. Vertebrate species selector - should remain unchanged after this update. Click on the Select an alignment button on this page:

http://wp-np2-1f.ebi.ac.uk:10105/Mus_musculus/Location/Compara_Alignments/Image?r=4:136366473-136547301

and check that you can select the individual mouse strains in the multiple alignment.

2. Not a view, but NV packed files should be more-or-less the same size after these changes are applied, since the "copy-on-write" code is designed to prevent unnecassary file bloat. This has been checked by comparing freshly-generated files against the equivalent release on /nfs/public/nobackup/ensweb - the file sizes were either identical or within a few bytes, and any differences are likely to be down to using post-104 code with 104 databases.

## Possible complications

Shouldn't have any impact beyond the situations described above.

## Merge conflicts

I don't think anyone else is working on this low-level code.

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6168
