### PR TITLE
Bugfix/off by one error

### DIFF
--- a/modules/EnsEMBL/Draw/Style/Feature/MultiBlocks.pm
+++ b/modules/EnsEMBL/Draw/Style/Feature/MultiBlocks.pm
@@ -60,7 +60,7 @@ sub draw_feature {
   my $x                     = $feature->{'start'} - 1;
   $x                        = 0 if $x < 0;
   $params{'x'}              = $x;
-  $params{'width'}          = $position->{'width'};
+  $params{'width'}          = $position->{'width'} - 1;
   $params{'colour'}         = $feature->{'colour'};
   $params{'bordercolour'}   = $feature->{'bordercolour'};
   $params{'pattern'}        = $feature->{'pattern'};

--- a/modules/EnsEMBL/Draw/Style/Feature/MultiBlocks.pm
+++ b/modules/EnsEMBL/Draw/Style/Feature/MultiBlocks.pm
@@ -57,7 +57,7 @@ sub draw_feature {
 
   ## Draw main feature 
   my %params                = %defaults; 
-  my $x                     = $feature->{'start'};
+  my $x                     = $feature->{'start'} - 1;
   $x                        = 0 if $x < 0;
   $params{'x'}              = $x;
   $params{'width'}          = $position->{'width'};


### PR DESCRIPTION
## Description

The regulatory build track starts one off to the left. This has been a longstanding bug and also affected matrix-driven regulation track. I've applied the fix @ens-ap5 recommended for this bug.

### Sandbox URL

http://wp-np2-1e.ebi.ac.uk:8310/Homo_sapiens/Location/View?db=core;g=ENSG00000221914;r=1:54961569-54961649

## Related JIRA Issues (EBI developers only)

[ENSWEB-6542](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6542)

## Views affected

Region in detail -> Regulatory build track

Also affects matrix driven regulation tracks.