### PR TITLE
Add EVA URL look up for variants

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -376,6 +376,7 @@ EFO                         = https://www.ebi.ac.uk/ols/ontologies/efo/terms?sho
 EGA_SEARCH                  = http://www.ebi.ac.uk/ebisearch/search.ebi?db=ega&query=###ID###
 ESP                         = http://evs.gs.washington.edu/EVS/PopStatsServlet?searchBy=chromosome&chromosome=###CHR###&chromoStart=###START###&chromoEnd=###END###
 ESP_HOME                    = http://evs.gs.washington.edu/EVS/ 
+EVA                         = https://www.ebi.ac.uk/eva/?variant&accessionID=###ID###
 EVA_STUDY                   = https://www.ebi.ac.uk/eva/?eva-study=
 GEFOS                       = http://www.gefos.org 
 GEM_J_POP                   = https://togovar.biosciencedbc.jp/doc/datasets/gem_j_wga

--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -222,6 +222,8 @@ sub variation_source {
     } else {
       $source_link = "";
     } 
+  } elsif ($source eq "EVA") {
+    $source_link = $hub->get_ExtURL_link("$source_prefix $source", $sname, $name);
   } elsif ($source =~ /ClinVar/i) {
     $sname = ($name =~ /^rs/) ?  'CLINVAR_DBSNP' : 'CLINVAR';
     $source_link = $hub->get_ExtURL_link("About $source", $sname, $name);


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

This enables linking to EVA variant pages for refSNP, based on source being 'EVA'. This is required for the next release of the covid19 site hense on postreleasefix/104

## Views affected

All variant pages as the change is in the summary section. 

the source link on here: 
http://wp-np2-1f.ebi.ac.uk:10666/Sars_cov_2/Variation/Explore?db=core;r=MN908947.3:21068-22068;v=rs3161509327;vdb=variation;vf=9855

will point to 

- https://www.ebi.ac.uk/eva/?variant&accessionID=rs3161509327

rather than 

- https://www.ebi.ac.uk/eva/

## Possible complications

Any site using the webcode will need access to the ini file link for the URL to resolve. The DEFAULTS.ini is added for covid19 & www.

## Merge conflicts

none

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4367