### PR TITLE
Highlight MANE transcripts and proteins on gene and transcript pages

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/GeneSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GeneSummary.pm
@@ -96,7 +96,7 @@ sub content {
       my $mane_plus_clinical_translation_url = $hub->url({ type => 'Transcript', action => 'ProteinSummary', t => $mane_plus_clinical_translation });
       my $mane_plus_clinical_translation_link = sprintf('<a href="%s">%s</a>', $mane_plus_clinical_translation_url, $mane_plus_clinical_translation);
 
-      $mane_description .= sprintf(' and MANE Plus Clinical %s, %s', $mane_plus_clinical_translation_link, $mane_plus_clinical_translation_link);
+      $mane_description .= sprintf(' and MANE Plus Clinical %s, %s', $mane_plus_clinical_link, $mane_plus_clinical_translation_link);
     }
 
     $table->add_row('MANE', $mane_description);

--- a/modules/EnsEMBL/Web/Component/Gene/GeneSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GeneSummary.pm
@@ -44,7 +44,7 @@ sub content {
   my @Uniprot       = @{$object->Obj->get_all_DBLinks('Uniprot/SWISSPROT')};
   my $db            = $object->get_db;
   my $alt_genes     = $self->get_matches('alternative_genes', 'Alternative Genes', 'ALT_GENE', 'show_version'); #gets all xrefs, sorts them and stores them on the object. Returns HTML only for ALT_GENES
-  my $ensembl_select = $gene->get_all_Attributes('Ensembl_select')->[0] ? $gene->get_all_Attributes('Ensembl_select')->[0]->value : '';
+  my $ensembl_select     = $gene->get_all_Attributes('Ensembl_Select')->[0] ? $gene->get_all_Attributes('Ensembl_Select')->[0]->value : '';
   my $display_xref  = $gene->display_xref;
   my ($link_url)    = $display_xref ? $self->get_gene_display_link($gene, $display_xref) : ();
 
@@ -53,6 +53,53 @@ sub content {
       ? sprintf('<p><a href="%s" class="constant">%s</a> (%s)</p>', $link_url, $display_xref->display_id, $display_xref->db_display_name)
       : sprintf('<p>%s (%s)</p>', $display_xref->display_id, $display_xref->db_display_name)
     );
+  }
+
+  my ($has_mane_select, $has_mane_plus_clinical) = 0;
+  my ($mane_select, $mane_select_translation, $mane_plus_clinical, $mane_plus_clinical_translation);
+
+  ## add MANE info
+  if ($ensembl_select) {
+    foreach my $t (@{$gene->get_all_Transcripts}) {
+      next if $has_mane_select;
+      next unless $t->stable_id eq $ensembl_select;
+
+      $has_mane_select = 1 if (@{$t->get_all_Attributes('MANE_Select')});
+
+      $mane_select = $t->stable_id if $has_mane_select;
+      $mane_select_translation = $t->translation->stable_id if $has_mane_select;
+    }
+
+    foreach my $t (@{$gene->get_all_Transcripts}) {
+      next if $has_mane_plus_clinical;
+
+      $has_mane_plus_clinical = 1 if (@{$t->get_all_Attributes('MANE_Plus_Clinical')});
+
+      $mane_plus_clinical = $t->stable_id if $has_mane_plus_clinical;
+      $mane_plus_clinical_translation = $t->translation->stable_id if $has_mane_plus_clinical;
+    }
+  }
+
+  if ($has_mane_select) {
+    my $mane_select_url = $hub->url({ type => 'Transcript', action => 'Summary', t => $mane_select });
+    my $mane_select_link = sprintf('<a href="%s">%s</a>', $mane_select_url, $mane_select);
+
+    my $mane_select_translation_url = $hub->url({ type => 'Transcript', action => 'ProteinSummary', t => $mane_select_translation });
+    my $mane_select_translation_link = sprintf('<a href="%s">%s</a>', $mane_select_translation_url, $mane_select_translation);
+
+    my $mane_description = sprintf('This gene contains MANE Select %s, %s', $mane_select_link, $mane_select_translation_link);
+
+    if ($has_mane_plus_clinical) {
+      my $mane_plus_clinical_url = $hub->url({ type => 'Transcript', action => 'Summary', t => $mane_plus_clinical });
+      my $mane_plus_clinical_link = sprintf('<a href="%s">%s</a>', $mane_plus_clinical_url, $mane_plus_clinical);
+      
+      my $mane_plus_clinical_translation_url = $hub->url({ type => 'Transcript', action => 'ProteinSummary', t => $mane_plus_clinical_translation });
+      my $mane_plus_clinical_translation_link = sprintf('<a href="%s">%s</a>', $mane_plus_clinical_translation_url, $mane_plus_clinical_translation);
+
+      $mane_description .= sprintf(' and MANE Plus Clinical %s, %s', $mane_plus_clinical_translation_link, $mane_plus_clinical_translation_link);
+    }
+
+    $table->add_row('MANE', $mane_description);
   }
 
   ## Start assembling bioschema information
@@ -92,21 +139,6 @@ sub content {
     add_species_bioschema($species_defs, $bs_gene);
   }
 
-  # add CCDS info
-  if (scalar @CCDS) {
-    my %temp = map { $_->display_id, 1 } @CCDS;
-    @CCDS = sort keys %temp;
-    my $template  = '<p>This gene is a member of the %s CCDS set: %s</p>';
-    my $sp_name   = $species_defs->SPECIES_DISPLAY_NAME; 
-    ## Mouse strains hack
-    if ($species_defs->STRAIN_GROUP && $species_defs->STRAIN_GROUP eq 'mus_musculus') {
-      my $ref_sp = 'Mus_musculus';
-      $template = 'This gene is similar to a CCDS gene on %s: %s';
-      $sp_name  = sprintf '%s %s', $species_defs->get_config($ref_sp, 'SPECIES_DISPLAY_NAME'), $species_defs->get_config($ref_sp, 'ASSEMBLY_VERSION');
-    }
-    $table->add_row('CCDS', sprintf($template, $sp_name, join ', ', map $hub->get_ExtURL_link($_, 'CCDS', $_), @CCDS));
-  }
-
   # add Uniprot info
   if (scalar @Uniprot) {
     my %temp = map { $_->primary_id, 1 } @Uniprot;
@@ -122,18 +154,25 @@ sub content {
       g      => $gene->stable_id, 
     });
     my $msg = 'This Ensembl/Gencode gene does not contain any transcripts for which we have <a href="/info/genome/genebuild/mane.html">selected identical model(s) in RefSeq</a>.'; 
-    my $has_mane_select = 0;
-    if ($ensembl_select) {
-      foreach my $t (@{$gene->get_all_Transcripts}){
-        next if $has_mane_select;
-        next unless $t->stable_id eq $ensembl_select;
-        $has_mane_select = 1 if (@{$t->get_all_Attributes('MANE_select')});
-      }
-    }  
     if ($has_mane_select) {
       $msg = 'This Ensembl/Gencode gene contains transcript(s) for which we have <a href="/info/genome/genebuild/mane.html">selected identical RefSeq transcript(s)</a>.';
     }
     $table->add_row('RefSeq', sprintf(qq{%s If there are other RefSeq transcripts available they will be in the <a href="%s">External references</a> table}, $msg, $url)); 
+  }
+
+  # add CCDS info
+  if (scalar @CCDS) {
+    my %temp = map { $_->display_id, 1 } @CCDS;
+    @CCDS = sort keys %temp;
+    my $template  = '<p>This gene is a member of the %s CCDS set: %s</p>';
+    my $sp_name   = $species_defs->SPECIES_DISPLAY_NAME; 
+    ## Mouse strains hack
+    if ($species_defs->STRAIN_GROUP && $species_defs->STRAIN_GROUP eq 'mus_musculus') {
+      my $ref_sp = 'Mus_musculus';
+      $template = 'This gene is similar to a CCDS gene on %s: %s';
+      $sp_name  = sprintf '%s %s', $species_defs->get_config($ref_sp, 'SPECIES_DISPLAY_NAME'), $species_defs->get_config($ref_sp, 'ASSEMBLY_VERSION');
+    }   
+    $table->add_row('CCDS', sprintf($template, $sp_name, join ', ', map $hub->get_ExtURL_link($_, 'CCDS', $_), @CCDS));
   }
 
   ## LRG info

--- a/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
@@ -60,17 +60,31 @@ sub content {
 
   $table->add_row('Statistics', $html);
 
-  ## add CCDS info
-  if (scalar @CCDS) {
-    my %T = map { $_->primary_id => 1 } @CCDS;
-    @CCDS = sort keys %T;
-    $table->add_row('CCDS', sprintf('<p>This transcript is a member of the %s CCDS set: %s</p>', $sp, join ', ', map $hub->get_ExtURL_link($_, 'CCDS', $_), @CCDS));
+  ## add MANE info
+  if ($transcript->is_mane) {
+    my $mane_select = $transcript->get_all_Attributes('MANE_Select')->[0];
+    my $mane_plus_clinical = $transcript->get_all_Attributes('MANE_Plus_Clinical')->[0];
+    my $mane_type = $mane_select ? 'MANE Select' : 'MANE Plus Clinical';
+    my $refseq_id = $mane_select ? $mane_select->value : $mane_plus_clinical->value;
+
+    my $mane_transcript_translation = $transcript->translation->stable_id;
+    my $refseq_link = $hub->get_ExtURL('REFSEQ_DNA', {'ID' => $refseq_id}); 
+
+    $table->add_row('MANE', sprintf('<p>This %s transcript contains %s and matches to <a href="%s">%s</a></p>', $mane_type, $mane_transcript_translation, $refseq_link, $refseq_id));
   }
+
   ## add Uniprot info
   if (scalar @Uniprot) {
     my %T = map { $_->primary_id => 1 } @Uniprot;
     @Uniprot = sort keys %T;
     $table->add_row('Uniprot', sprintf('<p>This transcript corresponds to the following Uniprot identifiers: %s</p>', join ', ', map $hub->get_ExtURL_link($_, 'Uniprot/SWISSPROT', $_), @Uniprot));
+  }
+
+  ## add CCDS info
+  if (scalar @CCDS) {
+    my %T = map { $_->primary_id => 1 } @CCDS;
+    @CCDS = sort keys %T; 
+    $table->add_row('CCDS', sprintf('<p>This transcript is a member of the %s CCDS set: %s</p>', $sp, join ', ', map $hub->get_ExtURL_link($_, 'CCDS', $_), @CCDS));
   }
 
   ## add TSL info

--- a/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
@@ -64,17 +64,25 @@ sub content {
   if ($transcript->is_mane) {
     my $mane_select = $transcript->get_all_Attributes('MANE_Select')->[0];
     my $mane_plus_clinical = $transcript->get_all_Attributes('MANE_Plus_Clinical')->[0];
-    my $mane_type = $mane_select ? 'MANE Select' : 'MANE Plus Clinical';
+    my $mane_type = $mane_select ? 'MANE_Select' : 'MANE_Plus_Clinical';
+    my $mane_type_str = $mane_select ? 'MANE Select' : 'MANE Plus Clinical';
 
-    my $refseq_id = $mane_select ? $mane_select->value : $mane_plus_clinical->value;
-    my $refseq_url = $hub->get_ExtURL('REFSEQ_DNA', {'ID' => $refseq_id});
-    my $refseq_link = sprintf('<a href="%s">%s</a>', $refseq_url, $refseq_id);
+    my $transcript_refseq_id = $mane_select ? $mane_select->value : $mane_plus_clinical->value;
+    my $transcript_refseq_url = $hub->get_ExtURL('REFSEQ_DNA', { 'ID' => $transcript_refseq_id });
+    my $refseq_links = sprintf('<a href="%s">%s</a>', $transcript_refseq_url, $transcript_refseq_id);
 
-    my $mane_transcript_translation = $transcript->translation->stable_id;
-    my $mane_transcript_translation_url = $hub->url({ type => 'Transcript', action => 'ProteinSummary', t => $mane_transcript_translation });
-    my $mane_transcript_translation_link = sprintf('<a href="%s">%s</a>', $mane_transcript_translation_url, $mane_transcript_translation);
+    my $mane_transcript_translation_url = $hub->url({ type => 'Transcript', action => 'ProteinSummary', t => $transcript->translation->stable_id });
+    my $mane_transcript_translation_link = sprintf('<a href="%s">%s</a>', $mane_transcript_translation_url, $transcript->translation->stable_id);
 
-    $table->add_row('MANE', sprintf('<p>This %s transcript contains %s and matches to %s</p>', $mane_type, $mane_transcript_translation_link, $refseq_link));
+    my $translation_refseq_id = $transcript->translation->get_all_Attributes($mane_type)->[0]->value;
+
+    if ($translation_refseq_id) {
+      my $translation_refseq_url = $hub->get_ExtURL('REFSEQ_RNA', { 'ID' => $translation_refseq_id });
+
+      $refseq_links .= sprintf(' and <a href="%s">%s</a>', $translation_refseq_url, $translation_refseq_id);
+    }
+
+    $table->add_row('MANE', sprintf('<p>This %s transcript contains %s and matches to %s</p>', $mane_type_str, $mane_transcript_translation_link, $refseq_links));
   }
 
   ## add Uniprot info

--- a/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
@@ -65,12 +65,16 @@ sub content {
     my $mane_select = $transcript->get_all_Attributes('MANE_Select')->[0];
     my $mane_plus_clinical = $transcript->get_all_Attributes('MANE_Plus_Clinical')->[0];
     my $mane_type = $mane_select ? 'MANE Select' : 'MANE Plus Clinical';
+
     my $refseq_id = $mane_select ? $mane_select->value : $mane_plus_clinical->value;
+    my $refseq_url = $hub->get_ExtURL('REFSEQ_DNA', {'ID' => $refseq_id});
+    my $refseq_link = sprintf('<a href="%s">%s</a>', $refseq_url, $refseq_id);
 
     my $mane_transcript_translation = $transcript->translation->stable_id;
-    my $refseq_link = $hub->get_ExtURL('REFSEQ_DNA', {'ID' => $refseq_id}); 
+    my $mane_transcript_translation_url = $hub->url({ type => 'Transcript', action => 'ProteinSummary', t => $mane_transcript_translation });
+    my $mane_transcript_translation_link = sprintf('<a href="%s">%s</a>', $mane_transcript_translation_url, $mane_transcript_translation);
 
-    $table->add_row('MANE', sprintf('<p>This %s transcript contains %s and matches to <a href="%s">%s</a></p>', $mane_type, $mane_transcript_translation, $refseq_link, $refseq_id));
+    $table->add_row('MANE', sprintf('<p>This %s transcript contains %s and matches to %s</p>', $mane_type, $mane_transcript_translation_link, $refseq_link));
   }
 
   ## add Uniprot info


### PR DESCRIPTION
## Description
This PR does the following changes to the gene summary and transcript summary pages:

1. Move the CCDS link below RefSeq in gene pages
2. Add MANE section to both the pages
3. On transcript pages move the CCDS link to below UniProt
4. On transcript pages add text with links to RefSeq

### Release version
108

### Sandbox URL
Gene Summary: http://wp-np2-1e.ebi.ac.uk:8330/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000053747;r=18:23873020-23955066;t=ENST00000585600

Transcript Summary: http://wp-np2-1e.ebi.ac.uk:8330/Homo_sapiens/Transcript/Summary?db=core;g=ENSG00000053747;r=18:23873020-23955066;t=ENST00000313654

## Views affected
Gene Summary and Transcript Summary

## Related JIRA Issues (EBI developers only)
[ENSWEB-6552](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6552)