### PR TITLE
correct Variation ClinVar link in rapid release

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -226,7 +226,7 @@ sub variation_source {
     } 
   } elsif ($source =~ /ClinVar/i) {
     $sname = ($name =~ /^rs/) ?  'CLINVAR_DBSNP' : 'CLINVAR';
-    $source_link = $hub->get_ExtURL_link("About $source", $sname, $name);
+    $source_link = $hub->get_ExtURL_link("View in $source", $sname, $name);
   } elsif ($source =~ /SGRP/) {
     $source_link = $hub->get_ExtURL_link("About $source", 'SGRP_PROJECT');
   } elsif ($source =~ /COSMIC/) {


### PR DESCRIPTION
## Description

Correct the text for the hyperlinks (not the actual href link) linking EnsEMBL Variation 'Original source' from 'About ClinVar' to 'View in ClinVar'.

## Views affected

Affects the region view - click on a variant's link along the track for ClinVar

examples with my Rapid Release sandbox:
[Example 1 - human T2T pangenome](http://wp-np2-25.ebi.ac.uk:8001/Homo_sapiens_GCA_009914755.4/Variation/Explore?db=core;r=2:179145571-179145780;source=ClinVar;v=467074;vdb=variation;vf=2:179145597:G_C:ClinVar)
[Example 2 - human pangenome GCA_018472595.1](http://wp-np2-25.ebi.ac.uk:8001/Homo_sapiens_GCA_018472595.1/Variation/Explore?db=core;r=JAHBCB010000019.1:53183300-53183427;source=ClinVar;v=1304774;vdb=variation;vf=JAHBCB010000019.1:53183379:G_C:ClinVar)

## Possible complications

None expected

## Merge conflicts

Tested just before submitting this pull request

## Related JIRA Issues (EBI developers only)

JIRA link for context - [ENSVAR-5264](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5264)

## Additional reviewers
@nakib103 has kindly aggreed to review this pull request for Variation's side.
