### PR TITLE
Remove link to old ENCODE tutorial

### DIFF
--- a/modules/EnsEMBL/Web/Component/Info/HomePage.pm
+++ b/modules/EnsEMBL/Web/Component/Info/HomePage.pm
@@ -377,9 +377,7 @@ sub funcgen_text {
         "Go to regulatory feature $sample_data->{'REGULATION_TEXT'}", 'regulation', 'Example regulatory feature'
       ),
       
-      $species eq 'Homo_sapiens' ? '
-        <a class="nodeco _ht _ht_track" href="/info/website/tutorials/encode.html" title="Find out about ENCODE data"><img src="/img/ENCODE_logo.jpg" class="bordered" /><span>ENCODE data in Ensembl</span></a>
-      ' : '',
+      '',
 
       sprintf($self->{'icon'}, 'info'), $species_defs->ENSEMBL_SITETYPE,
       

--- a/modules/EnsEMBL/Web/Component/Info/HomePage.pm
+++ b/modules/EnsEMBL/Web/Component/Info/HomePage.pm
@@ -363,7 +363,6 @@ sub funcgen_text {
     return sprintf('
       <div class="homepage-icon">
         %s
-        %s
       </div>
       <h2>Regulation</h2>
       <p><strong>What can I find?</strong> DNA methylation, transcription factor binding sites, histone modifications, and regulatory features such as enhancers and repressors, and microarray annotations.</p>
@@ -377,8 +376,6 @@ sub funcgen_text {
         "Go to regulatory feature $sample_data->{'REGULATION_TEXT'}", 'regulation', 'Example regulatory feature'
       ),
       
-      '',
-
       sprintf($self->{'icon'}, 'info'), $species_defs->ENSEMBL_SITETYPE,
       
       $hub->url({'type' => 'Experiment', 'action' => 'Sources', 'ex' => 'all'}), sprintf($self->{'icon'}, 'info'), 


### PR DESCRIPTION
## Description

This change is for e!107. It removes a link in the Regulation pane on the [human overview page](https://www.ensembl.org/Homo_sapiens/Info/Index). 

The link refers to an old [ENCODE tutorial](https://www.ensembl.org/info/website/tutorials/encode.html) in public-plugins. 

## Views affected

[Sandbox view](http://wp-np2-11.ebi.ac.uk:6010/Homo_sapiens/Info/Index)

## Possible complications

The encode.html page can be removed from public-plugins if there are no further dependencies.

## Merge conflicts

No known conflicts.

## Related JIRA Issues (EBI developers only)

None. The change has been approved by Outreach.