### PR TITLE
Fix all regulation tracks enabled by default

### DIFF
--- a/modules/EnsEMBL/Web/ImageConfig/structural_variation.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/structural_variation.pm
@@ -69,7 +69,7 @@ sub init_cacheable {
   );
 
   $self->modify_configs(
-    [ 'variation_feature_variation', 'somatic_mutation_all', 'regulatory_features', 'functional_other_regulatory_regions' ],
+    [ 'variation_feature_variation', 'somatic_mutation_all', 'functional_other_regulatory_regions'],
     { display => 'normal' }
   );
 


### PR DESCRIPTION
## Description

There is a long list of regulatory tracks that were turned on by default in the Structural Variation page. A side cause of this issue is that the page eventually breaks due to attempting to load a big amount of data into the page.

The issue was fixed after removing `regulatory_features` tracks which were enabled in the code. This was the longest list of regulatory tracks.

Relevant links:

- Live site where the page breaks: https://www.ensembl.org/Homo_sapiens/StructuralVariation/Context?r=13:99984196-99986821;sv=nsv916030;svf=121912273;vdb=variation
- Sandbox where it now works: http://wp-np2-1e.ebi.ac.uk:8310/Homo_sapiens/StructuralVariation/Context?r=13:99984196-99986821;sv=nsv916030;svf=121912273;vdb=variation

## Views affected

Structural variant (genome context)

## Possible complications

Not sure about this yet

## Related JIRA Issues (EBI developers only)

[ENSWEB-6624](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6624)