### PR TITLE
Fix correct tools form options for a particular species not being displayed 

### DIFF
--- a/htdocs/components/00_jquery_selecttotoggle.js
+++ b/htdocs/components/00_jquery_selecttotoggle.js
@@ -30,12 +30,23 @@
       var currValue = this.nodeName === 'INPUT' && this.type === 'checkbox' && !this.checked ? false : this.value; // if checkbox is not ticked, ignore it's value
 
       var escapeDotInClassName = function (className) {
-        var i = 0;
+        var escapeDot = function (str) {
+          var i = 0;
+          
+          return str ? str.replace(/[.]/g, function (match) {
+            i += 1;
+            return i > 1 ? '\\\.' : '.';
+          }) : '';
+        };
 
-        return className ? className.replace(/[.]/g, function (match) {
-           i += 1;
-           return i > 1 ? '\\\.' : '.';
-        }) : '';
+        if (/\s/g.test(className)) {
+          var classList = className.split(',');
+          return classList.map(function (className) {
+            return escapeDot(className);
+          }).join(',');
+        } else {
+          escapeDot(className);
+        }
       };
 
       // go through all the selectors in the toggleMap and hide them except the one that corresponds to current element's value


### PR DESCRIPTION
## Description
@jyobhai spotted that the relevant options were not being displayed when species are changed in forms when testing the fix for MANE select being displayed to all species (https://github.com/Ensembl/public-plugins/pull/655). This was due to the escape code breaking the species selection.

The related PR in public-plugins is: https://github.com/Ensembl/public-plugins/pull/661

## Views affected
Tools forms (especially Variant Recorder and VEP)

## Possible complications
Some more species selection issues?

## Related JIRA Issues (EBI developers only)
[ENSWEB-6716](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6716)
