### PR TITLE
FOR 107: add specific regulatory feature lines by type

### DIFF
--- a/conf/ini-files/COLOUR.ini
+++ b/conf/ini-files/COLOUR.ini
@@ -574,19 +574,19 @@ _inherit            = fg_regulatory_features
 
 [fg_regulatory_features]
 ctcf                = 40E0D0    CTCF
-enhancer            = FACA00    Enhancer
-heterochromatin     = grey40    Heterochromatin
-repressed           = 7F7F7F    Repressed/Low Activity
-open_chromatin      = grey85    Open Chromatin
-unclassified        = grey      Unclassified
-tf_binding_site     = plum3     Transcription Factor Binding Site
-region              = 00B050    Predicted Transcribed Region
-weak                = FFFC04    Predicted Weak enhancer/Cis-reg element
-promoter_flanking   = ff6969    Promoter Flank
-promoter            = FF0000    Promoter
-poised              = C000BD    Poised
-na                  = grey90    N/A
-repressed           = 7F7F7F    Repressed
+enhancer            = FACA00    enhancer
+heterochromatin     = grey40    heterochromatin
+repressed           = 7F7F7F    repressed/low activity
+open_chromatin      = grey85    open chromatin
+unclassified        = grey      unclassified
+tf_binding          = plum3     transcription factor binding
+region              = 00B050    predicted transcribed region
+weak                = FFFC04    predicted weak enhancer/cis-reg element
+promoter_flanking   = ff6969    promoter flank
+promoter            = FF0000    promoter
+poised              = C000BD    poised
+na                  = grey90    n/a
+repressed           = 7F7F7F    repressed
 
 [ctcf]
 default             = blue

--- a/modules/EnsEMBL/Draw/GlyphSet/fg_regulatory_features.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/fg_regulatory_features.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2022] EMBL-European Bioinformatics Institute
+Copyright [2016-2018] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -100,12 +100,12 @@ sub get_data {
       elsif ($activity eq 'inactive') { ## Only show one generic entry for all inactive features
         $legend_params->{'stripe'}  = $patterncolour;
         $legend_params->{'colour'}  = 'grey80';
-        $legend_params->{'legend'}  = 'Activity in epigenome: Inactive';
+        $legend_params->{'legend'}  = 'activity in epigenome: inactive';
         $activities->{'inactive'}   = $legend_params;
       }
       else {
-        my $label = 'Activity in epigenome: ';
-        $label .= $_ eq 'na' ? 'Insufficient evidence' : ucfirst($activity);
+        my $label = 'activity in epigenome: ';
+        $label .= $_ eq 'na' ? 'insufficient evidence' : $activity;
         $legend_params->{'legend'} = $label; 
         $activities->{$activity} = $legend_params;
       }
@@ -136,8 +136,8 @@ sub get_data {
       my ($extra_blocks, $flank_colour, $has_motifs) = $self->get_structure($rf, $type, $activity, $appearance);
     
       ## Extra legend items as required
-      $entries->{'promoter_flanking'} = {'legend' => 'Promoter Flank', 'colour' => $flank_colour} if $flank_colour;
-      $entries->{'x_motif'} = {'legend' => 'Motif feature', 'colour' => 'black', 'width' => 4} if $has_motifs;
+      $entries->{'promoter_flanking'} = {'legend' => 'promoter flank', 'colour' => 'ff6969'} if $flank_colour;
+      $entries->{'x_motif'} = {'legend' => 'motif feature', 'colour' => 'black', 'width' => 4} if $has_motifs;
       $feature->{extra_blocks}  = $extra_blocks;
     }
 
@@ -245,14 +245,14 @@ sub colour_key {
 
   if($type =~ /CTCF/i) {
     $type = 'ctcf';
-  } elsif($type =~ /Enhancer/i) {
-    $type = 'enhancer';
+  } elsif($type =~ /Enhancer II/i) {
+    $type = 'promoter_flanking';
   } elsif($type =~ /Open chromatin/i) {
     $type = 'open_chromatin';
-  } elsif($type =~ /TF binding site/i) {
-    $type = 'tf_binding_site';
-  } elsif($type =~ /Promoter Flanking Region/i) {
-    $type = 'promoter_flanking';
+  } elsif($type =~ /TF binding/i) {
+    $type = 'tf_binding';
+  } elsif($type =~ /Enhancer/i) {
+    $type = 'enhancer';
   } elsif($type =~ /Promoter/i) {
     $type = 'promoter';
   } else  {

--- a/modules/EnsEMBL/Draw/Style/Feature.pm
+++ b/modules/EnsEMBL/Draw/Style/Feature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2022] EMBL-European Bioinformatics Institute
+Copyright [2016-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ no warnings 'uninitialized';
 
 use POSIX qw(ceil);
 use List::Util qw(max);
+use List::MoreUtils qw(any);
 
 use EnsEMBL::Draw::Utils::Bump qw(mr_bump do_bump);
 
@@ -143,6 +144,19 @@ sub create_glyphs {
     #$Data::Dumper::Sortkeys = 1;
     #$Data::Dumper::Maxdepth = 2;
     #warn Dumper(\@features);
+    
+    ###################### VARS - REG FEATURES #########################
+    my @reg_features = (
+      'promoter',
+      'enhancer',
+      'open chromatin',
+      'CTCF',
+      'transcription factor binding'
+    );
+    my @reg_features_pos_values = (1, 2, 2, 3, 2);
+    my %reg_features_bump_rows;
+    @reg_features_bump_rows{@reg_features} = @reg_features_pos_values;
+    #####################################################################
 
     ## SECOND LOOP - draw features row by row
     my $count = 0;
@@ -153,7 +167,8 @@ sub create_glyphs {
         my $label_row   = 0;
         ## Work out if we're bumping the whole feature or just the label
         if ($bumped) {
-          my $bump = $track_config->get('flip_vertical') ? $bump_rows - $feature->{'_bump'} : $feature->{'_bump'};
+          #my $bump = $track_config->get('flip_vertical') ? $bump_rows - $feature->{'_bump'} : $feature->{'_bump'};
+          my $bump = $reg_features_bump_rows{$feature->{'label'}} if any {$_ eq $feature->{'label'}} @reg_features;
           $label_row   = $bump unless $bumped eq 'features_only';
           $feature_row = $bump unless $bumped eq 'labels_only';       
         }

--- a/modules/EnsEMBL/Draw/Style/Feature.pm
+++ b/modules/EnsEMBL/Draw/Style/Feature.pm
@@ -167,8 +167,8 @@ sub create_glyphs {
         my $label_row   = 0;
         ## Work out if we're bumping the whole feature or just the label
         if ($bumped) {
-          #my $bump = $track_config->get('flip_vertical') ? $bump_rows - $feature->{'_bump'} : $feature->{'_bump'};
-          my $bump = $reg_features_bump_rows{$feature->{'label'}} if any {$_ eq $feature->{'label'}} @reg_features;
+          my $bump = $track_config->get('flip_vertical') ? $bump_rows - $feature->{'_bump'} : $feature->{'_bump'};
+          $bump = $reg_features_bump_rows{$feature->{'label'}} if any {$_ eq $feature->{'label'}} @reg_features;
           $label_row   = $bump unless $bumped eq 'features_only';
           $feature_row = $bump unless $bumped eq 'labels_only';       
         }


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

Add specific regulatory feature lines by type and switch Regulatory features legends to lower case.

E.g.
	•	promoter: 1st line;
	•	enhancer/open chromatin/transcription factor binding: 2nd line;
	•	CTCF: 3rd line.

Discussed with @ens-ap5 

## Views affected

Regulatory build track.
http://wp-np2-25.ebi.ac.uk:6020/Homo_sapiens/Location/View?r=8%3A26291508-26372680

## Possible complications


## Merge conflicts

## Related JIRA Issues (EBI developers only)

