### PR TITLE
Fix xss caused by unsanitised url path parameters

### DIFF
--- a/modules/EnsEMBL/Web/Apache/SpeciesHandler.pm
+++ b/modules/EnsEMBL/Web/Apache/SpeciesHandler.pm
@@ -23,7 +23,7 @@ use strict;
 use warnings;
 
 use Apache2::Const qw(:common :http :methods);
-use HTML::Entities;
+use HTML::Entities qw(encode_entities);
 
 use EnsEMBL::Web::Exceptions;
 use EnsEMBL::Web::OldLinks qw(get_redirect);
@@ -80,7 +80,7 @@ sub handler {
   my $species         = $r->subprocess_env('ENSEMBL_SPECIES');
   my $path            = $r->subprocess_env('ENSEMBL_PATH');
   my $query           = $r->subprocess_env('ENSEMBL_QUERY');
-  my @path_segments   = map { HTML::Entities::encode($_) } grep $_, split '/', $path;
+  my @path_segments   = map { encode_entities($_) } grep $_, split '/', $path;
 
   # handle redirects
   if (my $redirect = get_redirect_uri($species, \@path_segments, $query)) {

--- a/modules/EnsEMBL/Web/Apache/SpeciesHandler.pm
+++ b/modules/EnsEMBL/Web/Apache/SpeciesHandler.pm
@@ -23,6 +23,7 @@ use strict;
 use warnings;
 
 use Apache2::Const qw(:common :http :methods);
+use HTML::Entities;
 
 use EnsEMBL::Web::Exceptions;
 use EnsEMBL::Web::OldLinks qw(get_redirect);
@@ -79,7 +80,7 @@ sub handler {
   my $species         = $r->subprocess_env('ENSEMBL_SPECIES');
   my $path            = $r->subprocess_env('ENSEMBL_PATH');
   my $query           = $r->subprocess_env('ENSEMBL_QUERY');
-  my @path_segments   = grep $_, split '/', $path;
+  my @path_segments   = map { HTML::Entities::encode($_) } grep $_, split '/', $path;
 
   # handle redirects
   if (my $redirect = get_redirect_uri($species, \@path_segments, $query)) {


### PR DESCRIPTION
## Description
Ensembl code does not sanitise url path parameters, which can then me used on the server to inject malignant code into the html of the document.

See [example in production](https://www.ensembl.org/Homo_sapiens/Info/Index/%22%3E%3Cimg%20src%3Dx%20onerror%3Dconfirm(document.domain)%3E)

This PR adds the sanitisation of url path in the relevant Apache handler following one of the suggestions from [this article](https://www.perl.com/pub/2002/02/20/css.html).

## Sandbox url
[link](http://wp-np2-1e.ebi.ac.uk:8410/Homo_sapiens/Info/Index/%22%3E%3Cimg%20src%3Dx%20onerror%3Dconfirm(document.domain)%3E)

## Views affected
All pages that are built using the Legacy.pm template.

## Possible complications
🤷‍♂️ 

Might potentially break any view; but from what I checked (e.g. the Search page), the site is holding up fine.

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6493