### PR TITLE
e107: Add separate tracks for MANE Select & MANE Plus Clinical

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/_mane_plus_clinical.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/_mane_plus_clinical.pm
@@ -1,0 +1,35 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2021] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Draw::GlyphSet::_mane_plus_clinical;
+
+### Module for drawing the MANE Plus Clinical track inheriting from _transcript.pm.
+
+use strict;
+use Carp qw(cluck);
+use List::Util qw(min max);
+
+use base qw(EnsEMBL::Draw::GlyphSet::_transcript);
+
+sub max_label_rows { return $_[0]->my_config('max_label_rows') || 2; }
+
+sub only_attrib { 
+    return 'MANE_Plus_Clinical'; }
+
+1;

--- a/modules/EnsEMBL/Draw/GlyphSet/_mane_plus_clinical.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/_mane_plus_clinical.pm
@@ -22,14 +22,11 @@ package EnsEMBL::Draw::GlyphSet::_mane_plus_clinical;
 ### Module for drawing the MANE Plus Clinical track inheriting from _transcript.pm.
 
 use strict;
-use Carp qw(cluck);
-use List::Util qw(min max);
 
 use base qw(EnsEMBL::Draw::GlyphSet::_transcript);
 
 sub max_label_rows { return $_[0]->my_config('max_label_rows') || 2; }
 
-sub only_attrib { 
-    return 'MANE_Plus_Clinical'; }
+sub only_attrib { return 'MANE_Plus_Clinical'; }
 
 1;

--- a/modules/EnsEMBL/Draw/GlyphSet/_mane_select.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/_mane_select.pm
@@ -22,14 +22,11 @@ package EnsEMBL::Draw::GlyphSet::_mane_select;
 ### Module for drawing the MANE Select track inheriting from _transcript.pm.
 
 use strict;
-use Carp qw(cluck);
-use List::Util qw(min max);
 
 use base qw(EnsEMBL::Draw::GlyphSet::_transcript);
 
 sub max_label_rows { return $_[0]->my_config('max_label_rows') || 2; }
 
-sub only_attrib { 
-    return 'MANE_Select'; }
+sub only_attrib { return 'MANE_Select'; }
 
 1;

--- a/modules/EnsEMBL/Draw/GlyphSet/_mane_select.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/_mane_select.pm
@@ -1,0 +1,35 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2021] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Draw::GlyphSet::_mane_select;
+
+### Module for drawing the MANE Select track inheriting from _transcript.pm.
+
+use strict;
+use Carp qw(cluck);
+use List::Util qw(min max);
+
+use base qw(EnsEMBL::Draw::GlyphSet::_transcript);
+
+sub max_label_rows { return $_[0]->my_config('max_label_rows') || 2; }
+
+sub only_attrib { 
+    return 'MANE_Select'; }
+
+1;

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -449,7 +449,6 @@ sub add_genes {
 
       my $menu = $self->get_node($t);
       next unless $menu;
-
       $self->_add_track($menu, $key, "${t}_${key}_$key2", $data->{$key2}, {
         glyphset  => ($t =~ /_/ ? '' : '_') . $type, # QUICK HACK
         colours   => $colours,
@@ -462,7 +461,7 @@ sub add_genes {
         ] : [
          'off',          'Off',
          'gene_nolabel', 'No labels',
-         'gene_label',   'With labels'
+	 'gene_label', 'With labels'
         ]
       });
       $flag = 1;
@@ -476,7 +475,7 @@ sub add_genes {
       display       => 'off',
       description   => 'The GENCODE set is the gene set for human and mouse. <a href="/Help/Glossary?id=500" class="popup">GENCODE Basic</a> is a subset of representative transcripts (splice variants).',
       sortable      => 1,
-      colours       => $self->species_defs->colour('gene'),
+      colours       => $colours,
       label_key     => '[biotype]',
       logic_names   => ['proj_ensembl',  'proj_ncrna', 'proj_havana_ig_gene', 'havana_ig_gene', 'ensembl_havana_ig_gene', 'proj_ensembl_havana_lincrna', 'proj_havana', 'ensembl', 'mt_genbank_import', 'ensembl_havana_lincrna', 'proj_ensembl_havana_ig_gene', 'ncrna', 'assembly_patch_ensembl', 'ensembl_havana_gene', 'ensembl_lincrna', 'proj_ensembl_havana_gene', 'havana'],
       renderers     =>  [
@@ -491,6 +490,45 @@ sub add_genes {
       ],
     });
   }
+  
+  # Adding MANE tracks (Only for Humans)
+  if( $self->species eq 'Homo_sapiens'){
+    
+    # Adding MANE Select track
+    $self->add_track('transcript', 'mane_select', "MANE Select Transcripts", '_mane_select', {
+      labelcaption  => "MANE Select Transcripts",
+      display       => 'transcript_label',
+      db            => "core",
+      description   => "The Matched Annotation from NCBI and EMBL-EBI is a collaboration between Ensembl/GENCODE and RefSeq. The MANE Select is a default transcript per human gene that is representative of biology, well-supported, expressed and highly-conserved. This transcript set matches GRCh38 and is 100% identical between RefSeq and Ensembl/GENCODE for 5' UTR, CDS, splicing and 3'UTR.",
+      sortable      => 1,
+      colours       => $colours,
+      label_key     => '[biotype]',
+      logic_names   => ['proj_ensembl',  'proj_ncrna', 'proj_havana_ig_gene', 'havana_ig_gene', 'ensembl_havana_ig_gene', 'proj_ensembl_havana_lincrna', 'proj_havana', 'ensembl', 'mt_genbank_import', 'ensembl_havana_lincrna', 'proj_ensembl_havana_ig_gene', 'ncrna', 'assembly_patch_ensembl', 'ensembl_havana_gene', 'ensembl_lincrna', 'proj_ensembl_havana_gene', 'havana', 'ensembl_havana_transcript'],
+      renderers     =>  [
+        'off',                     'Off',
+        'transcript_nolabel',      'Expanded without labels',
+        'transcript_label',        'Expanded with labels'
+      ],
+    });
+
+    # Adding MANE PLUS Clinical track
+    $self->add_track('transcript', 'mane_plus_clinical', "MANE Plus Clinical Transcripts", '_mane_plus_clinical', {
+      labelcaption  => "MANE Plus Clinical Transcripts",
+      display       => 'off',
+      db            => "core",
+      description   => "Transcripts in the MANE Plus Clinical set are additional transcripts per locus necessary to support clinical variant reporting, for example transcripts containing known Pathogenic or Likely Pathogenic clinical variants not reportable using the MANE Select set. Note there may be additional clinically relevant transcripts in the wider RefSeq and Ensembl/GENCODE sets but not yet in MANE.",
+      sortable      => 1,
+      colours       => $colours,
+      label_key     => '[biotype]',
+      logic_names   => ['proj_ensembl',  'proj_ncrna', 'proj_havana_ig_gene', 'havana_ig_gene', 'ensembl_havana_ig_gene', 'proj_ensembl_havana_lincrna', 'proj_havana', 'ensembl', 'mt_genbank_import', 'ensembl_havana_lincrna', 'proj_ensembl_havana_ig_gene', 'ncrna', 'assembly_patch_ensembl', 'ensembl_havana_gene', 'ensembl_lincrna', 'proj_ensembl_havana_gene', 'havana', 'ensembl_havana_transcript'],
+      renderers     =>  [
+        'off',                     'Off',
+        'transcript_nolabel',      'Expanded without labels',
+        'transcript_label',        'Expanded with labels'
+      ],
+    });
+  }
+
 
 
   # Need to add the gene menu track here

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -492,7 +492,7 @@ sub add_genes {
   }
   
   # Adding MANE tracks (Only for Humans)
-  if( $self->species eq 'Homo_sapiens'){
+  if($self->hub->species_defs->SEPARATE_MANE_TRACKS){
     
     # Adding MANE Select track
     $self->add_track('transcript', 'mane_select', "MANE Select Transcripts", '_mane_select', {


### PR DESCRIPTION
## Description
- Added separate tracks for MANE Select and MANE Plus Clinical Transcripts
- MANE Select transcript track will be on by default

## Views affected
http://wp-np2-1d.ebi.ac.uk:42229/Homo_sapiens/Location/View?db=core;g=ENSG00000053747;r=18:23689453-24689453;t=ENST00000313654

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6439

Related PR:
https://github.com/Ensembl/public-plugins/pull/510
