### PR TITLE
FOR 108: remove motif dependancy on peak table

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/fg_regulatory_features.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/fg_regulatory_features.pm
@@ -233,8 +233,8 @@ sub get_structure {
 
     ## Get peaks that overlap this epigenome
     foreach (@$mfs) {
-      my $peaks = $_->get_all_overlapping_Peaks_by_Epigenome($epigenome);
-      if (scalar @{$peaks||[]}) {
+      my $peak_callings = $_->get_overlapping_Peak_Callings_by_Epigenome_and_Regulatory_Feature($epigenome, $f);
+      if (scalar @{$peak_callings||[]}) {
         push @$extra_blocks, {
                               start   => $_->start - $slice->start, 
                               end     => $_->end - $slice->start,

--- a/modules/EnsEMBL/Web/ZMenu/RegulationBase.pm
+++ b/modules/EnsEMBL/Web/ZMenu/RegulationBase.pm
@@ -48,8 +48,8 @@ sub get_motif_features_by_epigenome {
   my $motifs = {};
 
   foreach my $mf (@motif_features) {
-    my $peak = $mf->get_all_overlapping_Peaks_by_Epigenome($cell_line);
-    if ($peak) {
+    my $peak_callings = $mf->get_overlapping_Peak_Callings_by_Epigenome_and_Regulatory_Feature($cell_line, $reg_feat);
+    if ($peak_callings) {
       my $mf_info = $self->_format_mf_info($mf);
       $motifs->{$mf->start .':'. $mf->end} = $mf_info if $mf_info;
     }


### PR DESCRIPTION
## Description

To contemplate the ["Peak files viewable in Ensembl browser"](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6558) task, the motif dependency on peaks should be removed mainly by adapting the code to switch the use of the motif_feature_peak table to the motif_feature_regulatory_feature.

This PR proposes the updates in the webcore repo to contemplate the current funcgen PERL API in order to achieve this removal.

## Views affected

- Regulation Peak tracks.

## Possible complications

None.

## Merge conflicts

None.

## Related JIRA Issues (EBI developers only)

- [ENSWEB-6558](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6558)
- [ENSREGULATION-1419](https://www.ebi.ac.uk/panda/jira/browse/ENSREGULATION-1419)
