### PR TITLE
Do not show %GC track by default

### DIFF
--- a/modules/EnsEMBL/Web/ImageConfig/contigviewbottom.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/contigviewbottom.pm
@@ -291,8 +291,6 @@ sub init_cacheable {
     [ 'codons',    'Start/stop codons',   'codons',   { display => 'off',    strand => 'b', description => $desc{'codons'},    colourset => 'codons',   threshold => 50                   }],
   );
 
-  $self->add_track('decorations', 'gc_plot', '%GC', 'gcplot', { display => 'normal',  strand => 'r', description => 'Shows percentage of Gs & Cs in region', sortable => 1 });
-
   # Add in additional tracks
   $self->load_tracks;
   $self->load_configured_trackhubs;

--- a/modules/EnsEMBL/Web/ImageConfig/contigviewbottom.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/contigviewbottom.pm
@@ -291,6 +291,8 @@ sub init_cacheable {
     [ 'codons',    'Start/stop codons',   'codons',   { display => 'off',    strand => 'b', description => $desc{'codons'},    colourset => 'codons',   threshold => 50                   }],
   );
 
+  $self->add_track('decorations', 'gc_plot', '%GC', 'gcplot', { display => 'off', strand => 'r', description => 'Shows percentage of Gs & Cs in region', sortable => 1 });
+
   # Add in additional tracks
   $self->load_tracks;
   $self->load_configured_trackhubs;


### PR DESCRIPTION
## Description
Stop showing %GC track by default in Region in detail.

Release version: 107

Sandbox URL: http://wp-np2-1e.ebi.ac.uk:8320/Homo_sapiens/Location/View?db=core;g=ENSG00000139618;r=13:32315086-32400268

## Views affected
Region in detail

## Related JIRA Issues (EBI developers only)
[ENSWEB-6556](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6556)