### PR TITLE
Fix missing orthologues issue

### DIFF
--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -819,7 +819,7 @@ sub fetch_homology_species_hash {
 
     ## In case of data bugs, make sure this is a genuine node
     my $species_tree_node = eval { $homology->species_tree_node(); };
-    my $species_url = $name_lookup->{$genome_db_name};
+    my $species_url = $name_lookup->{$genome_db_name} || $genome_db_name;
 
     if ($species_tree_node) {
       push @{$homologues{$species_url}}, [ $target_member, $homology->description, $species_tree_node, $query_perc_id, $target_perc_id, $dnds_ratio, $homology->{_gene_tree_node_id}, $homology->dbID, $goc_score, $goc_threshold, $wgac, $wga_threshold, $highconfidence ];    


### PR DESCRIPTION

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6496

## Description
This PR is to fix the issue mentioned in the ticket for vertebrates.

For non-vertebrates: https://github.com/EnsemblGenomes/eg-web-common/pull/95


## Views affected
http://wp-np2-1d.ebi.ac.uk:42228/Arabidopsis_thaliana/Gene/Compara_Ortholog?db=core;g=AT4G30560;r=4:14926834-14930355;t=AT4G30560.1

NOTE: Once this gets merged, I will cherry-pick the changes on to 105
