### PR TITLE
Fix summary redirect issue in variant table.

### DIFF
--- a/modules/EnsEMBL/Web/Component/VariationTable.pm
+++ b/modules/EnsEMBL/Web/Component/VariationTable.pm
@@ -344,7 +344,7 @@ sub make_table {
     helptip => 'Variant identifier',
     link_url => {
       type   => 'Variation',
-      action => 'Summary',
+      action => 'Explore',
       vf     => ["vf"],
       v      => undef # remove the 'v' param from the links if already present
     }


### PR DESCRIPTION

## Description

Metazoa variant table page the redirect from summary page to explore wasn't working.

## Views affected

[SandBox](http://wp-np2-1e:8785/Anopheles_gambiae/Gene/Variation_Gene/Table?db=core;g=AGAP029451;r=2R:11467344-11496378;source=VBP0000002;v=tmp_2R_11462677_C_T;vdb=variation;vf=52783028)
## Possible complications
- Other variant tables might have the same issue.
- The explore page might not work in some websites.
## Merge conflicts


## Related JIRA Issues (EBI developers only)

Jira ticket: [ENSWEB-6539](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6539)
Jira ticket: [ENSWEB-6502](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6502)
