### PR TITLE
Support addition of alphafold molecule viewer

### DIFF
--- a/modules/EnsEMBL/Web/Apache/Static.pm
+++ b/modules/EnsEMBL/Web/Apache/Static.pm
@@ -80,9 +80,8 @@ sub handler {
     $r->headers_out->set('X-MEMCACHED'    => 'yes');
     $r->headers_out->set('Accept-Ranges'  => 'bytes');
     $r->headers_out->set('Content-Length' => length $content);
-    $r->headers_out->set('Cache-Control'  => 'max-age=' . 60*60*24*30);
-    $r->headers_out->set('Expires'        => HTTP::Date::time2str(time + 60*60*24*30));
     $r->content_type(mime_type($uri));
+    add_caching_headers($r);
     $r->print($content);
     static_cache_hook($uri,$content);
     return OK;
@@ -129,8 +128,7 @@ sub handler {
 
     if (-e $file) {
       ## Send 2MB+ files without caching them
-      $r->headers_out->set('Cache-Control'  => 'max-age=' . 60*60*24*30);
-      $r->headers_out->set('Expires'        => HTTP::Date::time2str(time + 60*60*24*30));
+      add_caching_headers($r);
       $r->content_type(mime_type($uri));
       return $r->sendfile($file) if -s $file > 2*1024*1024;
 
@@ -182,5 +180,11 @@ sub htdoc_dir {
   return $file;
 }
 
+sub add_caching_headers {
+  my $r = shift;
+  my $thirty_days = 60 * 60 * 24 * 30;
+  $r->headers_out->set('Cache-Control'  => 'max-age=' . $thirty_days);
+  $r->headers_out->set('Expires'        => HTTP::Date::time2str(time + $thirty_days));
+}
 
 1;

--- a/modules/EnsEMBL/Web/Apache/Static.pm
+++ b/modules/EnsEMBL/Web/Apache/Static.pm
@@ -180,12 +180,20 @@ sub htdoc_dir {
   return $file;
 }
 
-#overwritten in public plugins
 sub add_caching_headers {
   my $r = shift;
-  my $thirty_days = 60 * 60 * 24 * 30;
-  $r->headers_out->set('Cache-Control'  => 'max-age=' . $thirty_days);
-  $r->headers_out->set('Expires'        => HTTP::Date::time2str(time + $thirty_days));
+  if (should_skip_caching($r)) {
+    $r->headers_out->set('Cache-Control'  => 'no-store, max-age=0');
+  } else {
+    my $thirty_days = 60 * 60 * 24 * 30;
+    $r->headers_out->set('Cache-Control'  => 'max-age=' . $thirty_days);
+    $r->headers_out->set('Expires'        => HTTP::Date::time2str(time + $thirty_days));
+  }
+}
+
+#overwritten in public plugins
+sub should_skip_caching {
+  return 0;
 }
 
 1;

--- a/modules/EnsEMBL/Web/Apache/Static.pm
+++ b/modules/EnsEMBL/Web/Apache/Static.pm
@@ -180,6 +180,7 @@ sub htdoc_dir {
   return $file;
 }
 
+#overwritten in public plugins
 sub add_caching_headers {
   my $r = shift;
   my $thirty_days = 60 * 60 * 24 * 30;

--- a/modules/EnsEMBL/Web/Configuration/Transcript.pm
+++ b/modules/EnsEMBL/Web/Configuration/Transcript.pm
@@ -92,9 +92,14 @@ sub populate_tree {
     { 'availability' => 'either database:variation has_variations translation', 'concise' => 'Variants' }
   ));
 
-  $prot_menu->append($self->create_node('PDB', '3D Protein model',
+  $prot_menu->append($self->create_node('PDB', 'PDB 3D Protein model',
     [qw( alignment EnsEMBL::Web::Component::Transcript::PDB )],
     { 'availability' => 'transcript translation has_pdbe','concise' => '3D Protein model (PDBe)' }
+  ));
+
+  $prot_menu->append($self->create_node('AFDB', 'AFDB 3D Protein model',
+    [qw( alignment EnsEMBL::Web::Component::Transcript::AFDB )],
+    { 'availability' => 'transcript translation has_afdb','concise' => '3D Protein model (AFDB)' }
   ));
  
   my $var_menu = $self->create_submenu('Variation', 'Genetic Variation');

--- a/modules/EnsEMBL/Web/Configuration/Transcript.pm
+++ b/modules/EnsEMBL/Web/Configuration/Transcript.pm
@@ -92,12 +92,12 @@ sub populate_tree {
     { 'availability' => 'either database:variation has_variations translation', 'concise' => 'Variants' }
   ));
 
-  $prot_menu->append($self->create_node('PDB', 'PDB 3D Protein model',
+  $prot_menu->append($self->create_node('PDB', 'PDB 3D protein model',
     [qw( alignment EnsEMBL::Web::Component::Transcript::PDB )],
     { 'availability' => 'transcript translation has_pdbe','concise' => '3D Protein model (PDBe)' }
   ));
 
-  $prot_menu->append($self->create_node('AFDB', 'AFDB 3D Protein model',
+  $prot_menu->append($self->create_node('AFDB', 'AlphaFold predicted model',
     [qw( alignment EnsEMBL::Web::Component::Transcript::AFDB )],
     { 'availability' => 'transcript translation has_afdb','concise' => '3D Protein model (AFDB)' }
   ));

--- a/modules/EnsEMBL/Web/Configuration/Transcript.pm
+++ b/modules/EnsEMBL/Web/Configuration/Transcript.pm
@@ -94,12 +94,12 @@ sub populate_tree {
 
   $prot_menu->append($self->create_node('PDB', 'PDB 3D protein model',
     [qw( alignment EnsEMBL::Web::Component::Transcript::PDB )],
-    { 'availability' => 'transcript translation has_pdbe','concise' => '3D Protein model (PDBe)' }
+    { 'availability' => 'transcript translation has_pdbe','concise' => 'PDB 3D protein model' }
   ));
 
   $prot_menu->append($self->create_node('AFDB', 'AlphaFold predicted model',
     [qw( alignment EnsEMBL::Web::Component::Transcript::AFDB )],
-    { 'availability' => 'transcript translation has_afdb','concise' => '3D Protein model (AFDB)' }
+    { 'availability' => 'transcript translation has_afdb','concise' => 'AlphaFold predicted model' }
   ));
  
   my $var_menu = $self->create_submenu('Variation', 'Genetic Variation');

--- a/modules/EnsEMBL/Web/Object/Transcript.pm
+++ b/modules/EnsEMBL/Web/Object/Transcript.pm
@@ -71,6 +71,7 @@ sub availability {
       $availability->{"has_$_"}          = $counts->{$_} for qw(exons evidence similarity_matches oligos);
       $availability->{ref_slice}       //= $self->Obj->slice->is_reference();
       $availability->{'has_pdbe'}        = $self->has_pdbe_analysis();
+      $availability->{'has_afdb'}        = $self->has_afdb_analysis();
     }
   
     $self->{'_availability'} = $availability;
@@ -276,6 +277,11 @@ sub count_oligos {
 sub has_pdbe_analysis {
   my $self = shift;
   return ($self->table_info($self->get_db, 'protein_feature')->{'analyses'}{'sifts_import'}) ? 1 : 0;
+}
+
+sub has_afdb_analysis {
+  my $self = shift;
+  return ($self->table_info($self->get_db, 'protein_feature')->{'analyses'}{'alphafold_import'}) ? 1 : 0;
 }
 
 sub default_track_by_gene {


### PR DESCRIPTION
# Description
This is a pull request intended to support https://github.com/Ensembl/public-plugins/pull/476

- a method is added to detect when a feature has an associated alphafold-predicted 3d structure (checks for the presence of alphafold analysis record in the database)
- the left-hand menu (configuration) has been updated to include a link to the Alphafold view
- the module for the caching of static files has been updated to allow for configurability (javascript files used for the alphafold view are not cached)

## Sandbox
http://ves-hx2-75.ebi.ac.uk:8450/Arabidopsis_thaliana/Transcript/AFDB?db=core;g=AT3G52430;r=3:19431095-19434450;t=AT3G52430.1


The pull request is submitted against the `master` branch.