### PR TITLE
Fix id history converter assembly label

### DIFF
--- a/htdocs/components/00_jquery_selecttotoggle.js
+++ b/htdocs/components/00_jquery_selecttotoggle.js
@@ -32,7 +32,10 @@
       // go through all the selectors in the toggleMap and hide them except the one that corresponds to current element's value
       for (var val in toggleMap) {
         if (val !== currValue) {
-          wrapper.find(toggleMap[val]).hide().removeAttr('checked').filter('option').each(function() { // if hiding an option element, also disable it to make it work in webkit
+          var elemClass = '[class="' + toggleMap[val] + '"]'; // jQuery doesn't like class names with a dot in the middle so need to get elem using class attr e.g. _stt_Gallus_gallus_GCA_000002315.5
+          elemClass = elemClass.replace('.', ''); // replace the first dot in the string since we now need the class attr's value rather than the csss class name 
+
+          wrapper.find(elemClass).hide().removeAttr('checked').filter('option').each(function() { // if hiding an option element, also disable it to make it work in webkit
             var option = $(this);
 
             if (typeof option.data('sttDisabled') === 'undefined') {

--- a/htdocs/components/00_jquery_selecttotoggle.js
+++ b/htdocs/components/00_jquery_selecttotoggle.js
@@ -32,10 +32,10 @@
       // go through all the selectors in the toggleMap and hide them except the one that corresponds to current element's value
       for (var val in toggleMap) {
         if (val !== currValue) {
-          var elemClass = '[class="' + toggleMap[val] + '"]'; // jQuery doesn't like class names with a dot in the middle so need to get elem using class attr e.g. _stt_Gallus_gallus_GCA_000002315.5
-          elemClass = elemClass.replace('.', ''); // replace the first dot in the string since we now need the class attr's value rather than the csss class name 
+          var elemClassAttr = '[class="' + toggleMap[val] + '"]'; // jQuery doesn't like class names with a dot in the middle so need to get elem using class attr e.g. _stt_Gallus_gallus_GCA_000002315.5
+          elemClassAttr = elemClassAttr.replace('.', ''); // replace the first dot in the string since we now need the class attr's value rather than the csss class name 
 
-          wrapper.find(elemClass).hide().removeAttr('checked').filter('option').each(function() { // if hiding an option element, also disable it to make it work in webkit
+          wrapper.find(elemClassAttr).hide().removeAttr('checked').filter('option').each(function() { // if hiding an option element, also disable it to make it work in webkit
             var option = $(this);
 
             if (typeof option.data('sttDisabled') === 'undefined') {
@@ -45,8 +45,11 @@
         }
       }
 
+      var currElemClassAttr = '[class="' + toggleMap[currValue] + '"]'; // same as what's done for elemClassAttr
+      currElemClassAttr = currElemClassAttr.replace('.', '');
+
       // show the html block corresponsing to current element's value
-      wrapper.find(toggleMap[currValue]).show().filter('option').prop('disabled', function() {
+      wrapper.find(currElemClassAttr).show().filter('option').prop('disabled', function() {
         return $(this).data('sttDisabled');
       }).filter('select option').parent().each(function() {
         var dropdown = $(this);


### PR DESCRIPTION
## Description
The ID History Converter assembly label was showing the genome of chicken which contains a dot (.). This was because when jQuery was querying the class name, which also happen to contain the dot, it couldn't find the element. Apparently, we need to either escape the dot in class names that we used to query with jQuery or query using an attribute name (source: https://stackoverflow.com/questions/32890749/use-a-dot-in-a-class-name-within-jquery-b-avf-toggle). This PR uses the latter, since escaping the dots in strings could become hacky.

### Sandbox URL
http://wp-np2-1e.ebi.ac.uk:8310/Homo_sapiens/Tools/IDMapper

## Views affected
ID History Converter

## Related JIRA Issues (EBI developers only)
[ENSWEB-6670](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6670)
