### PR TITLE
Update ftp links to https

### DIFF
--- a/conf/httpd.conf
+++ b/conf/httpd.conf
@@ -155,8 +155,8 @@ RewriteRule ^(.*)$ /Tools/Down [R]
 </IfDefine>
 
 <Location /ftp>
- ProxyPass http://ftp.ebi.ac.uk/ensemblorg/
- ProxyPassReverse http://ftp.ebi.ac.uk/ensemblorg/
+ ProxyPass https://ftp.ebi.ac.uk/ensemblorg/
+ ProxyPassReverse https://ftp.ebi.ac.uk/ensemblorg/
 </Location>
 
 #### Biomart redirect ####

--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -28,8 +28,8 @@ ENSEMBL_SITE_NAME_SHORT       = Ensembl
 ENSEMBL_REGISTRY_LOCATION     = xxxxxx
 ENSEMBL_DEFAULT_SEARCHCODE    = ensembl
 
-ENSEMBL_FTP_URL               = http://ftp.ensembl.org/pub
-ENSEMBL_GENOMES_FTP_URL       = http://ftp.ebi.ac.uk/ensemblgenomes/pub
+ENSEMBL_FTP_URL               = https://ftp.ensembl.org/pub
+ENSEMBL_GENOMES_FTP_URL       = https://ftp.ebi.ac.uk/ensemblgenomes/pub
 
 TRACKHUB_MAX_TRACKS           = 10000
 TRACKHUB_REGISTRY_URL         = https://www.trackhubregistry.org 

--- a/htdocs/info/data/ftp/rsync.html
+++ b/htdocs/info/data/ftp/rsync.html
@@ -21,7 +21,7 @@ in your web browser to locate the files you need, then alter the FTP URL as foll
 
 <p>Examples
     <li>The following command will download all the human EMBL files from 
-<kbd>http://ftp.ensembl.org/pub/current_embl/homo_sapiens</kbd> 
+<kbd>https://ftp.ensembl.org/pub/current_embl/homo_sapiens</kbd> 
 to the current directory:</p>
 
 <pre class="code">
@@ -30,7 +30,7 @@ rsync -av rsync://ftp.ensembl.org/ensembl/pub/current_embl/homo_sapiens .
 </li>
 
 <li>The following command will download all the <i>Actinidia chinensis</i> FASTA files from
-    <kbd>http://ftp.ebi.ac.uk/ensemblgenomes/pub/plants/current/fasta/actinidia_chinensis</kbd> 
+    <kbd>https://ftp.ebi.ac.uk/ensemblgenomes/pub/plants/current/fasta/actinidia_chinensis</kbd> 
     to the current directory:</p>
     
     <pre class="code">

--- a/htdocs/info/website/trackhubs/adding_trackhubs.html
+++ b/htdocs/info/website/trackhubs/adding_trackhubs.html
@@ -15,7 +15,7 @@
   <li>Give your track hub a name (optional - it will be parsed from the hub.txt file)</li>
   <li>The current species will be preselected - note that we now support multispecies hubs, so relevant data will be available on all appropriate species</li>
   <li>The assembly is automatically set to the current assembly for the species you are on - if you wish to use a track hub with data on older assemblies, you will need to use an <a href="/info/website/archives/">archive site</a> (not available for all Ensembl-powered websites, or for assemblies that predate our track hub code)</li>
-  <li>In the large text box, type/paste the <strong>full URL of your hub's <kbd>hub.txt</kbd> file</strong>, e.g. http://ftp.ebi.ac.uk/pub/databases/blueprint/releases/current_release/homo_sapiens/hub/hub.txt
+  <li>In the large text box, type/paste the <strong>full URL of your hub's <kbd>hub.txt</kbd> file</strong>, e.g. https://ftp.ebi.ac.uk/pub/databases/blueprint/releases/current_release/homo_sapiens/hub/hub.txt
   <li>A dropdown box labeled 'Data format' will appear</li>
     <ul>
       <li>If your hub file is called <kbd>hub.txt</kbd>, the form will automatically set the format to 'Track hub'</li>

--- a/htdocs/info/website/upload/sample_files/Pulmonary_function.vcf.txt
+++ b/htdocs/info/website/upload/sample_files/Pulmonary_function.vcf.txt
@@ -17,7 +17,7 @@
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=DS,Number=1,Type=Float,Description="Genotype dosage from MaCH/Thunder">
 ##FORMAT=<ID=GL,Number=.,Type=Float,Description="Genotype Likelihoods">
-##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele, http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/pilot_data/technical/reference/ancestral_alignments/README">
+##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele, https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/pilot_data/technical/reference/ancestral_alignments/README">
 ##INFO=<ID=AF,Number=1,Type=Float,Description="Global Allele Frequency based on AC/AN">
 ##INFO=<ID=AMR_AF,Number=1,Type=Float,Description="Allele Frequency for samples from AMR based on AC/AN">
 ##INFO=<ID=ASN_AF,Number=1,Type=Float,Description="Allele Frequency for samples from ASN based on AC/AN">

--- a/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
@@ -426,7 +426,7 @@ broken into chunks of 1000 sequence records for easier downloading.
   <dt>EMBL</dt>
   <dd>Ensembl database dumps in <a href="http://www.ebi.ac.uk/ena/about/sequence_format"
   rel="external">EMBL</a> nucleotide
-  sequence <a href="http://ftp.ebi.ac.uk/pub/databases/embl/doc/usrman.txt"
+  sequence <a href="https://ftp.ebi.ac.uk/pub/databases/embl/doc/usrman.txt"
   rel="external">database format</a></dd>
 
   <dt>GenBank</dt>


### PR DESCRIPTION
This PR updates all `http://ftp` URLs to https.
The affected URL hostnames have been tested working with https.
Similar PRs in other repos are listed in the JIRA ticket.

JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6632
Sandbox: http://wp-np2-1d.ebi.ac.uk:1680