### PR TITLE
Fix escapeDot breaking BLAST form

### DIFF
--- a/htdocs/components/00_jquery_selecttotoggle.js
+++ b/htdocs/components/00_jquery_selecttotoggle.js
@@ -30,6 +30,10 @@
       var currValue = this.nodeName === 'INPUT' && this.type === 'checkbox' && !this.checked ? false : this.value; // if checkbox is not ticked, ignore it's value
 
       var escapeDotInClassName = function (className) {
+        if (!className) {
+          return;
+        }
+
         var escapeDot = function (str) {
           var i = 0;
           


### PR DESCRIPTION
## Description

Fix BLAST form being broken because of a change that was made in #950. Now the `className` is explicitly checked if it is undefined or not before the rest of the function is executed.

Sandbox link: http://wp-np2-1e.ebi.ac.uk:8310/Multi/Tools/Blast?db=core

## Views affected

BLAST

## Possible complications

Not sure

## Related JIRA Issues (EBI developers only)

[ENSWEB-6794](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6794)
