### PR TITLE
Update for IntAct plugin for web VEP

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -250,6 +250,7 @@ MIM                         = http://www.omim.org/###ID###
 MIM_GENE                    = http://www.omim.org/###ID###
 MIM_MORBID                  = http://www.omim.org/###ID###
 ZFIN_ID                     = http://zfin.org/###ID###
+INTACT			    = https://www.ebi.ac.uk/intact/details/interaction/###ID###
 
 ## Core team
 APPRIS                      = http://appris.bioinfo.cnio.es/


### PR DESCRIPTION
## Requirements

IntAct is a new VEP plugin that reports variants effect on molecular interaction. We will add this plugin in release 107 to web VEP.

## Description

We want to put external links that will navigate user to relevant IntAct page where he/she can get more information about the molecular interaction. Hence, we wish to add url template to add the external links which will be used by IntAct (through public plugins - see https://github.com/Ensembl/public-plugins/pull/523)

## Views affected

IntAct interaction ac column in web VEP result with IntAct plugin turned on.

sandbox url - http://wp-np2-11.ebi.ac.uk:7070/Tools/VEP 
test data - 
```
1       5890912 297808  C       T
1       9975672 982555  C       T
```

## Possible complications

Nothing comes to mind.

## Merge conflicts

tested in sandbox.

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-3250
