### PR TITLE
Trim whitespace when generating CSVs

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/SimilarityMatches.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/SimilarityMatches.pm
@@ -26,6 +26,7 @@ use base qw(EnsEMBL::Web::Component::Gene);
 sub _init {
   my $self = shift;
   $self->cacheable(1);
+  $self->mcacheable(0);
   $self->ajaxable(1);
 }
 

--- a/modules/EnsEMBL/Web/Component/Gene/SimilarityMatches.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/SimilarityMatches.pm
@@ -26,7 +26,6 @@ use base qw(EnsEMBL::Web::Component::Gene);
 sub _init {
   my $self = shift;
   $self->cacheable(1);
-  $self->mcacheable(0);
   $self->ajaxable(1);
 }
 

--- a/modules/EnsEMBL/Web/Document/Panel.pm
+++ b/modules/EnsEMBL/Web/Document/Panel.pm
@@ -374,7 +374,6 @@ sub component_content {
   my $base_url     = $hub->species_defs->ENSEMBL_BASE_URL;
   my $function     = $hub->function;
   my $is_html      = ($hub->param('_format') || 'HTML') eq 'HTML';
-  my $table_count  = 0;
   
   for (map [$_, $self->{'components'}{$_} || []], $self->components) {
     my ($code, $entry) = @$_;
@@ -454,19 +453,6 @@ sub component_content {
       }
     }
 
-    ## Does this component have any tables?
-    if ($component && $component->{'_table_count'}) {
-      $table_count += $component->{'_table_count'};
-    }    
-
-  }
-
-  if ($table_count > 1) {
-    my $button = sprintf(
-      '<div class="component_tools tool_buttons"><p style="display:inline-block"><a class="export" href="%s;filename=%s;_format=Excel" title="Download all tables as CSV">Download all tables as CSV</a></p></div>',
-      $hub->url, $hub->filename
-    );
-    $html = $button.$html;
   }
 
   $html .= sprintf '<div class="more"><a href="%s">more about %s ...</a></div>', $self->{'link'}, encode_entities($self->parse($self->{'caption'})) if $self->{'link'};

--- a/modules/EnsEMBL/Web/Document/Table.pm
+++ b/modules/EnsEMBL/Web/Document/Table.pm
@@ -305,6 +305,7 @@ sub csv_escape {
   my $self  = shift;
   my $value = $self->strip_HTML(shift);
      $value =~ s/"/""/g;
+     $value =~ s/^\s+|\s+$//g; # trim white space on both ends of the string
   
   return $value;
 }


### PR DESCRIPTION
## Description

### Problem 1: "strange CSV"

**Step to reproduce**: Open https://www.ensembl.org/Homo_sapiens/Gene/Matches?db=core;g=ENSG00000139618;r=13:32315086-32400268 and click on the "Download all tables as CSV" button (if is is visible on the page)

**Symptom:** the downloaded CSV wasn't displaying properly in Excel

![image](https://user-images.githubusercontent.com/6834224/140979585-d41c4f23-470a-4aed-bcda-c28292580c5f.png)

**Likely cause:** sometimes values in a column would start with a line break, making Excel unable to display the whole value properly.

![image](https://user-images.githubusercontent.com/6834224/140980185-c32ddd15-3bdd-46cf-9798-e6376c09359b.png)

**Solution:** always trim white space for values added to CSV columns 

**View after the fix:**

![image](https://user-images.githubusercontent.com/6834224/140980694-656ea933-1b43-40c3-b813-56dfec5b0048.png)

### Problem 2: "button disappears after click"

**Steps to reproduce:** click on the "Download all tables as CSV" button (if is is visible on the page) and refresh the page; the button will no longer be visible.

**Cause:**
- the button appears only when a certain counter that keeps track of the number of tables in a panel shows that there are more than one table ([see relevant code](https://github.com/Ensembl/ensembl-webcode/blob/release/104/modules/EnsEMBL/Web/Document/Panel.pm#L457-L470))
- however, component's output can get cached, in which case the table-rendering code will not get run, and the counter will not get incremented ([see relevant code](https://github.com/Ensembl/ensembl-webcode/blob/release/104/modules/EnsEMBL/Web/Component.pm#L229-L236))

**Solution:** no idea, but a naive approach would be to avoid caching a component.

**Notice:** this example shows that any panel with multiple tables will have exactly the same problem. I do not know how best to fix it properly.

## Views affected
http://wp-np2-1e.ebi.ac.uk:8410/Homo_sapiens/Gene/Matches?db=core;g=ENSG00000139618;r=13:32315086-32400268

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6396