### PR TITLE
Remove Ensembl gene/protein family entries

### DIFF
--- a/modules/EnsEMBL/Web/Configuration/Gene.pm
+++ b/modules/EnsEMBL/Web/Configuration/Gene.pm
@@ -125,17 +125,6 @@ sub populate_tree {
   
   $compara_menu->append($pl_node);
   
-  my $fam_node = $self->create_node('Family', 'Ensembl protein families',
-    [qw( family EnsEMBL::Web::Component::Gene::Family )],
-    { 'availability' => 'family not_strain', 'concise' => 'Ensembl protein families' }
-  );
-  
-  $fam_node->append($self->create_subnode('Family/Genes', uc($species_defs->get_config($hub->species, 'SPECIES_DISPLAY_NAME')) . ' genes in this family',
-    [qw( genes EnsEMBL::Web::Component::Gene::FamilyGenes )],
-    { 'availability'  => 'family not_strain', 'no_menu_entry' => 1 }
-  ));
-
-  $compara_menu->append($fam_node);
   
   # Compara menu for strain (strain menu available on main species but collapse, main menu not available/grey out/collapse on strain page)
   # The node key (Strain_) is used by Component.pm to determine if it is a strain link on the main species page, so be CAREFUL when changing this  


### PR DESCRIPTION
This PR removes the Ensembl protein family and Ensembl gene family left-side menu entries from gene view.
The menu entries have been disabled since its retirement in e102.

JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6678
Affected views: Gene view
Sandbox: http://wp-np2-1d.ebi.ac.uk:1680/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000139618;r=13:32315086-32400268