### PR TITLE
Remove postgap

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/ToolsTable.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/ToolsTable.pm
@@ -193,20 +193,6 @@ sub render {
     });
   }
 
-  ## Postgap
-  if ($sd->ENSEMBL_PG_ENABLED) {
-    my $link = $hub->url({'species' => $sp, qw(type Tools action Postgap)});
-    $table->add_row({
-      'name'  => sprintf('<b><a class="nodeco" href="%s">Post-GWAS</a></b>', $link),
-      'desc'  => "Upload GWAS summary statistics and highlight likely causal gene candidates.",
-      'tool'  => sprintf('<a href="%s" class="nodeco"><img src="%s16/tool.png" alt="Tool" title="Go to online tool" /></a>', $link, $img_url),
-      'limit' => '',
-      'code'  => sprintf('<a href="https://github.com/Ensembl/postgap/" rel="external" class="nodeco"><img src="%s16/download.png" alt="Download" title="Github repo" /></a>', $img_url),
-      'docs'  => sprintf('<a href="/%s" class="popup"><img src="%s16/info.png" alt="Documentation" /></a>', $hub->url({'species' => '', 'type' => 'Help', 'action' => 'View', 'id' => { $sd->multiX('ENSEMBL_HELP') }->{'Tools/Postgap'}}), $img_url),
-    });
-  }  
-
-
   if ($table->has_rows) {
     $html .= $table->render;
     $html .= '* For larger datasets we provide an API script that can be downloaded (you will also need to install our Perl API, below, to run the script).';


### PR DESCRIPTION
## Description

The Post-GWAS tool is being [retired in 108](https://www.ensembl.info/2022/07/28/retiring-the-post-gwas-tool/). This PR removes the row in the tools table that describes Post-GWAS.

See the complementary PRs in [public-plugins](https://github.com/Ensembl/public-plugins/pull/615) and [ebi-plugins](https://github.com/Ensembl/ebi-plugins/pull/133) that remove the configuration related to Post-GWAS.

## Views affected

Tools index page. See [sandbox](http://wp-np2-1f.ebi.ac.uk:8800/info/docs/tools/index.html).

## Possible complications

None

## Merge conflicts

None

## Related JIRA Issues (EBI developers only)

This PR fulfills the first part of [ENSWEB-6588](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6588). 
