### PR TITLE
Update OMIM URLs

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -244,9 +244,9 @@ EPMC_MED                    = http://europepmc.org/abstract/MED/###ID###
 EUROPE_PMC                  = http://europepmc.org/abstract/###SOURCE###/###ID###
 HAMAP                       = http://hamap.expasy.org/signature/###ID###
 LRG                         = https://www.lrg-sequence.org/search/?query=###ID###
-MIM                         = http://www.omim.org/###ID###
-MIM_GENE                    = http://www.omim.org/###ID###
-MIM_MORBID                  = http://www.omim.org/###ID###
+MIM                         = http://www.omim.org/entry/###ID###
+MIM_GENE                    = http://www.omim.org/entry/###ID###
+MIM_MORBID                  = http://www.omim.org/entry/###ID###
 PANTHERDB                   = http://www.pantherdb.org/panther/family.do?clsAccession=###ID###
 ZFIN_ID                     = http://zfin.org/###ID###
 INTACT			    = https://www.ebi.ac.uk/intact/details/interaction/###ID###
@@ -402,7 +402,7 @@ NEXTGEN_POP                 = http://projects.ensembl.org/nextgen/
 OIVD                        = http://www.lovd.nl/###ID###
 OLS                         = http://www.ebi.ac.uk/ols/search?q=###ID###
 OMIA                        = https://omia.org/###ID###/###TAX###/
-OMIM                        = http://www.omim.org/###ID###
+OMIM                        = http://www.omim.org/entry/###ID###
 ORDO                        = http://www.orpha.net/ORDO/###ID###
 ORPHANET                    = http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=###ID###
 PAHDB                       = http://www.pahdb.mcgill.ca/PahdbSearch.php?SearchValue=###ID###&SearchField=mut_name&SearchOrderedField=id_mut&SearchAscDesc=ASC&Submit=Submit&MenuSelection=Mutation


### PR DESCRIPTION

## Description

The URLs for OMIM are broken in the main site; see [ENSWEB-6803](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6803). This PR updates the URL in DEFAULTS.ini, as per Ben's ticket.

## Views affected

See the "MIM Morbid" link in the [phenotypes table](https://www.ensembl.org/Homo_sapiens/Gene/Phenotype?db=core;g=ENSG00000164405;r=5:132866630-132868847).

## Possible complications

None.

## Merge conflicts

None.

## Related JIRA Issues (EBI developers only)

[ENSWEB-6803](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6803)
