### PR TITLE
Fix broken link in motif feature zmenu

### DIFF
--- a/modules/EnsEMBL/Web/ZMenu/MotifFeature.pm
+++ b/modules/EnsEMBL/Web/ZMenu/MotifFeature.pm
@@ -44,6 +44,7 @@ sub content {
                     type       => 'Location',
                     label_html => $r, 
                     link       => $hub->url({
+                                    type    => 'Location',
                                     action  => 'View',
                                     r       => $r,
                                   }),


### PR DESCRIPTION
## Description
The zmenu for the motif feature track shows broken links for Location. So when a user clicks on it, the page is redirected to an invalid URL page. As suggested in the JIRA ticket, I replaced the broken link with a link to the Location View.

## Views affected
Ensembl live site -> Regulation -> Summary (Regulatory Feature) -> Motif feature track -> Location link

## Related JIRA Issues (EBI developers only)
[ENSWEB-6305](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6305)

## Sandbox Link
http://wp-np2-1e.ebi.ac.uk:8320/Homo_sapiens/Regulation/Summary?db=core;fdb=funcgen;r=17:68035636-68047364;rf=ENSR00000097453