### PR TITLE
ENSWEB-6564 Store GD::Simple in PNG format.

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet.pm
@@ -925,8 +925,8 @@ sub get_gd {
   my $ptsize   = shift || 10;
   my $font_key = "${font}--${ptsize}"; 
   
-  return $cache{$font_key} if exists $cache{$font_key};
-  
+  return GD::Simple->newFromPngData($cache{$font_key}) if exists $cache{$font_key};
+
   my $fontpath = $self->{'config'}->species_defs->get_font_path."$font.ttf";
   my $gd       = GD::Simple->new(400, 400);
   
@@ -949,7 +949,8 @@ sub get_gd {
   
   warn $@ if $@;
 
-  return $cache{$font_key} = $gd; # Update font cache
+  $cache{$font_key} = $gd->png; # Update font cache using PNG format
+  return $gd;
 }
 
 sub bp_to_nearest_unit {

--- a/modules/EnsEMBL/Draw/Utils/Text.pm
+++ b/modules/EnsEMBL/Draw/Utils/Text.pm
@@ -133,13 +133,11 @@ sub _get_gd {
   my $font     = shift || 'Arial';
   my $ptsize   = shift || 10;
   my $font_key = "${font}--${ptsize}";
-
-  my $gd = $cache->get($font_key);
-
-  return $gd if $gd;
-
+ 
+  return GD::Simple->newFromPngData($cache->get($font_key)) if ($cache->get($font_key));
+ 
   my $fontpath = $image_config->species_defs->get_font_path."$font.ttf";
-  $gd = GD::Simple->new(400, 400);
+  my $gd = GD::Simple->new(400, 400);
 
   eval {
     if (-e $fontpath) {
@@ -160,7 +158,7 @@ sub _get_gd {
 
   warn $@ if $@;
 
-  $cache->set($font_key, $gd); # Update font cache
+  $cache->set($font_key, $gd->png); # Update font cache using PNG format
 
   return $gd;
 }


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6564

The upstream LibGD 2.3.3 disabled GD and GD2 format but the Perl wrapper GD::Simple still uses it as an internal format. We store the unsupported format in cache but can't read it back.

The PR changes GD::Simple to use PNG format.

Working on http://test.ensembl.org/Homo_sapiens/Location/View?r=8:26291508-26372680