### PR TITLE
Restrict iframe embedding

### DIFF
--- a/conf/httpd.conf
+++ b/conf/httpd.conf
@@ -637,3 +637,4 @@ ExtendedStatus on
 
 # Restrict iframe embedding
 Header set X-Frame-Options: "SAMEORIGIN"
+Header set Content-Security-Policy: "frame-ancestors 'self'"

--- a/conf/httpd.conf
+++ b/conf/httpd.conf
@@ -634,3 +634,6 @@ ExtendedStatus on
 <LocationMatch "/*/Widgets/*">
   Header set Access-Control-Allow-Origin "*"
 </LocationMatch>
+
+# Restrict iframe embedding
+Header set X-Frame-Options: "SAMEORIGIN"


### PR DESCRIPTION
## Description

This PR addresses a potential security issue (called Clickjacking) that exploits the ability to embed a target webiste (e.g. Ensembl) in a malicious website.  The HTTP response header directive in this PR blocks embedding Ensembl web pages in iframes on external websites.

## Views affected

All Ensembl web pages.

## Possible complications

Any trusted websites that want to embed Ensembl in iframe need to be explicitly added to the HTTP header whitelist.

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6692

Sandbox: http://wp-np2-1d.ebi.ac.uk:1680
