### PR TITLE
Add/update URL templates for protein domains in VEP (109)

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -242,10 +242,12 @@ Translation       = Peptide
 ## Used by more than one group
 EPMC_MED                    = http://europepmc.org/abstract/MED/###ID###
 EUROPE_PMC                  = http://europepmc.org/abstract/###SOURCE###/###ID###
+HAMAP                       = http://hamap.expasy.org/signature/###ID###
 LRG                         = https://www.lrg-sequence.org/search/?query=###ID###
 MIM                         = http://www.omim.org/###ID###
 MIM_GENE                    = http://www.omim.org/###ID###
 MIM_MORBID                  = http://www.omim.org/###ID###
+PANTHERDB                   = http://www.pantherdb.org/panther/family.do?clsAccession=###ID###
 ZFIN_ID                     = http://zfin.org/###ID###
 INTACT			    = https://www.ebi.ac.uk/intact/details/interaction/###ID###
 
@@ -356,6 +358,7 @@ CLIN_SIG                    = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
 CLINVAR                     = http://www.ncbi.nlm.nih.gov/clinvar/###ID###
 CLINVAR_VAR                 = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
 CLINVAR_DBSNP               = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
+CDD                         = https://www.ebi.ac.uk/interpro/entry/cdd/###ID###
 COSMIC                      = http://cancer.sanger.ac.uk/cosmic/search?q=###ID###
 COSMIC_STUDY                = http://cancer.sanger.ac.uk/cosmic/browse/tissue?#sn=###ID###&ss=&hn=&sh=&in=t&src=tissue
 COSMIC_SV                   = http://cancer.sanger.ac.uk/cosmic/rearrangement/overview?id=###ID###
@@ -379,6 +382,7 @@ EVA_STUDY                   = https://www.ebi.ac.uk/eva/?eva-study=
 GEFOS                       = http://www.gefos.org 
 GEM_J_POP                   = https://togovar.biosciencedbc.jp/doc/datasets/gem_j_wga
 GEM_J_POP_USE               = https://togovar.biosciencedbc.jp/doc/datasets/gem_j_wga#terms
+GENE3D                      = https://www.ebi.ac.uk/interpro/entry/cathgene3d/###ID###
 GIANT                       = http://www.broadinstitute.org/collaboration/giant/index.php/Main_Page
 HAPMAP                      = http://www.hapmap.org/cgi-perl/secure/gbrowse/snp_details/hapmap?class=SNP;name=###ID###
 HBVAR                       = http://globin.bx.psu.edu/cgi-bin/hbvar/query_vars3?mode=output&display_format=page&i=###ID### 
@@ -401,12 +405,22 @@ OMIM                        = http://www.omim.org/###ID###
 ORDO                        = http://www.orpha.net/ORDO/###ID###
 ORPHANET                    = http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=###ID###
 PAHDB                       = http://www.pahdb.mcgill.ca/PahdbSearch.php?SearchValue=###ID###&SearchField=mut_name&SearchOrderedField=id_mut&SearchAscDesc=ASC&Submit=Submit&MenuSelection=Mutation
+PFAM                        = https://www.ebi.ac.uk/interpro/entry/pfam/###ID###
 PHARMGKB                    = https://www.pharmgkb.org/rsid/###ID###
 PHARMGKB_VARIANT            = https://www.pharmgkb.org/variant/###ID###
 PHENCODE                    = http://phencode.bx.psu.edu/cgi-bin/phencode/phencode?build=hg19&id=###ID### 
+PIRSF                       = http://pir.georgetown.edu/cgi-bin/ipcSF?id=###ID###
+PRINTS                      = http://www.bioinf.manchester.ac.uk/cgi-bin/dbbrowser/sprint/searchprintss.cgi?prints_accn=###ID###&display_opts=Prints&category=None&queryform=false&regexpr=off&prints_accn=###ID###
+PROSITE                     = http://www.expasy.ch/prosite/###ID###
+PROSITE_PROFILES            = http://www.expasy.ch/prosite/###ID###
+PROSITE_PATTERNS            = http://www.expasy.ch/prosite/###ID###
 QUICK_GO_IMP                = http://www.ebi.ac.uk/QuickGO/annotations?goId=###ID###&evidence=IMP&geneProductId=###PR_ID###
 RGD_SEARCH                  = https://rgd.mcw.edu/rgdweb/elasticResults.html?category=###TYPE###&term=###ID###
+SFLD                        = https://www.ebi.ac.uk/interpro/entry/sfld/###ID###
+SMART                       = http://smart.embl-heidelberg.de/smart/do_annotation.pl?DOMAIN=###ID###
+SUPERFAMILY                 = http://supfam.org/SUPERFAMILY/cgi-bin/scop.cgi?ipid=###ID###
 TESLOVICH                   = http://www.sph.umich.edu/csg/abecasis/public/lipids2010
+TIGRFAM                     = http://www.ebi.ac.uk/interpro/entry/tigrfams/###ID###
 UNIPROT_SEARCH              = http://www.uniprot.org/uniprot/?query=###ID###
 UNIPROT_VARIATION           = http://web.expasy.org/variant_pages/###ID###.html
 SNPEDIA                     = http://bots.snpedia.com/
@@ -433,8 +447,6 @@ TREEFAMSEQ                  = http://www.treefam.org/sequence/###ID###
 TREEFAMTREE                 = http://www.treefam.org/family/ac=###ID###
 GENOMICUSSYNTENY            = http://www.genomicus.biologie.ens.fr/genomicus/cgi-bin/search.pl?view=default&query=###ID###
 PHYLOMEDB                   = http://phylomedb.org/?q=search_tree&seqid=###ID###
-PANTHERDB                   = http://www.pantherdb.org/panther/family.do?clsAccession=###ID###
-HAMAP                       = http://hamap.expasy.org/unirule/###ID###
 WASABI                      = http://wasabiapp.org:8000/
 WASABI_ENSEMBL              = http://wasabiapp.org/ensembl/?wasabiURL=###URL###
 
@@ -522,16 +534,10 @@ OXFORD_FGU_MD_GENE          =
 OXFORD_FGU_MD_TSCRIPT       =
 OXFORD_FGU_OA_GENE          = http://genserv.anat.ox.ac.uk/cgi-bin/gbrowse_details/Platypus?name=###ID###;class=Gene
 OXFORD_FGU_OA_TSCRIPT       = http://genserv.anat.ox.ac.uk/cgi-bin/gbrowse_details/Platypus?name=###ID###;class=mRNA
-PFAM                     = http://pfam.xfam.org/family/###ID###
 PFSCAN                   = http://www.isrec.isb-sib.ch/cgi-bin/get_pstprf?###ID###
 PIDN                     = http://srs.ebi.ac.uk/srsbin/cgi-bin/wgetz?-e+[EMBL_features-prd:###ID###]
-PIRSF                    = http://pir.georgetown.edu/cgi-bin/ipcSF?id=###ID###
 PIPMAKER                 = http://pipmaker.bx.psu.edu/pipmaker/
 PLATYPUS_OLFACTORY_RECEPTOR = http://genome.weizmann.ac.il/horde/organism/card/symbol:###ID###
-PRINTS                   = http://www.bioinf.manchester.ac.uk/cgi-bin/dbbrowser/sprint/searchprintss.cgi?prints_accn=###ID###&display_opts=Prints&category=None&queryform=false&regexpr=off&prints_accn=###ID###
-PROSITE                  = http://www.expasy.ch/prosite/###ID###
-PROSITE_PROFILES         = http://www.expasy.ch/prosite/###ID###
-PROSITE_PATTERNS         = http://www.expasy.ch/prosite/###ID###
 PREDICTION_SPTREMBL         = http://www.ebi.uniprot.org/entry/###ID###
 QUICKGO                  = http://www.ebi.ac.uk/ego/DisplayGoTerm?id=###ID###
 RAT_GENOME_DATABASE      = http://rgd.mcw.edu/tools/query/query.cgi?id=###ID###
@@ -561,14 +567,12 @@ SHGC                     = http://www-shgc.stanford.edu/cgi-bin/getSTSinfo?###ID
 SHARES_CDS_WITH_ENST        = /###SPECIES###/idhistoryview?transcript=###ID###
 SHARES_CDS_WITH_OTTT        = http://vega.sanger.ac.uk/###SPECIES###/Transcript/Summary?t=###ID###
 SHARES_CDS_AND_UTR_WITH_OTTT = http://vega.sanger.ac.uk/###SPECIES###/Transcript/Summary?t=###ID###
-SMART                    = http://smart.embl-heidelberg.de/smart/do_annotation.pl?DOMAIN=###ID###
 SNGR_HVER                   =
 SP                       = http://www.uniprot.org/uniprot/###ID###
 SPROT                    = http://www.uniprot.org/uniprot/###ID###
 SPTREMBL                 = http://www.uniprot.org/uniprot/###ID###
 SRS_FALLBACK             = http://srs.ebi.ac.uk/srsbin/cgi-bin/wgetz?-newId+-e+[libs%3d{IMGTLIGM%20SWALL%20REFSEQ%20EMBL%20REFSEQP}-all:###ID###]+-vn+2
 SRS_PROTEIN              = http://srs.ebi.ac.uk/srsbin/cgi-bin/wgetz?-e+[libs%3d{SWALL%20REFSEQP}-all:###ID###*]
-SUPERFAMILY                 = http://supfam.org/SUPERFAMILY/cgi-bin/scop.cgi?ipid=###ID###
 SWALLPROTEIN             = http://www.uniprot.org/uniprot/###ID###
 SWISS                    = http://www.uniprot.org/uniprot/###ID###
 SWISS-PROT               = http://www.uniprot.org/uniprot/###ID###
@@ -577,7 +581,6 @@ SWISSPROT_NAME           = http://www.uniprot.org/uniprot/###ID###
 SWISSPROT_SANGER         = http://www.uniprot.org/uniprot/###ID###
 TCAG                        =
 TIFFIN                      =
-TIGRFAM                     = http://www.ebi.ac.uk/interpro/signature/###ID###
 TIGR_HOME                = http://www.tigr.org/tdb/tdb.html
 TRACE                    = http://trace.ensembl.org/perl/traceview?tracedb=0;traceid=###ID###
 TRNA                     = http://www.ebi.ac.uk/cgi-bin/dbfetch?db=emblsva;id=###ID###


### PR DESCRIPTION
## Description

Add and update URL templates. This is required to add links to protein domains in web VEP results: https://github.com/Ensembl/public-plugins/pull/618

## Views affected

Web VEP results: http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Tools/VEP/Results?tl=Jhfkd0i4oa5KPvRV-82

Any view that uses external URLs based on the modified variables.

## Possible complications

This PR replaces `PFAM` website with InterPro: the [Pfam website](http://pfam.xfam.org) is going to be decommissioned in January 2023 and redirects to InterPro. All links that make use of the `PFAM` variable to create an external URL should now direct to InterPro.

## Related JIRA Issues (EBI developers only)

[ENSVAR-3396](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-3396)
