### PR TITLE
Remove This probe does not map to any transcripts message

### DIFF
--- a/modules/EnsEMBL/Web/Component/Location/Genome.pm
+++ b/modules/EnsEMBL/Web/Component/Location/Genome.pm
@@ -417,10 +417,7 @@ sub _feature_table {
       
     $html .= "<h3>$table_info->{'header'}</h3>";
 
-    if (!@{$table_info->{'rows'}||[]} && $table_info->{'empty_msg'}) {
-      $html .= '<p>'.$table_info->{'empty_msg'}.'</p>';
-    }
-    else {
+    if ($table_info->{'rows'}) {
       my $table = $self->new_table($columns, $table_info->{'rows'}, { data_table => 1, id => "${feat_type}_table", %{$table_info->{'table_style'} || {}} });
       $html .= $table->render;
     }
@@ -546,7 +543,9 @@ sub _configure_ProbeTranscript_table {
 
   my $config = {'header' => $header, 'column_order' => $column_order, 'rows' => $rows}; 
   if (!@$rows) {
-    $config->{'empty_msg'} = 'This probe does not map to any transcripts';
+    $config ->{'header'} = '';
+    $config ->{'column_order'} = '';
+    $config ->{'rows'} = '';
   }
   return $config;
 }


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

Currently, in the Whole-genome view, when a probe does not much with any transcripts, this message is shown in the Transcripts Mappings section: "This probe does not map to any transcripts".
Our probemapping pipeline does not map methylation arrays to transcripts and the message can be confusing because the reason for not having these mappings is not shown. 
In this case, when there is no mapping to show, we prefer to not show any message (and the section itself) so the users do not get confused. 
This PR is to solve this issue.

## Views affected

Whole-genome view.

http://ves-hx2-77.ebi.ac.uk:6008/Homo_sapiens/Location/Genome?array=HumanMethylation450;db=core;fdb=funcgen;ftype=ProbeFeature;h=cg04006839;id=cg04006839;ptype=probe;r=17:66229318-66229367;vendor=ILLUMINA

## Possible complications



## Merge conflicts


## Related JIRA Issues (EBI developers only)

_Please provide the URL(s) for any JIRA issues related to this PR._
