### PR TITLE
Fix collaboration info link

### DIFF
--- a/htdocs/info/about/contact/index.html
+++ b/htdocs/info/about/contact/index.html
@@ -54,7 +54,7 @@ breaking Ensembl news and service status updates.</p>
 <p>We encourage organisations to collaborate with us on projects of all sizes, from
 setting up a custom install of Ensembl with additional views and data, to 
 large-scale research programs.
-<a href="/info/about/contact/collaboration.html">More information</a>...</p>
+<a href="/info/about/collaborations/">More information</a>...</p>
 
 </body>
 </html>


### PR DESCRIPTION
## Description

Fixes the collaborations info link in the contact page.

## Views affected

["Cotact us" page](https://www.ensembl.org/info/about/contact/index.html) on all divisions.

## Related JIRA Issues (EBI developers only)

[ENSWEB-6420](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6420)
