### PR TITLE
Add info on artefecturally duplicated genes to gene summary

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/GeneSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GeneSummary.pm
@@ -256,6 +256,19 @@ sub content {
   my $type = $object->gene_type;
   $table->add_row('Gene type', $type) if $type;
 
+  if ($gene->biotype =~ /artifact/) {
+    foreach my $attr (@{$gene->get_all_Attributes}) {
+      if ($attr->code eq 'artef_dupl') {
+        my $label = 'Artefactural duplication';
+        my $prepended_str_in_value = $label . '. ';
+        my $text = $attr->value;
+        $text =~ s/$prepended_str_in_value//g;
+
+        $table->add_row($label, $text);
+      }
+    }
+  }
+
   eval {
     # add prediction method
     my $label = 'Annotation method';


### PR DESCRIPTION
## Description
Added a new row to gene summary info section for artefecturally duplicated genes.

## Release version
e107

## Sandbox link
http://wp-np2-1e.ebi.ac.uk:8320/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000274559;r=21:5972924-5973383;t=ENST00000464664

## Views affected
Gene summary page

## Related JIRA Issues (EBI developers only)
[ENSWEB-6492](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6492)

