### PR TITLE
Add links to protein domains in Variation page (e109)

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
@@ -711,7 +711,27 @@ sub detail_panel {
         }
       }
       foreach my $domain_src (sort(keys(%domains))) {
-        $data{domains} .= "<b>$domain_src</b><div class=\"column-right\"><ul class=\"compact\"><li>".join('</li><li>', @{$domains{$domain_src}})."</li></ul></div>";
+        $data{domains} .= "<b>$domain_src</b><div class=\"column-right\"><ul class=\"compact\">";
+        foreach my $value (@{$domains{$domain_src}}) {
+          my $key = uc $domain_src;
+          my $value_url = $value;
+
+          if ($key eq 'PANTHER') {
+            $key = "PANTHERDB";
+          } elsif ($key =~ '^PROSITE') {
+            $key = "PROSITE";
+          } elsif ($key =~ '^PDB-ENSP') {
+            $key = "PDB";
+            ( $value_url ) = $value =~ /(.+)\./;
+          } elsif ($key =~ '^AFDB-ENSP') {
+            $key = "ALPHAFOLD";
+            ( $value_url ) = $value =~ /-(.+)-/;
+          } elsif ($key eq 'GENE3D') {
+            $value_url = "G3DSA:$value" unless $value =~ /^G3DSA:/;
+          }
+          $data{domains} .= '<li>' . $hub->get_ExtURL_link($value, $key, $value_url) . '</li>';
+        }
+        $data{domains} .= "</ul></div>";
       }
 
 


### PR DESCRIPTION
## Description

Add external links to protein domains from multiple sources, including:
- AlphaFold
- Gene3D
- HAMAP
- PANTHER
- PDB
- Pfam
- CDD
- PIRSF
- PROSITE patterns
- PROSITE profiles
- SMART
- Superfamily
- SFLD
- TIGRFAM
- Prints

## Views affected

Variation page > Consequence details table > **Overlapping protein domains** row. Examples:
* [rs766926945](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Variation/Mappings?db=core;r=8:109335664-109336664;v=rs766926945;vdb=variation;vf=729142651#ENST00000521688_729142651_A_tablePanel)
* [rs1567817867](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Variation/Mappings?db=core;g=ENSG00000012048;r=17:43044295-43170245;t=ENST00000357654;v=rs1567817867;vdb=variation;vf=266701878#ENST00000352993_266701878_AT_tablePanel)
* [rs1216830090](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Variation/Mappings?db=core;r=CHR_HSCHR22_1_CTG7:23979729-23980729;v=rs1216830090;vdb=variation;vf=273674389#ENST00000618279_273674389_A_tablePanel)
* [rs780980629](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Variation/Mappings?r=20:64068900-64069900;v=rs780980629;vdb=variation;vf=240357688#ENST00000343484_240357688_A_tablePanel)
* [rs748536692](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Variation/Mappings?r=X:124346226-124347226;v=rs748536692;vdb=variation;vf=110816314#ENST00000360027_110816314_T_tablePanel)

@likhitha-surapaneni could you please check if these links make sense?

## Possible complications

Only changes a table cell for individual variation entries.

## Merge conflicts

No merge conflicts found.

## Related JIRA Issues (EBI developers only)

[ENSVAR-5207](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5207)
