### PR TITLE
Fix regulation matrix when feature types are missing

### DIFF
--- a/htdocs/components/25_ConfigRegMatrixForm.js
+++ b/htdocs/components/25_ConfigRegMatrixForm.js
@@ -1406,6 +1406,11 @@ Ensembl.Panel.ConfigRegMatrixForm = Ensembl.Panel.ConfigMatrixForm.extend({
   displayCheckbox: function(obj) {
 
     var data = obj.data;
+
+    if (!data) {
+      return;
+    }
+
     var container = obj.container;
     var listType = obj.listType;
     var parentTabContainer = obj.parentTabContainer;


### PR DESCRIPTION
## Description
If the regulation database does not contain entries in the `feature_type` table for all different classes of features (Open Chromatin, Histone and Transcription Factor), the regulation matrix becomes unusable. Here's what it looks like (trying to click a checkbox, but nothing happens):

https://user-images.githubusercontent.com/6834224/198000706-0c18d8b3-778e-486f-88de-c846133bcddf.mp4

The reason is because javascript is trying to access a field on an undefined object:

![image](https://user-images.githubusercontent.com/6834224/198005273-d21cb43c-2492-4f2d-b5e6-834e5fef1b87.png)

The null check added in this PR seems to be sufficient

## Related JIRA Issue
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6517

Sandbox url:
http://wp-np2-1e.ebi.ac.uk:8410/Sus_scrofa/Location/View?r=14:10195351-10284707

_(when testing please check that the sandbox is using the test pig database that doesn't contain all classes of features)_

![image](https://user-images.githubusercontent.com/6834224/198006291-ba9b6cf5-41b9-4b75-be5b-f887f9a01888.png)
