### PR TITLE
Add text to image header configuration icons

### DIFF
--- a/htdocs/components/81_images_dynamic.css
+++ b/htdocs/components/81_images_dynamic.css
@@ -247,12 +247,13 @@ div.boundaries_wrapper div.boundaries_panning ul          { overflow: hidden; }
 
 /* Icon toolbar for dynamic images */
 
-div.image_toolbar                 { background-color: [[MAIN_DARK]]; color: [[WHITE]]; height: 16px; padding: 4px 0; overflow: hidden; }
+div.image_toolbar                 { background-color: [[MAIN_DARK]]; color: [[WHITE]]; height: 16px; padding: 2px 0; overflow: hidden; }
 div.image_toolbar.top             { border-bottom: 1px solid [[MEDIUM_GREY]]; }
 div.image_toolbar.bottom          { border-top: 1px solid [[MEDIUM_GREY]]; }
-div.image_toolbar a               { float: left; width: 16px; height: 16px; display: block; margin: -2px 2px 2px; border: [[MAIN_DARK]] solid 2px; border-radius: 2px; cursor: pointer; }
+div.image_toolbar a               { float: left; height: 16px; display: block; border-right: 1px solid white; cursor: pointer; background-position: 6px; background-repeat: no-repeat; color: white; padding: 0 10px 0 28px; text-decoration: none; font-size: 12px; line-height: 1.4; }
+div.image_toolbar a:last-child    { border-right: none; }
 div.image_toolbar a:hover,
-div.image_toolbar a.selected      { border-color: [[MAIN_V_DARK]]; background-color: [[MAIN_V_DARK]]; }
+div.image_toolbar a.selected      { background-color: [[MAIN_V_DARK]]; }
 
 div.image_toolbar a.config        { background-image: url(/i/16/rev/setting.png);       }
 div.image_toolbar a.data          { background-image: url(/i/16/rev/page-user.png);     }

--- a/modules/EnsEMBL/Web/Document/Image.pm
+++ b/modules/EnsEMBL/Web/Document/Image.pm
@@ -148,11 +148,12 @@ sub _render_toolbars {
 
   my $toolbar;
   foreach my $icon (@$icons) {
-    $toolbar .= sprintf('<a href="%s" class="%s" title="%s" rel="%s"></a>',
+    $toolbar .= sprintf('<a href="%s" class="%s" title="%s" rel="%s">%s</a>',
                           $icon->{'href'} || '#',
                           $icon->{'class'} || '',
                           $icon_mappings->{$icon->{'icon_key'}}{'title'} || '',
                           $icon->{'rel'} || '',
+                          $icon->{'text'} || ''
                         );
   }
 
@@ -179,6 +180,7 @@ sub add_config_icon {
           'href'      => $config_url,
           'class'     => 'config modal_link force',
           'icon_key'  => 'config',
+          'text'      => 'Add/remove tracks',
           'rel'       => 'modal_config_'.lc($component_id),
           };
 }
@@ -196,6 +198,7 @@ sub add_userdata_icon {
           'href'      => $data_url,
           'class'     => 'data modal_link',
           'icon_key'  => 'userdata',
+          'text'      => 'Custom tracks',
           'rel'       => 'modal_user_data',
           };
 }
@@ -210,6 +213,7 @@ sub add_share_icon {
           'href'      => $share_url,
           'class'     => 'share popup',
           'icon_key'  => 'share',
+          'text'      => 'Share'
           };
 }
 
@@ -239,6 +243,7 @@ sub add_export_icon {
           'href'      => $hub->url($params),
           'class'     => 'download modal_link',
           'icon_key'  => 'download',
+          'text'      => 'Export'
           };
 }
 
@@ -251,6 +256,7 @@ sub add_resize_icon {
           'href'      => $hub->url,
           'class'     => 'resize popup',
           'icon_key'  => 'resize',
+          'text'      => 'Resize image'
           };
 }
 
@@ -307,6 +313,7 @@ sub add_image_export_icon {
           'href'      => $hub->url($params),
           'class'     => 'export modal_link '.$self->{'export'},
           'icon_key'  => 'image',
+          'text'      => 'Export image'
           };
 }
 
@@ -321,6 +328,7 @@ sub add_config_reset_icon {
           'href'      => $url,
           'class'     => 'config-reset _reset',
           'icon_key'  => 'reset_config',
+          'text'      => 'Reset configuration',
           };
 }
 sub add_order_reset_icon {
@@ -333,6 +341,7 @@ sub add_order_reset_icon {
           'href'      => $url,
           'class'     => 'order-reset _reset',
           'icon_key'  => 'reset_order',
+          'text'      => 'Reset track order'
           };
 }
 


### PR DESCRIPTION
## Description
Added text to image header icons in this repo. There is [a separate PR in `public-plugins`](https://github.com/Ensembl/public-plugins/pull/541) to add text to `genoverse_switch`.

## Release version
e107

## Sandbox link
http://wp-np2-1e.ebi.ac.uk:8320/Homo_sapiens/Location/View?db=core;g=ENSG00000139618;r=13:32315086-32400268

## Views affected
Configuration headers/toolbars in Region in detail and Gene pages

## Related JIRA Issues (EBI developers only)
[ENSWEB-6553](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6553)

