### PR TITLE
Fix the highlighted gene ID in Gene tree

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -181,23 +181,18 @@ sub content {
 
   # store g1 param in a different param as $highlight_gene can be undef if highlighting is disabled
   my $gene_to_highlight = $hub->param('g1');
-  my $current_gene = $hub->param('g'); # stable ID of current gene
+  my $current_gene_display_name = $gene->Obj->display_xref->display_id;
   my $highlight_gene_display_label;  
      
   my $lookup = $hub->species_defs->prodnames_to_urls_lookup; 
   foreach my $this_leaf (@$leaves) {
     if ($gene_to_highlight && $this_leaf->gene_member->stable_id eq $gene_to_highlight) {
-      $highlight_gene_display_label = $this_leaf->gene_member->display_label;
+      $highlight_gene_display_label = $this_leaf->gene_member->display_label || $current_gene_display_name;
       $highlight_species            = $lookup->{$this_leaf->gene_member->genome_db->name};
       $highlight_species_name       = $this_leaf->gene_member->genome_db->display_name;
       $highlight_genome_db_id       = $this_leaf->gene_member->genome_db_id;
       last;
     }
-  }
-
-  if ($highlight_gene_display_label eq undef) {
-    # $highlight_gene_display_label = $gene->display_name;
-    $highlight_gene_display_label = $current_gene;
   }
 
   # check if highlight ancestor (anc param) is available or not

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -181,8 +181,13 @@ sub content {
 
   # store g1 param in a different param as $highlight_gene can be undef if highlighting is disabled
   my $gene_to_highlight = $hub->param('g1');
-  my $current_gene_display_name = $gene->Obj->display_xref->display_id;
-  my $highlight_gene_display_label;  
+  my ($current_gene_display_name, $highlight_gene_display_label);
+
+  if (defined $gene->Obj->display_xref) {
+    $current_gene_display_name = $gene->Obj->display_xref->display_id;
+  } else {
+    $current_gene_display_name = $hub->param('g') 
+  } 
      
   my $lookup = $hub->species_defs->prodnames_to_urls_lookup; 
   foreach my $this_leaf (@$leaves) {

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -181,17 +181,23 @@ sub content {
 
   # store g1 param in a different param as $highlight_gene can be undef if highlighting is disabled
   my $gene_to_highlight = $hub->param('g1');
+  my $current_gene = $hub->param('g'); # stable ID of current gene
   my $highlight_gene_display_label;  
      
   my $lookup = $hub->species_defs->prodnames_to_urls_lookup; 
   foreach my $this_leaf (@$leaves) {
     if ($gene_to_highlight && $this_leaf->gene_member->stable_id eq $gene_to_highlight) {
-      $highlight_gene_display_label = $this_leaf->gene_member->display_label || $gene_to_highlight;
+      $highlight_gene_display_label = $this_leaf->gene_member->display_label;
       $highlight_species            = $lookup->{$this_leaf->gene_member->genome_db->name};
       $highlight_species_name       = $this_leaf->gene_member->genome_db->display_name;
       $highlight_genome_db_id       = $this_leaf->gene_member->genome_db_id;
       last;
     }
+  }
+
+  if ($highlight_gene_display_label eq undef) {
+    # $highlight_gene_display_label = $gene->display_name;
+    $highlight_gene_display_label = $current_gene;
   }
 
   # check if highlight ancestor (anc param) is available or not


### PR DESCRIPTION
## Description

The highlighted gene ID is not displayed correctly in the Highlighted genes info box. This happens when the orthologue gene ID does not have a display name. The reason behind this was that the code checked if the display name of the orthologue exists and when it fails would display the stable ID of the orthologue instead of the current gene.

The changes in this PR will show the stable ID of the current gene when this check fails. It would be ideal to show the display name instead, but I couldn't figure out how to do it as everything I tried ended up breaking the code.

**Sandbox link:** http://wp-np2-1e.ebi.ac.uk:8330/Homo_sapiens/Gene/Compara_Tree?anc=46819155;db=core;g=ENSG00000133392;g1=ENSEEUG00000000659;r=16:15703135-15857028

**For comparison the staging link is:** http://staging.ensembl.org/Homo_sapiens/Gene/Compara_Tree?anc=46819155;db=core;g=ENSG00000133392;g1=ENSEEUG00000000659;r=16:15703135-15857028

## Views affected

Gene tree -> Highlighted gene info box

## Related JIRA Issues (EBI developers only)

[ENSWEB-6591](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6591)