### PR TITLE
Use transcript ID in sequence download file name

### DIFF
--- a/modules/EnsEMBL/Web/Component/DataExport/Protein.pm
+++ b/modules/EnsEMBL/Web/Component/DataExport/Protein.pm
@@ -73,10 +73,10 @@ sub content {
 sub default_file_name {
   my $self = shift;
   my $name = $self->hub->species;
-  my $data_object = $self->hub->param('g') ? $self->hub->core_object('gene') : undef;
+  my $data_object = $self->hub->param('t') ? $self->hub->core_object('transcript') : undef;
   if ($data_object) {
     $name .= '_';
-    my $versioned_stable_id = $data_object->stable_id_version;
+    my $versioned_stable_id = $data_object->translation_object()->stable_id_version || $data_object->translation_object()->stable_id;
     # Replace '.' with '_' to avoid file extention clashes 
     $versioned_stable_id =~ s/\./_/g; 
     $name .= $versioned_stable_id;

--- a/modules/EnsEMBL/Web/Component/DataExport/Protein.pm
+++ b/modules/EnsEMBL/Web/Component/DataExport/Protein.pm
@@ -76,9 +76,10 @@ sub default_file_name {
   my $data_object = $self->hub->param('g') ? $self->hub->core_object('gene') : undef;
   if ($data_object) {
     $name .= '_';
-    my $stable_id = $data_object->stable_id;
-    my ($disp_id) = $data_object->display_xref;
-    $name .= $disp_id || $stable_id;
+    my $versioned_stable_id = $data_object->stable_id_version;
+    # Replace '.' with '_' to avoid file extention clashes 
+    $versioned_stable_id =~ s/\./_/g; 
+    $name .= $versioned_stable_id;
   }
   $name .= '_sequence';
   return $name;

--- a/modules/EnsEMBL/Web/Component/DataExport/Transcript.pm
+++ b/modules/EnsEMBL/Web/Component/DataExport/Transcript.pm
@@ -106,9 +106,10 @@ sub default_file_name {
   my $data_object = $self->hub->param('t') ? $self->hub->core_object('transcript') : undef;
   if ($data_object) {
     $name .= '_';
-    my $stable_id = $data_object->stable_id;
-    my ($disp_id) = $data_object->display_xref;
-    $name .= $disp_id || $stable_id;
+    my $versioned_stable_id = $data_object->stable_id_version;
+    # Replace '.' with '_' to avoid file extention clashes 
+    $versioned_stable_id =~ s/\./_/g; 
+    $name .= $versioned_stable_id;
   }
   $name .= '_sequence';
   return $name;

--- a/modules/EnsEMBL/Web/Component/DataExport/Transcript.pm
+++ b/modules/EnsEMBL/Web/Component/DataExport/Transcript.pm
@@ -106,7 +106,7 @@ sub default_file_name {
   my $data_object = $self->hub->param('t') ? $self->hub->core_object('transcript') : undef;
   if ($data_object) {
     $name .= '_';
-    my $versioned_stable_id = $data_object->stable_id_version;
+    my $versioned_stable_id = $data_object->stable_id_version || $data_object->stable_id;
     # Replace '.' with '_' to avoid file extention clashes 
     $versioned_stable_id =~ s/\./_/g; 
     $name .= $versioned_stable_id;

--- a/modules/EnsEMBL/Web/Object/Translation.pm
+++ b/modules/EnsEMBL/Web/Object/Translation.pm
@@ -195,6 +195,21 @@ sub stable_id {
   return $self->translation ? $self->translation->stable_id : undef;
 }
 
+=head2 stable_id_version
+
+ Arg[1]         : none
+ Example     : $stable_id_version = $pepdata->stable_id_version
+ Description : Wrapper for stable_id_version on core_API
+ Return type : string
+                The features stable_id_version
+
+=cut
+
+sub stable_id_version {
+  my $self = shift;
+  return $self->translation ? $self->translation->stable_id_version : undef;
+}
+
 =head2 display_xref
 
  Arg[1]         : none


### PR DESCRIPTION
## Description
Updated the filename used in sequence download to use transcript ID instead of the symbol.

## Views affected

http://ves-hx2-75.ebi.ac.uk:42229/Homo_sapiens/Transcript/Exons?db=core;g=ENSG00000128573;r=12:50992084-50993185;t=ENST00000403559


## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6333
