### PR TITLE
Fix orthologues list strain filter

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -95,7 +95,7 @@ sub content {
       }
       else {
         ## Do not show any strain species on main species view
-        if ($strain_group && $strain_group ne lc($species)) {
+        if ($strain_group && $strain_group ne $prod_name) {
           delete $species_to_show{$prod_name};
           next;
         }

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -95,7 +95,7 @@ sub content {
       }
       else {
         ## Do not show any strain species on main species view
-        if ($strain_group) {
+        if ($strain_group && $strain_group ne lc($species)) {
           delete $species_to_show{$prod_name};
           next;
         }


### PR DESCRIPTION

## Description

`Triticum aestivum` has the strain group value set to `triticum_aestivum` which is causing them to be filtered from getting displayed in the orthologues list.

## Views affected
http://wp-np2-1d.ebi.ac.uk:42228/Triticum_turgidum/Gene/Compara_Ortholog?db=core;g=TRITD2Bv1G183370;r=2B:540943210-541159134;t=TRITD2Bv1G183370.1#list_no_ortho

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6474
