### PR TITLE
Feature/species label

### DIFF
--- a/modules/EnsEMBL/Web/Component/Compara_AlignSliceSelector.pm
+++ b/modules/EnsEMBL/Web/Component/Compara_AlignSliceSelector.pm
@@ -59,13 +59,14 @@ sub content {
   }
 
   # For the variation compara view, only allow multi-way alignments
+  my $lookup = $species_defs->production_name_lookup;
   if ($align_label eq '') {
     my %species_hash;
     foreach my $key (grep { $alignments->{$_}{'class'} =~ /pairwise/ } keys %$alignments) {
       foreach (keys %{$alignments->{$key}->{'species'}}) {
         if ($alignments->{$key}->{'species'}->{$prodname} && $_ ne $prodname) {
           if ($key == $align) {
-            $align_label = $species_defs->production_name_mapping($_);
+            $align_label = $lookup->{$_};
             last;
           }
         }

--- a/modules/EnsEMBL/Web/Component/Compara_AlignSliceSelector.pm
+++ b/modules/EnsEMBL/Web/Component/Compara_AlignSliceSelector.pm
@@ -59,7 +59,7 @@ sub content {
   }
 
   # For the variation compara view, only allow multi-way alignments
-  my $lookup = $species_defs->production_name_lookup;
+  my $lookup = $species_defs->prodname_to_url_lookup;
   if ($align_label eq '') {
     my %species_hash;
     foreach my $key (grep { $alignments->{$_}{'class'} =~ /pairwise/ } keys %$alignments) {

--- a/modules/EnsEMBL/Web/Component/Compara_Alignments.pm
+++ b/modules/EnsEMBL/Web/Component/Compara_Alignments.pm
@@ -528,7 +528,7 @@ sub _get_target_slice_table {
   } elsif ($class =~ /pairwise/) {
     #Find the non-reference species for pairwise alignments
     #get the non_ref name from the first block
-    $other_species = $hub->species_defs->production_name_mapping($gabs->[0]->get_all_non_reference_genomic_aligns->[0]->genome_db->name);
+    $other_species = $hub->species_defs->prodname_to_url($gabs->[0]->get_all_non_reference_genomic_aligns->[0]->genome_db->name);
   }
 
   my $merged_blocks = $self->object->build_features_into_sorted_groups($groups);
@@ -547,7 +547,7 @@ sub _get_target_slice_table {
   my $gab_num = 0; #block counter
 
   #Add blocks to the table
-  my $lookup = $hub->species_defs->production_name_lookup;
+  my $lookup = $hub->species_defs->prodname_to_url_lookup;
   foreach my $gab_group (@$merged_blocks) {
     next unless $gab_group; 
     my $min_start;

--- a/modules/EnsEMBL/Web/Component/Compara_Alignments.pm
+++ b/modules/EnsEMBL/Web/Component/Compara_Alignments.pm
@@ -547,6 +547,7 @@ sub _get_target_slice_table {
   my $gab_num = 0; #block counter
 
   #Add blocks to the table
+  my $lookup = $hub->species_defs->production_name_lookup;
   foreach my $gab_group (@$merged_blocks) {
     next unless $gab_group; 
     my $min_start;
@@ -576,7 +577,7 @@ sub _get_target_slice_table {
     my $slice_length = ($ref_end-$ref_start+1);
 
     my $align_params = "$align";
-    $align_params .= "--" . $hub->species_defs->production_name_mapping($non_ref_ga->genome_db->name) . "--" . $non_ref_ga->dnafrag->name . ":$non_ref_start-$non_ref_end" if ($non_ref_ga);
+    $align_params .= "--" . $lookup->{$non_ref_ga->genome_db->name} . "--" . $non_ref_ga->dnafrag->name . ":$non_ref_start-$non_ref_end" if ($non_ref_ga);
 
     my %url_params = (
                      species => $ref_species,
@@ -605,7 +606,7 @@ sub _get_target_slice_table {
     if ($other_species) {
       $other_string = $non_ref_ga->dnafrag->name.":".$non_ref_start."-".$non_ref_end;
       $other_link = $hub->url({
-                                   species => $hub->species_defs->production_name_mapping($non_ref_ga->genome_db->name),
+                                   species => $lookup->{$non_ref_ga->genome_db->name},
                                    type   => 'Location',
                                    action => 'View',
                                    r      => $other_string,

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -192,9 +192,11 @@ sub content {
     }
   } 
   
+  my $lookup = $hub->species_defs->production_name_lookup;
   foreach my $species (sort { ($a =~ /^<.*?>(.+)/ ? $1 : $a) cmp ($b =~ /^<.*?>(.+)/ ? $1 : $b) } keys %orthologue_list) {
     next if $skipped{$species};
     next unless $species;
+    my $species_url = $lookup->{$species};
     
     foreach my $stable_id (sort keys %{$orthologue_list{$species}}) {
       my $orthologue = $orthologue_list{$species}{$stable_id};
@@ -316,7 +318,7 @@ sub content {
       });
 
       my $table_details = {
-        'Species'    => join('<br />(', split(/\s*\(/, $species_defs->species_label($species))),
+        'Species'    => join('<br />(', split(/\s*\(/, $species_defs->species_label($species_url))),
         'Type'       => $self->html_format ? glossary_helptip($hub, ucfirst $orthologue_desc, ucfirst "$orthologue_desc orthologues").qq{<p class="top-margin"><a href="$tree_url">View Gene Tree</a></p>} : glossary_helptip($hub, ucfirst $orthologue_desc, ucfirst "$orthologue_desc orthologues") ,
         'identifier' => $self->html_format ? $id_info : $stable_id,
         'Target %id' => qq{<span class="$target_class">}.sprintf('%.2f&nbsp;%%', $target).qq{</span>},
@@ -349,7 +351,7 @@ sub content {
       sprintf(
         '<p>%d orthologues not shown in the table above from the following species. Use the "<strong>Configure this page</strong>" on the left to show them.<ul><li>%s</li></ul></p>',
         $count,
-        join "</li>\n<li>", sort map {$species_defs->species_label($_)." ($skipped{$_})"} keys %skipped
+        join "</li>\n<li>", sort map {$species_defs->species_label($lookup->{_})." ($skipped{$_})"} keys %skipped
       )
     );
   }   
@@ -377,10 +379,11 @@ sub get_no_ortho_species_html {
   my ($self, $species_to_show, $sets_by_species) = @_;
   my $hub = $self->hub;
   my $no_ortho_species_html = '';
+  my $lookup = $hub->species_defs->production_name_lookup;
 
   foreach (sort {lc $a cmp lc $b} keys %$species_to_show) {
     if ($sets_by_species->{$_}) {
-      $no_ortho_species_html .= '<li class="'. join(' ', @{$sets_by_species->{$_}}) .'">'. $hub->species_defs->species_label($_) .'</li>';
+      $no_ortho_species_html .= '<li class="'. join(' ', @{$sets_by_species->{$_}}) .'">'. $hub->species_defs->species_label($lookup->{$_}) .'</li>';
     }
   }
 

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -377,7 +377,7 @@ sub get_no_ortho_species_html {
   my ($self, $species_to_show, $sets_by_species) = @_;
   my $hub = $self->hub;
   my $no_ortho_species_html = '';
-  my $lookup = $hub->species_defs->production_name_lookup;
+  my $lookup = $hub->species_defs->prodname_to_url_lookup;
 
   foreach (sort {lc $a cmp lc $b} keys %$species_to_show) {
     if ($sets_by_species->{$_}) {
@@ -424,7 +424,7 @@ sub get_export_data {
 
     if (keys %ok_species) {
       # It's the lower case species url name which is passed through the data export URL
-      my $lookup = $hub->species_defs->production_name_lookup;
+      my $lookup = $hub->species_defs->prodname_to_url_lookup;
       return [grep {$ok_species{lc($lookup->{$_->get_all_Members->[1]->genome_db->name})}} @$homologies];
     }
     else {

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -192,11 +192,9 @@ sub content {
     }
   } 
   
-  my $lookup = $hub->species_defs->production_name_lookup;
   foreach my $species (sort { ($a =~ /^<.*?>(.+)/ ? $1 : $a) cmp ($b =~ /^<.*?>(.+)/ ? $1 : $b) } keys %orthologue_list) {
     next if $skipped{$species};
     next unless $species;
-    my $species_url = $lookup->{$species};
     
     foreach my $stable_id (sort keys %{$orthologue_list{$species}}) {
       my $orthologue = $orthologue_list{$species}{$stable_id};
@@ -318,7 +316,7 @@ sub content {
       });
 
       my $table_details = {
-        'Species'    => join('<br />(', split(/\s*\(/, $species_defs->species_label($species_url))),
+        'Species'    => join('<br />(', split(/\s*\(/, $species_defs->species_label($spp))),
         'Type'       => $self->html_format ? glossary_helptip($hub, ucfirst $orthologue_desc, ucfirst "$orthologue_desc orthologues").qq{<p class="top-margin"><a href="$tree_url">View Gene Tree</a></p>} : glossary_helptip($hub, ucfirst $orthologue_desc, ucfirst "$orthologue_desc orthologues") ,
         'identifier' => $self->html_format ? $id_info : $stable_id,
         'Target %id' => qq{<span class="$target_class">}.sprintf('%.2f&nbsp;%%', $target).qq{</span>},
@@ -351,7 +349,7 @@ sub content {
       sprintf(
         '<p>%d orthologues not shown in the table above from the following species. Use the "<strong>Configure this page</strong>" on the left to show them.<ul><li>%s</li></ul></p>',
         $count,
-        join "</li>\n<li>", sort map {$species_defs->species_label($lookup->{_})." ($skipped{$_})"} keys %skipped
+        join "</li>\n<li>", sort map {$species_defs->species_label($_)." ($skipped{$_})"} keys %skipped
       )
     );
   }   

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -423,7 +423,8 @@ sub get_export_data {
 
     if (keys %ok_species) {
       # It's the lower case species url name which is passed through the data export URL
-      return [grep {$ok_species{lc($hub->species_defs->production_name_mapping($_->get_all_Members->[1]->genome_db->name))}} @$homologies];
+      my $lookup = $hub->species_defs->production_name_lookup;
+      return [grep {$ok_species{lc($lookup->{$_->get_all_Members->[1]->genome_db->name})}} @$homologies];
     }
     else {
       return $homologies;

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaParalogs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaParalogs.pm
@@ -62,7 +62,7 @@ sub content {
   
   my @rows;
  
-  my $lookup = $hub->species_defs->production_name_lookup; 
+  my $lookup = $hub->species_defs->prodname_to_url_lookup; 
   foreach my $species (sort keys %paralogue_list) {
     foreach my $stable_id (sort {$paralogue_list{$species}{$a}{'order'} <=> $paralogue_list{$species}{$b}{'order'}} keys %{$paralogue_list{$species}}) {
       my $paralogue = $paralogue_list{$species}{$stable_id};

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaParalogs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaParalogs.pm
@@ -61,7 +61,8 @@ sub content {
   ];
   
   my @rows;
-  
+ 
+  my $lookup = $hub->species_defs->production_name_lookup; 
   foreach my $species (sort keys %paralogue_list) {
     foreach my $stable_id (sort {$paralogue_list{$species}{$a}{'order'} <=> $paralogue_list{$species}{$b}{'order'}} keys %{$paralogue_list{$species}}) {
       my $paralogue = $paralogue_list{$species}{$stable_id};
@@ -144,7 +145,7 @@ sub content {
       } elsif (exists $cached_lca_desc{$species_tree_node->node_id}) {
         ($ancestral_taxonomy, $lca_desc) = @{$cached_lca_desc{$species_tree_node->node_id}};
       } elsif ($species_tree_node->is_leaf) {
-        $ancestral_taxonomy = $hub->species_defs->species_label($hub->species_defs->production_name_mapping($species_tree_node->genome_db->name));
+        $ancestral_taxonomy = $hub->species_defs->species_label($lookup->{$species_tree_node->genome_db->name});
       } else {
         $ancestral_taxonomy = species_tree_node_label($species_tree_node);
         my ($c0, $c1) = @{$species_tree_node->children()};

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -587,7 +587,7 @@ sub genomic_alignment_links {
         $type =~ s/_net//;
         $type =~ s/_/ /g;
         
-        $species_hash{$species_defs->species_label($lookup->{$_}) . "###$type"} = $i;
+        $species_hash{$species_defs->species_label($url_lookup->{$_}) . "###$type"} = $i;
       }
     } 
   }

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -182,11 +182,12 @@ sub content {
   # store g1 param in a different param as $highlight_gene can be undef if highlighting is disabled
   my $gene_to_highlight = $hub->param('g1');
   my $highlight_gene_display_label;  
-      
+     
+  my $lookup = $hub->species_defs->production_name_lookup; 
   foreach my $this_leaf (@$leaves) {
     if ($gene_to_highlight && $this_leaf->gene_member->stable_id eq $gene_to_highlight) {
       $highlight_gene_display_label = $this_leaf->gene_member->display_label || $gene_to_highlight;
-      $highlight_species            = $hub->species_defs->production_name_mapping($this_leaf->gene_member->genome_db->name);
+      $highlight_species            = $lookup->{$this_leaf->gene_member->genome_db->name};
       $highlight_species_name       = $this_leaf->gene_member->genome_db->display_name;
       $highlight_genome_db_id       = $this_leaf->gene_member->genome_db_id;
       last;
@@ -203,7 +204,7 @@ sub content {
         $html .= $self->_info('Highlighted genes',
           sprintf(
             '<p>The <i>%s</i> %s gene, its paralogues, its orthologue in <i>%s</i>, and paralogues of the <i>%s</i> gene, have all been highlighted. <a href="#" class="switch_highlighting on">Click here to disable highlighting</a>.</p>',
-            $hub->species_defs->get_config($hub->species_defs->production_name_mapping($member->genome_db->name), 'SPECIES_DISPLAY_NAME'),
+            $hub->species_defs->get_config($lookup->{$member->genome_db->name}, 'SPECIES_DISPLAY_NAME'),
             $highlight_gene_display_label,
             $hub->species_defs->get_config($highlight_species, 'SPECIES_DISPLAY_NAME') || $highlight_species_name,
             $hub->species_defs->get_config($highlight_species, 'SPECIES_DISPLAY_NAME') || $highlight_species_name
@@ -217,7 +218,7 @@ sub content {
       $html .= $self->_info('Highlighted genes', 
         sprintf(
           '<p>The <i>%s</i> %s gene and its paralogues are highlighted. <a href="#" class="switch_highlighting off">Click here to enable highlighting of %s homologues</a>.</p>',
-          $hub->species_defs->get_config($hub->species_defs->production_name_mapping($member->genome_db->name), 'SPECIES_DISPLAY_NAME'),
+          $hub->species_defs->get_config($lookup->{$member->genome_db->name}, 'SPECIES_DISPLAY_NAME'),
           $highlight_gene_display_label,
           $hub->species_defs->get_config($highlight_species, 'SPECIES_DISPLAY_NAME') || $highlight_species_name
         )

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -183,7 +183,7 @@ sub content {
   my $gene_to_highlight = $hub->param('g1');
   my $highlight_gene_display_label;  
      
-  my $lookup = $hub->species_defs->production_name_lookup; 
+  my $lookup = $hub->species_defs->prodname_to_url_lookup; 
   foreach my $this_leaf (@$leaves) {
     if ($gene_to_highlight && $this_leaf->gene_member->stable_id eq $gene_to_highlight) {
       $highlight_gene_display_label = $this_leaf->gene_member->display_label || $gene_to_highlight;

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -566,6 +566,7 @@ sub genomic_alignment_links {
   my $alignments    = $species_defs->multi_hash->{$ckey}{'ALIGNMENTS'}||{};
   my $species       = $hub->species;
   my $url           = $hub->url({ action => "Compara_Alignments$ckey", align => undef });
+  my $url_lookup    = $hub->species_defs->production_name_lookup;
   my (%species_hash, $list);
   
   foreach my $row_key (grep $alignments->{$_}{'class'} !~ /pairwise/, keys %$alignments) {
@@ -586,7 +587,7 @@ sub genomic_alignment_links {
         $type =~ s/_net//;
         $type =~ s/_/ /g;
         
-        $species_hash{$species_defs->species_label($_) . "###$type"} = $i;
+        $species_hash{$species_defs->species_label($lookup->{$_}) . "###$type"} = $i;
       }
     } 
   }

--- a/modules/EnsEMBL/Web/Component/Gene/FamilyProteins.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/FamilyProteins.pm
@@ -185,11 +185,12 @@ sub content_ensembl {
       { key => 'peptides', title => 'Proteins', width => '80%', align => 'left' },
     );
 
+    my $lookup = $production_name_lookup;
     foreach my $genomedb (sort { $a->name cmp $b->name } @genomedbs) {
       my $species_key = $genomedb->name;
 
       if ($hub->param('species_' . lc $species_key) ne 'yes') {
-        push @member_skipped_species, $species_defs->species_label($species_key);
+        push @member_skipped_species, $species_defs->species_label($lookup->{$species_key});
         $member_skipped_count += @{$data{$genomedb->dbID}};
         next;
       }
@@ -197,7 +198,7 @@ sub content_ensembl {
       next unless $data{$genomedb->dbID};
 
       my $row = {
-        species  => $species_defs->species_label($species_key),
+        species  => $species_defs->species_label($lookup->{$species_key}),
         peptides => '<dl class="long_id_list">'
       };
 

--- a/modules/EnsEMBL/Web/Component/Gene/FamilyProteins.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/FamilyProteins.pm
@@ -185,7 +185,7 @@ sub content_ensembl {
       { key => 'peptides', title => 'Proteins', width => '80%', align => 'left' },
     );
 
-    my $lookup = $prodname_to_url_lookup;
+    my $lookup = $species_defs->prodnames_to_urls_lookup;
     foreach my $genomedb (sort { $a->name cmp $b->name } @genomedbs) {
       my $species_key = $genomedb->name;
 

--- a/modules/EnsEMBL/Web/Component/Gene/FamilyProteins.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/FamilyProteins.pm
@@ -185,7 +185,7 @@ sub content_ensembl {
       { key => 'peptides', title => 'Proteins', width => '80%', align => 'left' },
     );
 
-    my $lookup = $production_name_lookup;
+    my $lookup = $prodname_to_url_lookup;
     foreach my $genomedb (sort { $a->name cmp $b->name } @genomedbs) {
       my $species_key = $genomedb->name;
 

--- a/modules/EnsEMBL/Web/Component/Gene/GenePhenotypeOrthologue.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GenePhenotypeOrthologue.pm
@@ -58,7 +58,8 @@ sub content {
   
   my @rows;
 
-  foreach my $species (map $hub->species_defs->production_name_mapping($_), sort { ($a =~ /^<.*?>(.+)/ ? $1 : $a) cmp ($b =~ /^<.*?>(.+)/ ? $1 : $b) } keys %orthologue_list) {
+  my $lookup = $hub->species_defs->production_name_lookup;
+  foreach my $species (map $lookup->{$_}, sort { ($a =~ /^<.*?>(.+)/ ? $1 : $a) cmp ($b =~ /^<.*?>(.+)/ ? $1 : $b) } keys %orthologue_list) {
     next unless $hub->species_defs->get_config($species, 'databases') && $hub->species_defs->get_config($species, 'databases')->{'DATABASE_VARIATION'};
 
     my $pfa = $hub->get_adaptor('get_PhenotypeFeatureAdaptor', 'variation', $species);

--- a/modules/EnsEMBL/Web/Component/Gene/GenePhenotypeOrthologue.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GenePhenotypeOrthologue.pm
@@ -58,7 +58,7 @@ sub content {
   
   my @rows;
 
-  my $lookup = $hub->species_defs->production_name_lookup;
+  my $lookup = $hub->species_defs->prodname_to_url_lookup;
   foreach my $species (map $lookup->{$_}, sort { ($a =~ /^<.*?>(.+)/ ? $1 : $a) cmp ($b =~ /^<.*?>(.+)/ ? $1 : $b) } keys %orthologue_list) {
     next unless $hub->species_defs->get_config($species, 'databases') && $hub->species_defs->get_config($species, 'databases')->{'DATABASE_VARIATION'};
 

--- a/modules/EnsEMBL/Web/Component/Gene/HomologAlignment.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/HomologAlignment.pm
@@ -69,7 +69,7 @@ sub content {
       my $data = [];
       my $flag = !$second_gene;
       
-      my $lookup = $species_defs->production_name_lookup;
+      my $lookup = $species_defs->prodname_to_url_lookup;
       foreach my $peptide (@{$homology->get_all_Members}) {
         my $gene = $peptide->gene_member;
         $flag = 1 if $gene->stable_id eq $second_gene; 

--- a/modules/EnsEMBL/Web/Component/Gene/HomologAlignment.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/HomologAlignment.pm
@@ -69,11 +69,12 @@ sub content {
       my $data = [];
       my $flag = !$second_gene;
       
+      my $lookup = $species_defs->production_name_lookup;
       foreach my $peptide (@{$homology->get_all_Members}) {
         my $gene = $peptide->gene_member;
         $flag = 1 if $gene->stable_id eq $second_gene; 
 
-        my $member_species = $species_defs->production_name_mapping($peptide->genome_db->name);
+        my $member_species = $lookup->{$peptide->genome_db->name};
         my $location       = sprintf '%s:%d-%d', $gene->dnafrag->name, $gene->dnafrag_start, $gene->dnafrag_end;
        
         if (!$second_gene && $member_species ne $species && $hub->param('species_' . lc $member_species) eq 'off') {

--- a/modules/EnsEMBL/Web/Component/LRG/GenePhenotypeOrthologue.pm
+++ b/modules/EnsEMBL/Web/Component/LRG/GenePhenotypeOrthologue.pm
@@ -61,7 +61,8 @@ sub content {
 
   my @rows;
   
-  foreach my $species (map $species_defs->production_name_mapping($_), sort { ($a =~ /^<.*?>(.+)/ ? $1 : $a) cmp ($b =~ /^<.*?>(.+)/ ? $1 : $b) } keys %orthologue_list) {
+  my $lookup = $species_defs->production_name_lookup;
+  foreach my $species (map $lookup->{$_}, sort { ($a =~ /^<.*?>(.+)/ ? $1 : $a) cmp ($b =~ /^<.*?>(.+)/ ? $1 : $b) } keys %orthologue_list) {
     next unless $species_defs->get_config($species, 'databases')->{'DATABASE_VARIATION'};
     
     my $pfa = $hub->get_adaptor('get_PhenotypeFeatureAdaptor', 'variation', $species);

--- a/modules/EnsEMBL/Web/Component/LRG/GenePhenotypeOrthologue.pm
+++ b/modules/EnsEMBL/Web/Component/LRG/GenePhenotypeOrthologue.pm
@@ -61,7 +61,7 @@ sub content {
 
   my @rows;
   
-  my $lookup = $species_defs->production_name_lookup;
+  my $lookup = $species_defs->prodname_to_url_lookup;
   foreach my $species (map $lookup->{$_}, sort { ($a =~ /^<.*?>(.+)/ ? $1 : $a) cmp ($b =~ /^<.*?>(.+)/ ? $1 : $b) } keys %orthologue_list) {
     next unless $species_defs->get_config($species, 'databases')->{'DATABASE_VARIATION'};
     

--- a/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
+++ b/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
@@ -92,7 +92,7 @@ sub content {
       more_slices     => $i != @$slices,
     });
     
-    my ($species_name, $slice_name) = split ':', $lookup->{$_->{'name'}};
+    my ($species_name, $slice_name) = split ':', $_->{'name'};
     
     my $panel_caption = $species_defs->get_config($species_name, 'SPECIES_DISPLAY_NAME') || 'Ancestral sequences';
     $panel_caption   .= " $slice_name" if $slice_name;

--- a/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
+++ b/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
@@ -79,7 +79,7 @@ sub content {
   my (@images, $html);
   
   my ($caption_height,$caption_img_offset) = (0,-24);
-  my $lookup = $species_defs->production_name_lookup;
+  my $lookup = $species_defs->prodname_to_url_lookup;
   foreach (@$slices) {
     my $species      = $_->{'name'} eq 'Ancestral_sequences' ? 'Multi' : $lookup->{$_->{'name'}}; # Cheating: set species to Multi to stop errors due to invalid species.
     my $image_config = $hub->get_imageconfig({'type' => 'alignsliceviewbottom', 'cache_code' => "alignsliceviewbottom_$i", 'species' => $species});

--- a/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
+++ b/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
@@ -79,8 +79,9 @@ sub content {
   my (@images, $html);
   
   my ($caption_height,$caption_img_offset) = (0,-24);
+  my $lookup = $species_defs->production_name_lookup;
   foreach (@$slices) {
-    my $species      = $_->{'name'} eq 'Ancestral_sequences' ? 'Multi' : $species_defs->production_name_mapping($_->{'name'}); # Cheating: set species to Multi to stop errors due to invalid species.
+    my $species      = $_->{'name'} eq 'Ancestral_sequences' ? 'Multi' : $lookup->{$_->{'name'}}; # Cheating: set species to Multi to stop errors due to invalid species.
     my $image_config = $hub->get_imageconfig({'type' => 'alignsliceviewbottom', 'cache_code' => "alignsliceviewbottom_$i", 'species' => $species});
     
     $image_config->set_parameters({
@@ -91,7 +92,7 @@ sub content {
       more_slices     => $i != @$slices,
     });
     
-    my ($species_name, $slice_name) = split ':', $species_defs->production_name_mapping($_->{'name'});
+    my ($species_name, $slice_name) = split ':', $lookup->{$_->{'name'}};
     
     my $panel_caption = $species_defs->get_config($species_name, 'SPECIES_DISPLAY_NAME') || 'Ancestral sequences';
     $panel_caption   .= " $slice_name" if $slice_name;

--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -961,7 +961,7 @@ sub check_for_missing_species {
     my $sp_url = $url_lookup->{$_};
     if ($align_details->{'class'} !~ /pairwise/
         && ($self->param(sprintf 'species_%d_%s', $align, lc) || 'off') eq 'off') {
-      push @skipped, $_ unless ($args->{ignore} && $args->{ignore} eq 'ancestral_sequences');
+      push @skipped, $sp_url unless ($args->{ignore} && $args->{ignore} eq 'ancestral_sequences');
     }
     elsif (defined $slice and !$aligned_species{$sp_url} and $_ ne 'ancestral_sequences') {
       my $key = $hub->is_strain($sp_url) ? pluralise($species_info->{$sp_url}{strain_type}) : 'species';

--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -946,7 +946,7 @@ sub check_for_missing_species {
   my $db_key        = $args->{cdb} =~ /pan_ensembl/ ? 'DATABASE_COMPARA_PAN_ENSEMBL' : 'DATABASE_COMPARA';
   my $align_details = $species_defs->multi_hash->{$db_key}->{'ALIGNMENTS'}->{$align};
   my $species_info  = $hub->get_species_info;
-  my $url_lookup    = $species_defs->production_name_lookup;
+  my $url_lookup    = $species_defs->prodname_to_url_lookup;
   my $slice         = $args->{slice} || $self->object->slice;
   $slice = undef if $slice == 1; # weirdly, we get 1 if feature_Slice is missing
 

--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -946,6 +946,7 @@ sub check_for_missing_species {
   my $db_key        = $args->{cdb} =~ /pan_ensembl/ ? 'DATABASE_COMPARA_PAN_ENSEMBL' : 'DATABASE_COMPARA';
   my $align_details = $species_defs->multi_hash->{$db_key}->{'ALIGNMENTS'}->{$align};
   my $species_info  = $hub->get_species_info;
+  my $url_lookup    = $species_defs->production_name_lookup;
   my $slice         = $args->{slice} || $self->object->slice;
   $slice = undef if $slice == 1; # weirdly, we get 1 if feature_Slice is missing
 
@@ -957,7 +958,7 @@ sub check_for_missing_species {
 
   foreach (keys %{$align_details->{'species'}}) {
     next if $_ eq $species;
-    my $sp_url = $species_defs->production_name_mapping($_);
+    my $sp_url = $url_lookup->{$_};
     if ($align_details->{'class'} !~ /pairwise/
         && ($self->param(sprintf 'species_%d_%s', $align, lc) || 'off') eq 'off') {
       push @skipped, $_ unless ($args->{ignore} && $args->{ignore} eq 'ancestral_sequences');

--- a/modules/EnsEMBL/Web/Component/TextSequence.pm
+++ b/modules/EnsEMBL/Web/Component/TextSequence.pm
@@ -249,7 +249,7 @@ sub set_variations {
   my $name   = $slice_data->{'name'};
   my $slice  = $slice_data->{'slice'};
   
-  my $species = $slice->can('genome_db') ? $hub->species_defs->production_name_mapping($slice->genome_db->name) : $hub->species;
+  my $species = $slice->can('genome_db') ? $hub->species_defs->prodname_to_url($slice->genome_db->name) : $hub->species;
   return unless $hub->database('variation', $species);
   my $strand = $slice->strand;
   my $focus  = $name eq $config->{'species'} ? $config->{'focus_variant'} : undef;

--- a/modules/EnsEMBL/Web/Document/HTML/Compara.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara.pm
@@ -32,13 +32,13 @@ use base qw(EnsEMBL::Web::Document::HTML);
 
 sub sci_name {
   my ($self, $name) = @_;
-  $name = $self->hub->species_defs->production_name_mapping($name);
+  $name = $self->hub->species_defs->prodname_to_url($name);
   return $self->hub->species_defs->get_config($name, 'SPECIES_SCIENTIFIC_NAME');
 }
 
 sub common_name {
   my ($self, $name) = @_;
-  $name = $self->hub->species_defs->production_name_mapping($name);
+  $name = $self->hub->species_defs->prodname_to_url($name);
   return $self->hub->species_defs->get_config($name, 'SPECIES_DISPLAY_NAME');
 }
 
@@ -191,7 +191,7 @@ sub mlss_species_info {
   return [] unless $compara_db;
 
   my $species = [];
-  my $lookup =  $self->hub->species_defs->production_name_lookup;
+  my $lookup =  $self->hub->species_defs->prodname_to_url_lookup;
   foreach my $db (@{$mlss->species_set->genome_dbs||[]}) {
     push @$species, $lookup->{$db->name};
   }
@@ -222,7 +222,7 @@ sub pairwise_mlss_data {
   my %synt_methods;
 
   ## Munge all the necessary information
-  my $lookup = $self->hub->species_defs->production_name_lookup;
+  my $lookup = $self->hub->species_defs->prodname_to_url_lookup;
   foreach my $method (@{$methods||[]}) {
     my $mlss_sets  = $mlss_adaptor->fetch_all_by_method_link_type($method);
     if (@$mlss_sets and ($mlss_sets->[0]->method->class =~ /SyntenyRegion.synteny/)) {
@@ -257,7 +257,7 @@ sub mlss_data {
  
   my $data = {};
   my $species = {};
-  my $lookup = $self->hub->species_defs->production_name_lookup;
+  my $lookup = $self->hub->species_defs->prodname_to_url_lookup;
 
   ## Munge all the necessary information
   foreach my $method (@{$methods||[]}) {

--- a/modules/EnsEMBL/Web/ImageConfig/alignsliceviewbottom.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/alignsliceviewbottom.pm
@@ -114,7 +114,7 @@ sub species_list {
     my $primary      = $referer->{'ENSEMBL_SPECIES'};
     my @species      = scalar keys %$alignment ? () : ([ $primary, $species_defs->SPECIES_DISPLAY_NAME($primary) ]);
 
-    my $lookup = $species_defs->production_name_lookup;
+    my $lookup = $species_defs->prodname_to_url_lookup;
     my @species_list = map { $_ = $lookup->{$_} || $_ } keys %$alignment;
 
     foreach (sort { $a->[1] cmp $b->[1] } map [ $_, $species_defs->SPECIES_DISPLAY_NAME($_) ], @species_list) {

--- a/modules/EnsEMBL/Web/ImageConfig/alignsliceviewbottom.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/alignsliceviewbottom.pm
@@ -114,7 +114,8 @@ sub species_list {
     my $primary      = $referer->{'ENSEMBL_SPECIES'};
     my @species      = scalar keys %$alignment ? () : ([ $primary, $species_defs->SPECIES_DISPLAY_NAME($primary) ]);
 
-    my @species_list = map { $_ = $species_defs->production_name_mapping($_) || $_ } keys %$alignment;
+    my $lookup = $species_defs->production_name_lookup;
+    my @species_list = map { $_ = $lookup->{$_} || $_ } keys %$alignment;
 
     foreach (sort { $a->[1] cmp $b->[1] } map [ $_, $species_defs->SPECIES_DISPLAY_NAME($_) ], @species_list) {
       if ($_->[0] eq $primary) {

--- a/modules/EnsEMBL/Web/JSONServer/SpeciesSelector/Compara_Alignments.pm
+++ b/modules/EnsEMBL/Web/JSONServer/SpeciesSelector/Compara_Alignments.pm
@@ -43,7 +43,7 @@ sub json_fetch_species {
   my $species_info = $hub->get_species_info;
   my $species      = $sd->SPECIES_PRODUCTION_NAME;
   my $species_hash_multiple = ();
-  my $url_lookup   = $sd->production_name_lookup;
+  my $url_lookup   = $sd->prodname_to_url_lookup;
 
   # Order by number of species (name is in the form "6 primates EPO")
   foreach my $row (sort { $a->{'name'} <=> $b->{'name'} } grep { $_->{'class'} !~ /pairwise/ && $_->{'species'}->{$species} } values %$alignments) {

--- a/modules/EnsEMBL/Web/JSONServer/SpeciesSelector/Compara_Alignments.pm
+++ b/modules/EnsEMBL/Web/JSONServer/SpeciesSelector/Compara_Alignments.pm
@@ -58,8 +58,8 @@ sub json_fetch_species {
     $t->{children}   = [];
     my @children;
 
+    my ($prod_name, $url_name); 
     foreach $_ (sort keys %{$row->{'species'}}) {
-      my ($prod_name, $url_name); 
       my $ancestral = 0;
       if ($_ =~/ancestral_sequences/i) {
         ## Not a real species, so it's legit to do ucfirst here!

--- a/modules/EnsEMBL/Web/JSONServer/SpeciesSelector/Compara_Alignments.pm
+++ b/modules/EnsEMBL/Web/JSONServer/SpeciesSelector/Compara_Alignments.pm
@@ -43,6 +43,7 @@ sub json_fetch_species {
   my $species_info = $hub->get_species_info;
   my $species      = $sd->SPECIES_PRODUCTION_NAME;
   my $species_hash_multiple = ();
+  my $url_lookup   = $sd->production_name_lookup;
 
   # Order by number of species (name is in the form "6 primates EPO")
   foreach my $row (sort { $a->{'name'} <=> $b->{'name'} } grep { $_->{'class'} !~ /pairwise/ && $_->{'species'}->{$species} } values %$alignments) {
@@ -57,18 +58,18 @@ sub json_fetch_species {
     $t->{children}   = [];
     my @children;
 
-    foreach (sort keys %{$row->{'species'}}) {
-      my $url_name  = $hub->species_defs->production_name_mapping($_);
-      my $prod_name = $hub->species_defs->get_config($url_name, 'SPECIES_PRODUCTION_NAME');
+    foreach $_ (sort keys %{$row->{'species'}}) {
+      my ($prod_name, $url_name); 
       my $ancestral = 0;
       if ($_ =~/ancestral_sequences/i) {
+        ## Not a real species, so it's legit to do ucfirst here!
         $url_name = ucfirst($_);
-        $prod_name = $_;
         $ancestral = 1;
       }
-
-      next unless $prod_name;
-      $prod_name = encode_entities($prod_name);
+      else {
+        $url_name = $url_lookup->{$_}; 
+      }
+      $prod_name = encode_entities($_);
       my $t_child = {};
       $t_child->{key}        = join '_', ('species', $row->{id}, lc($prod_name));
       $t_child->{title}      = encode_entities($ancestral ? '--Ancestral_sequences--' : $species_info->{$url_name}->{display_name});

--- a/modules/EnsEMBL/Web/JSONServer/SpeciesSelector/Compara_Alignments.pm
+++ b/modules/EnsEMBL/Web/JSONServer/SpeciesSelector/Compara_Alignments.pm
@@ -133,7 +133,7 @@ sub json_fetch_species {
     foreach my $align_id (keys %$final_alignments) {
       foreach (keys %{$final_alignments->{$align_id}->{'species'}}) {
         if ($alignments->{$align_id}{'species'}->{$species} && $_ ne $species) {
-          $_ = $hub->species_defs->production_name_mapping($_);
+          $_ = $url_lookup->{$_};
           $available_species_map->{$_} = $align_id;
         }
       }

--- a/modules/EnsEMBL/Web/JSONServer/SpeciesSelector/Multi.pm
+++ b/modules/EnsEMBL/Web/JSONServer/SpeciesSelector/Multi.pm
@@ -53,7 +53,7 @@ sub json_fetch_species {
   my $species_info    = $hub->get_species_info;
   my (%available_species, %included_regions);
 
-  my $url_lookup = $species_defs->production_name_lookup;
+  my $url_lookup = $species_defs->prodname_to_url_lookup;
   my $available_species_map = {};
   my $extras = {};
   my $uniq_assembly = {};

--- a/modules/EnsEMBL/Web/JSONServer/SpeciesSelector/Multi.pm
+++ b/modules/EnsEMBL/Web/JSONServer/SpeciesSelector/Multi.pm
@@ -124,8 +124,8 @@ sub json_fetch_species {
     }
   }
 
-  if ($shown{$prodname}) {
-    my ($chr) = split ':', $params->{"r$shown{$prodname}"};
+  if ($shown{$primary_species}) {
+    my ($chr) = split ':', $params->{"r$shown{$primary_species}"};
     $available_species{$prodname} = "$species_label - chromosome $chr";
   }
 

--- a/modules/EnsEMBL/Web/Object.pm
+++ b/modules/EnsEMBL/Web/Object.pm
@@ -342,6 +342,7 @@ sub get_slices {
   }
 
   my $counter = 0;
+  my $lookup = $self->hub->species_defs->production_name_lookup;
   foreach (@slices) {
     next unless $_;
 
@@ -355,7 +356,7 @@ sub get_slices {
       slice             => $_,
       underlying_slices => $underlying_slices && $_->can('get_all_underlying_Slices') ? $_->get_all_underlying_Slices : [ $_ ],
       name              => $name,
-      display_name      => $self->get_slice_display_name($self->hub->species_defs->production_name_mapping($name), $_),
+      display_name      => $self->get_slice_display_name($lookup->{$name}, $_),
       cigar_line        => $cigar_line,
     };
     if ($name eq 'Ancestral_sequences') {

--- a/modules/EnsEMBL/Web/Object.pm
+++ b/modules/EnsEMBL/Web/Object.pm
@@ -342,7 +342,6 @@ sub get_slices {
   }
 
   my $counter = 0;
-  my $lookup = $self->hub->species_defs->production_name_lookup;
   foreach (@slices) {
     next unless $_;
 
@@ -356,7 +355,7 @@ sub get_slices {
       slice             => $_,
       underlying_slices => $underlying_slices && $_->can('get_all_underlying_Slices') ? $_->get_all_underlying_Slices : [ $_ ],
       name              => $name,
-      display_name      => $self->get_slice_display_name($lookup->{$name}, $_),
+      display_name      => $self->get_slice_display_name($name, $_),
       cigar_line        => $cigar_line,
     };
     if ($name eq 'Ancestral_sequences') {

--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -830,7 +830,7 @@ sub fetch_homology_species_hash {
   my $homology_source      = shift;
   my $homology_description = shift;
   my $compara_db           = shift || 'compara';
-  my $name_lookup          = $self->hub->species_defs->production_name_lookup;
+  my $name_lookup          = $self->hub->species_defs->prodname_to_url_lookup;
   my ($homologies, $classification, $query_member) = $self->get_homologies($homology_source, $homology_description, $compara_db);
   my %homologues;
   my $missing;

--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -1587,8 +1587,8 @@ sub species_label {
   return $label;
 }
 
-sub production_name_lookup {
-## Maps all species to their production name
+sub prodnames_to_urls_lookup {
+## Maps all species' production names to their URLs
   my $self = shift;
   my $names = {};
   
@@ -1598,11 +1598,12 @@ sub production_name_lookup {
   return $names;
 }
 
-sub production_name_mapping {
+sub prodname_to_url {
+### Given a production name, work out the species URL
 ### As the name said, the function maps the production name with the species URL, 
-### @param key - species production name (or URL in the case of some compara code) 
+### @param key - species production name
 ### Return string = the corresponding species.url name which is the name web uses for URL and other code
-### Fall back to production name if not found - mostly for pan-compara
+### Falls back to production name if not found, mostly for pan-compara - the production name _should_be an alias anyway, but this method ensures we get the "correct" value where possible
   my ($self, $production_name) = @_;
   my $mapping_name = $production_name;
   

--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -1573,11 +1573,11 @@ sub species_label {
       ## Pan-compara species - get label from metadata db
       my $info = $self->get_config('MULTI', 'PAN_COMPARA_LOOKUP');
       if ($info) {
-        if ($info->{$key}) {
-          $label = $info->{$key}{'display_name'}
+        if ($info->{$url}) {
+          $label = $info->{$url}{'display_name'}
         }
         else {
-          $label = $info->{lc $key}{'display_name'}
+          $label = $info->{lc $url}{'display_name'}
         }
       }
     }

--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -1541,11 +1541,10 @@ sub species_label {
   ### This function will return the display name of all known (by Compara) species.
   ### Some species in genetree can be from other EG units, and some can be from external sources
   ### Arguments:
-  ###     key             String: species production name or URL
+  ###     url             String: species  URL
   ###     no_formating    Boolean: omit italics from scientific name  
-  my ($self, $key, $no_formatting) = @_;
+  my ($self, $url, $no_formatting) = @_;
 
-  my $url = $self->production_name_mapping($key);
   my $display = $self->get_config($url, 'SPECIES_DISPLAY_NAME');
   my $label = '';
 

--- a/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
@@ -62,7 +62,7 @@ sub content {
     $node->{_sub_leaves_count} = scalar(@$members);
     my $link_gene = $members->[0];
     foreach my $g (@$members) {
-      $link_gene = $g if (lc $hub->species_defs->production_name_mapping($g->genome_db->name)) eq (lc $hub->species);
+      $link_gene = $g if ($g->genome_db->name eq $hub->species_defs->SPECIES_PRODUCTION_NAME);
     }
     $node->{_sub_reference_gene} = $link_gene->gene_member;
   }
@@ -153,6 +153,7 @@ sub content {
   
   }
 
+  my $lookup = $hub->species_defs->production_name_lookup;
   if ($is_leaf and $is_supertree) {
 
       # Gene count
@@ -166,7 +167,7 @@ sub content {
       ## Strain trees and pon-compara trees are very different!
       my ($species, $action, $base_url);  
       if ($hub->action =~ /Strain/) {
-        $species = $hub->species_defs->production_name_mapping($link_gene->genome_db->name);
+        $species = $lookup->{$link_gene->genome_db->name};
         $action = $hub->action;
       }
       else {
@@ -328,11 +329,11 @@ sub content {
         next if $gene eq $hub->param('g');
         
         if ($s == 0) {
-          $url_params->{'species'} = $hub->species_defs->production_name_mapping($_->genome_db->name);
+          $url_params->{'species'} = $lookup->{$_->genome_db->name};
           $url_params->{'g'} = $gene;
         } 
         else {
-          $url_params->{"s$s"} = $hub->species_defs->production_name_mapping($_->genome_db->name);
+          $url_params->{"s$s"} = $lookup->{$_->genome_db->name};
           $url_params->{"g$s"} = $gene;
         }
         $s++;

--- a/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
@@ -153,7 +153,7 @@ sub content {
   
   }
 
-  my $lookup = $hub->species_defs->production_name_lookup;
+  my $lookup = $hub->species_defs->prodname_to_url_lookup;
   if ($is_leaf and $is_supertree) {
 
       # Gene count


### PR DESCRIPTION
## Description

Remove ability of the species_label method to accept a production name, as doing the necessary lookup is very expensive. Instead, update code to always pass in a URL - if this needs to be processed multiple times in a loop, create a lookup hash first (outside the loop).

## Views affected

- bacteria BLAST input form
- species selectors for compara views (Alignment Image, Region Comparison)
- other compara views, including zmenus

## Possible complications

There could be other components that pass a production name into species_label - need to check NV repos.

## Merge conflicts

None at the moment.

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6434


Bacteria Sandbox URL for testing:
http://wp-np2-1d.ebi.ac.uk:11010 (this is Ridwan's sandbox)