### PR TITLE
Fix tools assembly label name that broke due to previous PR (#906)

### DIFF
--- a/htdocs/components/00_jquery_selecttotoggle.js
+++ b/htdocs/components/00_jquery_selecttotoggle.js
@@ -29,13 +29,21 @@
       var toggleMap = data.toggleMap;
       var currValue = this.nodeName === 'INPUT' && this.type === 'checkbox' && !this.checked ? false : this.value; // if checkbox is not ticked, ignore it's value
 
+      var escapeDotInClassName = function (className) {
+        var i = 0;
+
+        return className.replace(/[.]/g, function (match) {
+           i += 1;
+           return i > 1 ? '\\\.' : '.';
+        });
+      };
+
       // go through all the selectors in the toggleMap and hide them except the one that corresponds to current element's value
       for (var val in toggleMap) {
         if (val !== currValue) {
-          var elemClassAttr = '[class="' + toggleMap[val] + '"]'; // jQuery doesn't like class names with a dot in the middle so need to get elem using class attr e.g. _stt_Gallus_gallus_GCA_000002315.5
-          elemClassAttr = elemClassAttr.replace('.', ''); // replace the first dot in the string since we now need the class attr's value rather than the csss class name 
+          var elemClass = escapeDotInClassName(toggleMap[val]);
 
-          wrapper.find(elemClassAttr).hide().removeAttr('checked').filter('option').each(function() { // if hiding an option element, also disable it to make it work in webkit
+          wrapper.find(elemClass).hide().removeAttr('checked').filter('option').each(function() { // if hiding an option element, also disable it to make it work in webkit
             var option = $(this);
 
             if (typeof option.data('sttDisabled') === 'undefined') {
@@ -45,11 +53,10 @@
         }
       }
 
-      var currElemClassAttr = '[class="' + toggleMap[currValue] + '"]'; // same as what's done for elemClassAttr
-      currElemClassAttr = currElemClassAttr.replace('.', '');
+      var currElemClass = escapeDotInClassName(toggleMap[currValue]);
 
       // show the html block corresponsing to current element's value
-      wrapper.find(currElemClassAttr).show().filter('option').prop('disabled', function() {
+      wrapper.find(currElemClass).show().filter('option').prop('disabled', function() {
         return $(this).data('sttDisabled');
       }).filter('select option').parent().each(function() {
         var dropdown = $(this);

--- a/htdocs/components/00_jquery_selecttotoggle.js
+++ b/htdocs/components/00_jquery_selecttotoggle.js
@@ -99,7 +99,7 @@
             if (this.value) {
               var filters = $.map(this.className.match(/(\s+|^)_stt__([^\s]+)/g) || [], function(str) { return str.replace('_stt__', '._stt_') });
                   filters.push('._stt_' + this.value);
-              tMap[this.value] = this.className.match(/(\s+|^)_sttmulti($|\s+)/) ? filters.join(',') : filters[0];
+              tMap[this.value] = this.className.match(/(\s+|^)_sttmulti($|\s+)/) ? (filters[1] || filters.join(',')) : filters[0];
             }
           });
         }


### PR DESCRIPTION
## Description
The previous fix for ID History Converter assembly label (#906) broken the assembly label in other tools such as File Chameleon. This PR is a fix for that issue.

Please note that this PR is not a fix for the jobs submissions failing in ID History Converter. There is a separate ticket for it ([ENSWEB-6684](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6684)), which I am working on at the moment.

### Sandbox URL
ID History Converter: http://wp-np2-1e.ebi.ac.uk:8310/Homo_sapiens/Tools/IDMapper
File Chameleon: http://wp-np2-1e.ebi.ac.uk:8310/Homo_sapiens/Tools/FileChameleon?db=core
VCF to PED: http://wp-np2-1e.ebi.ac.uk:8310/Homo_sapiens/Tools/VcftoPed

## Views affected
ID History Converter, File Chameleon and VCF to PED

## Related JIRA Issues (EBI developers only)
[ENSWEB-6684](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6684)
