### PR TITLE
Fix /ftp proxy to use http

### DIFF
--- a/conf/httpd.conf
+++ b/conf/httpd.conf
@@ -155,8 +155,8 @@ RewriteRule ^(.*)$ /Tools/Down [R]
 </IfDefine>
 
 <Location /ftp>
- ProxyPass https://ftp.ebi.ac.uk/ensemblorg/
- ProxyPassReverse https://ftp.ebi.ac.uk/ensemblorg/
+ ProxyPass http://ftp.ebi.ac.uk/ensemblorg/
+ ProxyPassReverse http://ftp.ebi.ac.uk/ensemblorg/
 </Location>
 
 #### Biomart redirect ####


### PR DESCRIPTION
www.ensembl.org/ftp is not working due to a recent change of http to https. 
Our Apache can't proxy requests to https, as it requires another module installed like mod_ssl.

Need to revert the latest commit.