### PR TITLE
Fix broken multiple species selector in BLAST form

### DIFF
--- a/htdocs/components/00_jquery_selecttotoggle.js
+++ b/htdocs/components/00_jquery_selecttotoggle.js
@@ -32,10 +32,10 @@
       var escapeDotInClassName = function (className) {
         var i = 0;
 
-        return className.replace(/[.]/g, function (match) {
+        return className ? className.replace(/[.]/g, function (match) {
            i += 1;
            return i > 1 ? '\\\.' : '.';
-        });
+        }) : '';
       };
 
       // go through all the selectors in the toggleMap and hide them except the one that corresponds to current element's value
@@ -74,7 +74,7 @@
 
   $.fn.selectToToggle = function (
     toggleMap,  // map of select element's option value to corresponding jquery selectors strings (as accepted by find() method) (Optional - defaults to '._stt_[className]' if class name uses prefix _stt__, or '._stt_[value]' otherwise)
-                // string 'trigger' to trigger toggling for an existing element (this is useful is option is selected by JS)
+                // string 'trigger' to trigger toggling for an existing element (this is useful if option is selected by JS)
                 // string 'destroy' to remove all selectToToggle data and events from the element
     wrapper     // wrapper element to call method 'find(selectors)' on - defaults to $(document.body)
   ) {
@@ -102,7 +102,7 @@
         el        = getAllEls(el, wrapper);
 
         if ($.isEmptyObject(tMap)) {
-          (this.nodeName == 'SELECT' ? el.find('option') : el).each(function() {
+          (this.nodeName === 'SELECT' ? el.find('option') : el).each(function() {
             if (this.value) {
               var filters = $.map(this.className.match(/(\s+|^)_stt__([^\s]+)/g) || [], function(str) { return str.replace('_stt__', '._stt_') });
                   filters.push('._stt_' + this.value);


### PR DESCRIPTION
## Description
Fixes the broken multiple species selector in both V and NV sites. The fix suggested by @ens-ma7 worked perfectly and was less hacky than what I had in mind (slack conversation: https://genomes-ebi.slack.com/archives/C02HWL7NKR8/p1663673566999799?thread_ts=1663664300.510469&cid=C02HWL7NKR8).

### Where to check?
Debug site: https://debug.ensembl.org/Multi/Tools/Blast
Debug EG site: https://debug-eg.ensembl.org/Multi/Tools/Blast

## Views affected
BLAST tools page

## Possible complications
The fix was applied in `htdocs/components/00_jquery_selecttotoggle.js` which is commonly used in other tools forms. The previous fixes for particular tools (e.g. ID History Converter) applied in the same files caused issues in other tools.

## Related JIRA Issues (EBI developers only)
[ENSWEB-6709](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6709)
