### PR TITLE
Add EVA URL look up for variants

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -378,6 +378,7 @@ EFO                         = https://www.ebi.ac.uk/ols/ontologies/efo/terms?sho
 EGA_SEARCH                  = http://www.ebi.ac.uk/ebisearch/search.ebi?db=ega&query=###ID###
 ESP                         = http://evs.gs.washington.edu/EVS/PopStatsServlet?searchBy=chromosome&chromosome=###CHR###&chromoStart=###START###&chromoEnd=###END###
 ESP_HOME                    = http://evs.gs.washington.edu/EVS/ 
+EVA                         = https://www.ebi.ac.uk/eva/?variant&accessionID=###ID###
 EVA_STUDY                   = https://www.ebi.ac.uk/eva/?eva-study=
 GEFOS                       = http://www.gefos.org 
 GEM_J_POP                   = https://togovar.biosciencedbc.jp/doc/datasets/gem_j_wga

--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -224,6 +224,9 @@ sub variation_source {
     } else {
       $source_link = "";
     } 
+  } elsif ($source eq "EVA") {
+    $source_link = $hub->get_ExtURL_link("$source_prefix $source", $source, $name);
+
   } elsif ($source =~ /ClinVar/i) {
     $sname = ($name =~ /^rs/) ?  'CLINVAR_DBSNP' : 'CLINVAR';
     $source_link = $hub->get_ExtURL_link("About $source", $sname, $name);


### PR DESCRIPTION
## Requirements

Can be fixed for e!109 release

## Description

Copy update adding EVA external link from https://github.com/Ensembl/ensembl-webcode/pull/859 to main branch.

## Views affected

The  'View in EVA'  link on the variant summary tab on www goes to the EVA home page, not the EVA variant page, eg:

http://www.ensembl.org/Felis_catus/Variation/Explore?r=A1:10292456-10293456;v=rs43782442;vdb=variation;vf=1711112

This update enables the linking to the EVA variant page, as in the covid site ( addded to e!104 after www release):

https://covid-19.ensembl.org/Sars_cov_2/Variation/Explore?db=core;g=ENSSASG00005000004;r=MN908947.3:21563-25384;t=ENSSAST00005000004;v=rs3161510488;vdb=variation;vf=1490

## Possible complications

None expected

## Merge conflicts
None expected

## Related JIRA Issues (EBI developers only)


