### PR TITLE
Fixes for compara API change in 109

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/HomologAlignment.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/HomologAlignment.pm
@@ -171,7 +171,8 @@ sub get_homologies {
   my $gene_id      = $object->stable_id;
 
   my $database     = $hub->database($cdb);
-  my $qm           = $database->get_GeneMemberAdaptor->fetch_by_stable_id($gene_id);
+  my $args         = {'stable_id' = $gene_id, 'cdb' => $cdb};
+  my $qm           = $self->object->get_compara_Member($args);;
   my $homologies;
   my $ok_homologies = [];
   my $action        = $hub->param('data_action') || $hub->action;

--- a/modules/EnsEMBL/Web/Document/Image/R2R.pm
+++ b/modules/EnsEMBL/Web/Document/Image/R2R.pm
@@ -53,8 +53,14 @@ sub find_ss_in_compara {
 
     my $gma = $database->get_GeneMemberAdaptor();
     my $gta = $database->get_GeneTreeAdaptor();
+    my $gda = $database->get_GenomeDBAdaptor();
 
-    my $member = $gma->fetch_by_stable_id($self->component->object->stable_id);
+    my $args = {
+      'stable_id' => $self->component->object->stable_id,
+      'cdb'       => 'comppara'
+    };
+    my $member = $self->component->object->get_compara_Member($args);
+
     if ($member and $member->has_GeneTree) {
       my $transcript = $member->get_canonical_SeqMember();
       my $gene_tree  = $gta->fetch_default_for_Member($member);

--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -862,7 +862,8 @@ sub get_homologue_alignments {
   };
 
   if ($database) {  
-    my $member  = $self->get_compara_Member($compara_db);
+    my $args = {'stable_id' => $self->stable_id, 'cdb' => $compara_db};
+    my $member  = $self->get_compara_Member($args);
     my $tree    = $self->get_GeneTree($compara_db, 1, $strain_tree);
     my @params  = ($member, $type);
     my $species = [];
@@ -908,22 +909,6 @@ sub get_homologue_alignments {
   return $msa;
 }
 
-sub get_compara_Member {
-  my $self       = shift;
-  my $compara_db = shift || 'compara';
-  my $stable_id  = shift || $self->stable_id;
-  my $cache_key  = "_compara_member_$compara_db\_$stable_id";
-  
-  if (!$self->{$cache_key}) {
-    my $compara_dba = $self->database($compara_db)              || return;
-    my $adaptor     = $compara_dba->get_adaptor('GeneMember')   || return;
-    my $member      = $adaptor->fetch_by_stable_id($stable_id);
-    
-    $self->{$cache_key} = $member if $member;
-  }
-  
-  return $self->{$cache_key};
-}
 
 sub get_GeneTree {
   my $self        = shift;
@@ -934,8 +919,9 @@ sub get_GeneTree {
   my $cache_key  = sprintf('_protein_tree_%s_%s_%s', $compara_db, $clusterset_id, $strain_tree);
 
   if (!$self->{$cache_key}) {  
-    my $member  = $self->get_compara_Member($compara_db)           || return;
-    my $adaptor = $member->adaptor->db->get_adaptor('GeneTree')    || return;
+    my $args = {'stable_id' => $self->stable_id, 'cdb' => $compara_db};
+    my $member  = $self->get_compara_Member($args)  || return;
+    my $adaptor = $member->adaptor->db->get_adaptor('GeneTree') || return;
     my $tree    = $adaptor->fetch_all_by_Member($member, -clusterset_id => $clusterset_id)->[0];
     unless ($tree) {
         $tree = $adaptor->fetch_default_for_Member($member);
@@ -995,7 +981,8 @@ sub get_SpeciesTree {
     my $cafeTree_Adaptor = $database->get_CAFEGeneFamilyAdaptor();
     my $geneTree_Adaptor = $database->get_GeneTreeAdaptor();
     
-    my $member   = $self->get_compara_Member($compara_db)           || return;        
+    my $args = {'stable_id' => $self->stable_id, 'cdb' => $compara_db};
+    my $member   = $self->get_compara_Member($args)           || return;        
     my $geneTree = $geneTree_Adaptor->fetch_default_for_Member($member, $strain_tree) || return;
     my $cafeTree = $cafeTree_Adaptor->fetch_by_GeneTree($geneTree) || return;		   
     
@@ -1024,7 +1011,8 @@ sub get_SpeciesTreeJSON {
 
     my $json_label = $collapsability eq 'part' ? 'cafe_lca' : 'cafe';
 
-    my $member   = $self->get_compara_Member($compara_db)           || return;
+    my $args = {'stable_id' => $self->stable_id, 'cdb' => $compara_db};
+    my $member   = $self->get_compara_Member($args)           || return;
     my $geneTree = $geneTree_Adaptor->fetch_default_for_Member($member) || return;
     my $cafeTree = $gtos_Adaptor->fetch_by_GeneTree_and_label($geneTree, $json_label) || return;
 

--- a/modules/EnsEMBL/Web/Object/LRG.pm
+++ b/modules/EnsEMBL/Web/Object/LRG.pm
@@ -888,30 +888,6 @@ sub get_disease_matches{
   return \%omim_disease ;
 }
 
-sub get_compara_Member{
-  # Returns the Bio::EnsEMBL::Compara::Member object
-  # corresponding to this gene 
-  my $self = shift;
-  my $compara_db = shift || 'compara';
-
-  # Catch coderef
-  my $cachekey = "_compara_member_$compara_db";
-  my $error = sub{ warn($_[0]); $self->{$cachekey}=0; return 0};
-
-  unless( defined( $self->{$cachekey} ) ){ # Look in cache
-    # Prepare the adaptors
-    my $compara_dba = $self->database( $compara_db )           || &$error( "No compara db" );
-    my $genemember_adaptor = $compara_dba->get_adaptor('GeneMember') || &$error( "Cannot COMPARA->get_adaptor('GeneMember')" );
-    # Fetch the object
-    my $id = $self->stable_id;
-    my $member = $genemember_adaptor->fetch_by_stable_id($id) || &$error( "<h3>No compara ENSEMBLGENE member for $id</h3>" );
-    # Update the cache
-    $self->{$cachekey} = $member;
-  }
-  # Return cached value
-  return $self->{$cachekey};
-}
-
 sub get_ProteinTree {
   # deprecated, use get_GeneTree
   return get_GeneTree(@_);
@@ -931,7 +907,8 @@ sub get_GeneTree {
 
   unless( defined( $self->{$cachekey} ) ){ # Look in cache
     # Fetch the objects
-    my $member = $self->get_compara_Member($compara_db)
+    my $args = {'stable_id' => $stable_id, 'cdb' => $compara_db};
+    my $member = $self->get_compara_Member($args)
         || &$error( "No compara member for this gene" );
     my $tree_adaptor = $member->adaptor->db->get_adaptor('GeneTree')
         || &$error( "Cannot COMPARA->get_adaptor('GeneTree')" );

--- a/modules/EnsEMBL/Web/Object/Location.pm
+++ b/modules/EnsEMBL/Web/Object/Location.pm
@@ -1007,7 +1007,8 @@ sub fetch_homologues_of_gene_in_species {
   
   return [] unless $self->database('compara');
 
-  my $qy_member = $self->database('compara')->get_GeneMemberAdaptor->fetch_by_stable_id($gene_stable_id);
+  my $args = {'stable_id' => $gene_stable_id, 'cdb' => 'compara'};
+  my $qy_member = $self->get_compara_Member($args);
   
   return [] unless defined $qy_member; 
 

--- a/modules/EnsEMBL/Web/QueryStore/Source/Adaptors.pm
+++ b/modules/EnsEMBL/Web/QueryStore/Source/Adaptors.pm
@@ -137,9 +137,15 @@ sub compara_member {
   my ($self,$id, $species) = @_;
 
   ## Pass species in case this site has single-species compara
+  my $gda = $self->_get_adaptor('get_GenomeDBAdaptor','compara', $species);
+  return undef unless $gda;
+  my $prod_name = $self->{_sd}->get_config($species, 'SPECIES_PRODUCTION_NAME');
+  my $genome_db = $gda->fetch_by_name_assembly($prod_name);
+  return undef unless $genome_db;
+
   my $gma = $self->_get_adaptor('get_GeneMemberAdaptor','compara', $species);
   return undef unless $gma;
-  return $gma->fetch_by_stable_id($id);
+  return $gma->fetch_by_stable_id_GenomeDB($id, $genome_db);
 }
 
 sub pancompara_member {

--- a/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
@@ -157,7 +157,9 @@ sub init_form_non_cacheable {
 
   if($hub->param('g')) {
     my $database           = $hub->database($cdb);
-    my $member             = $database->get_GeneMemberAdaptor->fetch_by_stable_id($hub->core_params->{'g'});
+    my $genome_db          = $database->get_GenomeDBAdaptor->fetch_by_name_assembly($hub->species_defs->SPECIES_PRODUCTION_NAME);
+
+    my $member             = $database->get_GeneMemberAdaptor->fetch_by_stable_id_GenomeDB($hub->core_params->{'g'}, $genome_db);
     my $adaptor            = $database->get_GeneTreeAdaptor;
     my $gene_tree          = $adaptor->fetch_default_for_Member($member);
     %other_clustersets     = map { $_->clusterset_id => 1 } @{$adaptor->fetch_all_linked_trees($gene_tree)};


### PR DESCRIPTION
## Description

One of the compara API calls has been changed to deal with metazoa annotation, where stable IDs may not be unique within a division. The new call requires passing in a GenomeDB object, which we can get from the API using the species production name.

## Views affected
The following pages should load correctly with no errors:

* Gene Summary: http://wp-np2-1f.ebi.ac.uk:10109/Homo_sapiens/Gene/Summary?g=ENSG00000139618;r=13:32315086-32400268
* Orthologues: http://wp-np2-1f.ebi.ac.uk:10109/Homo_sapiens/Gene/Compara_Ortholog?db=core;g=ENSG00000139618;r=13:32315086-32400268
* Orthologue alignments: http://wp-np2-1f.ebi.ac.uk:10109/Homo_sapiens/Gene/Compara_Ortholog/Alignment?db=core;g=ENSG00000139618;g1=MGP_SPRETEiJ_G0029058;hom_id=89314964;r=13:32315086-32400268
* Gene Tree: http://wp-np2-1f.ebi.ac.uk:10109/Homo_sapiens/Gene/Compara_Tree?db=core;g=ENSG00000139618;g1=MGP_SPRETEiJ_G0029058;hom_id=89314964;r=13:32315086-32400268
* LRG Summary: http://wp-np2-1f.ebi.ac.uk:10109/Homo_sapiens/LRG/Summary?lrg=LRG_1
* RNA secondary structure: http://wp-np2-1f.ebi.ac.uk:10109/Homo_sapiens/Gene/SecondaryStructure?db=core;g=ENSG00000263764;r=22:3931050-39319113;t=ENST00000583861
* Synteny (table under image): http://wp-np2-1f.ebi.ac.uk:10109/Homo_sapiens/Location/Synteny?db=core;g=ENSG00000263764;r=22:39319050-39319113;t=ENST00000583861

## Possible complications

Should only affect the views that use this API call.

## Merge conflicts

Should be OK, since it only touches a few specific areas of the code.

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6679
