### PR TITLE
Change the inheritance of the Transcript component back to Component::Shared

### DIFF
--- a/modules/EnsEMBL/Web/Component/Transcript.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript.pm
@@ -21,7 +21,7 @@ package EnsEMBL::Web::Component::Transcript;
 
 use strict;
 
-use parent qw(EnsEMBL::Web::Component);
+use parent qw(EnsEMBL::Web::Component::Shared);
 
 ## No sub stable_id   <- uses Gene's stable_id
 ## No sub name        <- uses Gene's name


### PR DESCRIPTION
Reverts a change made in https://github.com/Ensembl/ensembl-webcode/pull/894 to fix the following bug:

![image](https://user-images.githubusercontent.com/6834224/176733102-2c8f4ee4-9f8f-4f71-bf92-363fc85ec85d.png)


**Cause:** Transcript's child `EnsEMBL::Web::Component::Transcript::SimilarityMatches`, uses the `get_matches` method that is declared on `Component::Shared`.