### PR TITLE
Sync Variation consequences table (e110)

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/ConsequenceTable.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/ConsequenceTable.pm
@@ -147,13 +147,6 @@ sub render {
       'impact'  => 'MODERATE',
     },
     {
-      'term'    => 'regulatory_region_ablation', 
-      'colour'  => 'a52a2a', 
-      'desc'    => 'A feature ablation whereby the deleted region includes a regulatory region', 
-      'acc'     => '0001894', 
-      'impact'  => 'MODERATE',
-    },
-    {
       'term'    => 'splice_region_variant', 
       'colour'  => 'ff7f50', 
       'desc'    => 'A sequence variant in which a change has occurred within the region of the splice site, either within 1-3 bases of the exon or 3-8 bases of the intron', 
@@ -298,6 +291,13 @@ sub render {
       'colour'  => 'a52a2a', 
       'desc'    => 'A sequence variant located within a transcription factor binding site', 
       'acc'     => '0001782', 
+      'impact'  => 'MODIFIER',
+    },
+    {
+      'term'    => 'regulatory_region_ablation', 
+      'colour'  => 'a52a2a', 
+      'desc'    => 'A feature ablation whereby the deleted region includes a regulatory region', 
+      'acc'     => '0001894', 
       'impact'  => 'MODIFIER',
     },
     {


### PR DESCRIPTION
## Description

Sync Variation consequences table with that from https://github.com/Ensembl/public-plugins/pull/643. Only needed for e110.

## Views affected

Changes restricted to the Variation consequences table: http://wp-np2-11.ebi.ac.uk:6070/info/genome/variation/prediction/predicted_data.html

## Possible complications

None.

## Merge conflicts

None.

## Related JIRA Issues (EBI developers only)

[ENSVAR-3733](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-3733)
