### PR TITLE
Update Pfam URLs

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -522,7 +522,7 @@ OXFORD_FGU_MD_GENE          =
 OXFORD_FGU_MD_TSCRIPT       =
 OXFORD_FGU_OA_GENE          = http://genserv.anat.ox.ac.uk/cgi-bin/gbrowse_details/Platypus?name=###ID###;class=Gene
 OXFORD_FGU_OA_TSCRIPT       = http://genserv.anat.ox.ac.uk/cgi-bin/gbrowse_details/Platypus?name=###ID###;class=mRNA
-PFAM                     = http://pfam.xfam.org/family/###ID###
+PFAM                     =  https://www.ebi.ac.uk/interpro/entry/pfam/###ID###
 PFSCAN                   = http://www.isrec.isb-sib.ch/cgi-bin/get_pstprf?###ID###
 PIDN                     = http://srs.ebi.ac.uk/srsbin/cgi-bin/wgetz?-e+[EMBL_features-prd:###ID###]
 PIRSF                    = http://pir.georgetown.edu/cgi-bin/ipcSF?id=###ID###


### PR DESCRIPTION
This PR updates retired Pfam URLs to the new site (InterPro).
Other affected repos listed in the JIRA ticket.

JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6701
Sandbox: http://wp-np2-1d.ebi.ac.uk:1680