### PR TITLE
New trackhub registry

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -476,7 +476,7 @@ DROSOPHILABLAST          = http://www.flybase.org/cgi-bin/uniq.html?db=fbpp&fiel
 AEDESBLAST               = /Aedes_aegypti/protview?peptide=###ID###
 DROSOPHILA_EST           = http://weasel.lbl.gov/cgi-bin/EST/community_query/cloneReport.pl?url=cloneReport.pl&db_name=estlabtrack&id_type=0&id_value=###ID###&sort=3&reverse
 GDB_HOME                 = http://gdbwww.gdb.org/
-GENECARD                 = http://bioinfo.weizmann.ac.il/cards-bin/cardsearch.pl?search=###ID###
+GENECARDS                = https://www.genecards.org/cgi-bin/carddisp.pl?id_type=hgnc&id=###ID###
 GENETHON_HOME            = http://www.genethon.fr/
 GENEVIEW                 = /###SPECIES###/geneview?geneid=###ID###
 GOGENE                   = /###SPECIES###/goview?geneid=###ID###

--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -32,7 +32,7 @@ ENSEMBL_FTP_URL               = https://ftp.ensembl.org/pub
 ENSEMBL_GENOMES_FTP_URL       = https://ftp.ebi.ac.uk/ensemblgenomes/pub
 
 TRACKHUB_MAX_TRACKS           = 10000
-TRACKHUB_REGISTRY_URL         = https://www.trackhubregistry.org 
+TRACKHUB_REGISTRY_URL         = https://test.trackhubregistry.org 
 EUROPE_PMC_REST               = https://www.ebi.ac.uk/europepmc/webservices/rest
 
 ; Database connection settings.

--- a/modules/EnsEMBL/Web/Component/UserData/TrackHubResults.pm
+++ b/modules/EnsEMBL/Web/Component/UserData/TrackHubResults.pm
@@ -53,7 +53,7 @@ sub content {
   ## Pagination
   my $entries_per_page  = 5;
   my $current_page      = $hub->param('page') || 1;
-  my $url_params = {'page' => $current_page, 'entries_per_page' => $entries_per_page};
+  my $url_params = {'page' => $current_page, 'entries_per_page' => $entries_per_page, '_delimiter' => '&'};
   
   my ($result, $error) = $self->object->thr_search($url_params);
 


### PR DESCRIPTION
This PR will switch trackhub search to the new Trackhub Registry.
I will update the registry URL in the PR once the new service has moved to production.

Sandbox: http://wp-np2-1d.ebi.ac.uk:1680/info/website/trackhubs/index.html
JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6727 
