### PR TITLE
Do not display gene ID and symbol together

### DIFF
--- a/modules/EnsEMBL/Web/Query/GlyphSet/Transcript.pm
+++ b/modules/EnsEMBL/Web/Query/GlyphSet/Transcript.pm
@@ -141,12 +141,22 @@ sub _fixup_label {
 sub _feature_label {
   my ($self,$args,$gene,$transcript) = @_;
 
+  my $is_gene = 0;
+  if(!$transcript && $gene){
+    $is_gene = 1;
+  }
+
   $transcript ||= $gene;
+
+  use Data::Dumper;
+  warn "-------- ARGS----";
+  warn $self;
+  # warn Dumper($args);
 
 
   my $id = '';
 
-  if( $transcript->external_name && $transcript->stable_id){
+  if( $transcript->external_name && $transcript->stable_id && !$is_gene){
     $id = $transcript->external_name . " - " . $transcript->stable_id;
   } else {
     $id = $transcript->external_name || $transcript->stable_id;

--- a/modules/EnsEMBL/Web/Query/GlyphSet/Transcript.pm
+++ b/modules/EnsEMBL/Web/Query/GlyphSet/Transcript.pm
@@ -148,12 +148,6 @@ sub _feature_label {
 
   $transcript ||= $gene;
 
-  use Data::Dumper;
-  warn "-------- ARGS----";
-  warn $self;
-  # warn Dumper($args);
-
-
   my $id = '';
 
   if( $transcript->external_name && $transcript->stable_id && !$is_gene){


### PR DESCRIPTION
## Description
Updated the compact renderer to show either gene symbol or gene stable ID but not both.

## Views affected
http://wp-np2-1d.ebi.ac.uk:42229/Homo_sapiens/Location/View?db=core;g=ENSG00000139618;r=13:52589621-52667443;t=ENST00000544455


## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6334
