### PR TITLE
Add 3D structure links to PDB and AlphaFold in variation page (e109)

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
@@ -721,8 +721,8 @@ sub detail_panel {
         my $isAFDB = $domain_src =~ '^AFDB-ENSP' && $consequence && $consequence eq 'missense variant';
         if ( $isPDB || $isAFDB ) {
           my $button_url = $hub->url({
-            type    => 'Tools',
-            action  => $isPDB ? 'VEP/PDB' : 'VEP/AFDB',
+            type    => $isPDB ? 'Variation' : 'Tools',
+            action  => $isPDB ? 'PDB' : 'VEP/AFDB',
             var     => $object->name,
             pos     => $tv->translation_start,
             cons    => $consequence,

--- a/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
@@ -750,6 +750,7 @@ sub detail_panel {
             ( $value_url ) = $value =~ /(.+)\./;
           } elsif ($key =~ '^AFDB-ENSP') {
             $key = "ALPHAFOLD";
+            ( $value ) = $value =~ /(.+)\./; # remove chain from AlphaFold ID
             ( $value_url ) = $value =~ /-(.+)-/;
           } elsif ($key eq 'GENE3D') {
             $value_url = "G3DSA:$value" unless $value =~ /^G3DSA:/;

--- a/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
@@ -711,7 +711,32 @@ sub detail_panel {
         }
       }
       foreach my $domain_src (sort(keys(%domains))) {
-        $data{domains} .= "<b>$domain_src</b><div class=\"column-right\"><ul class=\"compact\">";
+
+        # add button to PDB and AlphaFold models
+        my $structure_button = "";
+        my $consequence = $tv->display_consequence;
+        $consequence =~ s/_/ /g;
+
+        my $isPDB = $domain_src =~ '^PDB-ENSP';
+        my $isAFDB = $domain_src =~ '^AFDB-ENSP' && $consequence && $consequence eq 'missense variant';
+        if ( $isPDB || $isAFDB ) {
+          my $button_url = $hub->url({
+            type    => 'Tools',
+            action  => $isPDB ? 'VEP/PDB' : 'VEP/AFDB',
+            var     => $object->name,
+            pos     => $tv->translation_start,
+            cons    => $consequence,
+            g       => $gene_id,
+            t       => $tr_id,
+            species => $hub->species
+          });
+
+          my $model_type = $isPDB ? "Protein Structure View" : "Alphafold model";
+          $structure_button = qq{<div class="in-table-button"><a href="$button_url">$model_type</a></div>};
+        }
+
+        $data{domains} .= "<b>$domain_src</b>" . $structure_button . "<div class=\"column-right\"><ul class=\"compact\">";
+
         foreach my $value (@{$domains{$domain_src}}) {
           my $key = uc $domain_src;
           my $value_url = $value;


### PR DESCRIPTION
## Description

Add buttons to view 3D protein structure models for PDB and AlphaFold associated with variant consequences, similar to code from https://github.com/Ensembl/public-plugins/pull/555

AlphaFold button is only shown for missense variants.

## Views affected

Variation tab > Genes and regulation > Details of transcript consequences > Overlapping protein domains

For instance: http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Variation/Mappings?db=core;r=8:109335664-109336664;v=rs334;vdb=variation;vf=164384244#ENST00000335295_164384244_C_tablePanel

## Possible complications

No complications, only adds HTML to variation page.

## Merge conflicts

No conflicts.

## Related JIRA Issues (EBI developers only)

[ENSVAR-5231](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5231)