### PR TITLE
Update GeneCards xref

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -488,7 +488,7 @@ DROSOPHILABLAST          = http://www.flybase.org/cgi-bin/uniq.html?db=fbpp&fiel
 AEDESBLAST               = /Aedes_aegypti/protview?peptide=###ID###
 DROSOPHILA_EST           = http://weasel.lbl.gov/cgi-bin/EST/community_query/cloneReport.pl?url=cloneReport.pl&db_name=estlabtrack&id_type=0&id_value=###ID###&sort=3&reverse
 GDB_HOME                 = http://gdbwww.gdb.org/
-GENECARD                 = http://bioinfo.weizmann.ac.il/cards-bin/cardsearch.pl?search=###ID###
+GENECARDS                = https://www.genecards.org/cgi-bin/carddisp.pl?id_type=hgnc&id=###ID###
 GENETHON_HOME            = http://www.genethon.fr/
 GENEVIEW                 = /###SPECIES###/geneview?geneid=###ID###
 GOGENE                   = /###SPECIES###/goview?geneid=###ID###


### PR DESCRIPTION
This PR updates xref URL template for GeneCards database.

[Sandbox](http://wp-np2-1d.ebi.ac.uk:1680) (xref not used in website)
[JIRA](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6642)