### PR TITLE
Fetch multiple alt allele groups for display in Gene Alleles web table

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/Alleles.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/Alleles.pm
@@ -36,7 +36,7 @@ sub content {
   my $self = shift;
   my $hub  = $self->hub;
   my $this_species = $hub->species;
-  my $alleles = $self->object->get_all_alt_alleles;
+  my $alleles = $self->object->get_alt_alleles;
 
   my $html;
   if (@$alleles) {

--- a/modules/EnsEMBL/Web/Component/Gene/Alleles.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/Alleles.pm
@@ -36,7 +36,7 @@ sub content {
   my $self = shift;
   my $hub  = $self->hub;
   my $this_species = $hub->species;
-  my $alleles = $self->object->get_alt_alleles;
+  my $alleles = $self->object->get_all_alt_alleles;
 
   my $html;
   if (@$alleles) {

--- a/modules/EnsEMBL/Web/Object.pm
+++ b/modules/EnsEMBL/Web/Object.pm
@@ -259,19 +259,14 @@ sub get_all_alt_alleles {
   return [] unless $gene; # eg GENSCAN is type Transcript, ->gene is undef
   my $stable_id = $gene->stable_id;
   my $alleles = [];
-  if ($gene->slice->is_reference) {
-    $alleles = $gene->get_all_alt_alleles;
-  }
-  else {
-    my $adaptor = $self->hub->get_adaptor('get_AltAlleleGroupAdaptor');
-    # fetch one or more alt allele groups by gene id
-    my $groups = $adaptor->fetch_all_by_gene_id($gene->dbID);
-    if ($groups) {
-      foreach my $group (@$groups) {
-        foreach my $alt_allele_gene (@{$group->get_all_Genes}) {
-          if ($alt_allele_gene->stable_id ne $stable_id) {
-            push @$alleles, $alt_allele_gene;
-          }
+  my $adaptor = $self->hub->get_adaptor('get_AltAlleleGroupAdaptor');
+  # fetch one or more alt allele groups by gene id
+  my $groups = $adaptor->fetch_all_by_gene_id($gene->dbID);
+  if ($groups) {
+    foreach my $group (@$groups) {
+      foreach my $alt_allele_gene (@{$group->get_all_Genes}) {
+        if ($alt_allele_gene->stable_id ne $stable_id) {
+          push @$alleles, $alt_allele_gene;
         }
       }
     }

--- a/modules/EnsEMBL/Web/Object.pm
+++ b/modules/EnsEMBL/Web/Object.pm
@@ -244,41 +244,6 @@ sub get_alt_alleles {
   return $alleles;
 }
 
-=head2 get_all_alt_alleles
-
- Example     : my $alleles = $gene->object->get_all_alt_alleles;
- Description : retrieves details of alt_alleles from one
-               or more alt allele groups
- Return type : list (arrayref of B::E::Genes)
-
-=cut
-
-sub get_all_alt_alleles {
-  my $self = shift;
-  my $gene = $self->type eq 'Gene' ? $self->Obj : $self->gene;
-  return [] unless $gene; # eg GENSCAN is type Transcript, ->gene is undef
-  my $stable_id = $gene->stable_id;
-  my $alleles = [];
-  if ($gene->slice->is_reference) {
-    $alleles = $gene->get_all_alt_alleles;
-  }
-  else {
-    my $adaptor = $self->hub->get_adaptor('get_AltAlleleGroupAdaptor');
-    # fetch one or more alt allele groups by gene id
-    my $groups = $adaptor->fetch_all_by_gene_id($gene->dbID);
-    if ($groups) {
-      foreach my $group (@$groups) {
-        foreach my $alt_allele_gene (@{$group->get_all_Genes}) {
-          if ($alt_allele_gene->stable_id ne $stable_id) {
-            push @$alleles, $alt_allele_gene;
-          }
-        }
-      }
-    }
-  }
-  return $alleles;
-}
-
 sub get_alt_allele_link {
   my ($self, $type) = @_;
   my $hub   = $self->hub;

--- a/modules/EnsEMBL/Web/Object.pm
+++ b/modules/EnsEMBL/Web/Object.pm
@@ -244,6 +244,41 @@ sub get_alt_alleles {
   return $alleles;
 }
 
+=head2 get_all_alt_alleles
+
+ Example     : my $alleles = $gene->object->get_all_alt_alleles;
+ Description : retrieves details of alt_alleles from one
+               or more alt allele groups
+ Return type : list (arrayref of B::E::Genes)
+
+=cut
+
+sub get_all_alt_alleles {
+  my $self = shift;
+  my $gene = $self->type eq 'Gene' ? $self->Obj : $self->gene;
+  return [] unless $gene; # eg GENSCAN is type Transcript, ->gene is undef
+  my $stable_id = $gene->stable_id;
+  my $alleles = [];
+  if ($gene->slice->is_reference) {
+    $alleles = $gene->get_all_alt_alleles;
+  }
+  else {
+    my $adaptor = $self->hub->get_adaptor('get_AltAlleleGroupAdaptor');
+    # fetch one or more alt allele groups by gene id
+    my $groups = $adaptor->fetch_all_by_gene_id($gene->dbID);
+    if ($groups) {
+      foreach my $group (@$groups) {
+        foreach my $alt_allele_gene (@{$group->get_all_Genes}) {
+          if ($alt_allele_gene->stable_id ne $stable_id) {
+            push @$alleles, $alt_allele_gene;
+          }
+        }
+      }
+    }
+  }
+  return $alleles;
+}
+
 sub get_alt_allele_link {
   my ($self, $type) = @_;
   my $hub   = $self->hub;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

This PR contains changes to update the Gene Alleles table so that all gene alleles are now displayed, i.e. if the gene in question is associated with multiple alt allele groups, all of the gene alleles will be shown. Has been tested on Release 108 and currently testing on Release 110.

## Views affected

The view of the Gene Alleles table will be updated.

Example from an X PAR gene web page: http://wp-np2-11.ebi.ac.uk:7065/Homo_sapiens/Gene/Alleles?db=core;g=ENSG00000167393;r=X:1-964539.

Example from a Y PAR gene web page: http://wp-np2-11.ebi.ac.uk:7065/Homo_sapiens/Gene/Alleles?db=core;g=ENSG00000292329;r=Y:253743-255091;t=ENST00000711121.

## Possible complications

Now that the modified human core database is now ready for Release 110, there should not be any complications.

## Merge conflicts

This PR has been rebased again the main branch as of 20th February 2023, so I don't believe there are any merge conflicts.

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-3811
