### PR TITLE
Change incl to excl readthrough for protein coding gene counts

### DIFF
--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -189,7 +189,7 @@ sub _add_gene_counts {
   my ($self,$genome_container,$sd,$cols,$options,$tail,$our_type) = @_;
 
   my @order           = qw(coding_cnt noncoding_cnt noncoding_cnt/s noncoding_cnt/l noncoding_cnt/m pseudogene_cnt transcript);
-  my @suffixes        = (['','~'], ['r',' (incl ~ '.glossary_helptip($self->hub, 'readthrough', 'Readthrough').')']);
+  my @suffixes        = (['','~'], ['r',' (excl ~ '.glossary_helptip($self->hub, 'readthrough', 'Readthrough').')']);
   my $glossary_lookup = {
     'coding_cnt'        => 'Protein coding',
     'noncoding_cnt/s'   => 'Small non coding gene',


### PR DESCRIPTION
## Description

Change `incl readthrough` to `excl readthrough` for protein coding gene counts.

## Release version

107

## Views affected

Species info (annotation) page

## Related JIRA Issues (EBI developers only)

[ENSWEB-6618](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6618)

## Sandbox link

http://wp-np2-1e.ebi.ac.uk:8320/Homo_sapiens/Info/Annotation