### PR TITLE
Fall back to MLSS if genome not in species tree

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/Compara.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara.pm
@@ -361,7 +361,7 @@ sub get_species_info {
       my $id = $gdb->dbID;
       my @stats = qw(genome_coverage genome_length coding_exon_coverage coding_exon_length);
       foreach (@stats) {
-        $info->{$sp}{$_} = $genome_db_id_2_node_hash ? $genome_db_id_2_node_hash->{$id}->get_value_for_tag($_) : $mlss->get_value_for_tag($_.'_'.$id);
+        $info->{$sp}{$_} = $genome_db_id_2_node_hash && exists $genome_db_id_2_node_hash->{$id} ? $genome_db_id_2_node_hash->{$id}->get_value_for_tag($_) : $mlss->get_value_for_tag($_.'_'.$id);
       }
     }
   }


### PR DESCRIPTION
This allows for the multiple genome statistics page to be viewed for Cactus HAL alignments in which each subgenome of a polyploid genome is stored separately, so that the principal polyploid `genome_db_id` is not in the species tree associated with the Cactus MLSS.

## Description

In `EnsEMBL::Web::Document::HTML::Compara`, the `get_species_info` method fetches genomic coverage stats from the species-tree node corresponding to a given genome. However, if a genome does not correspond to a single node of a species tree — as is the case for the polyploid genomes in the Wheat Cactus alignment — then it is not currently possible to fetch any stats for that genome from a node of the species tree.

This results in an error which prevents the display of the multiple genome alignment stats page  (e.g. [here](https://staging-plants.ensembl.org/info/genome/compara/mlss.html?mlss=313160)).

This PR adds an additional check to the existing code for fetching genomic alignment stats from the species-tree node corresponding to a genome: if the genome isn't present in the species tree, the method falls back to fetching these from the MLSS.

## Views affected

This affects the multiple genome alignment statistics views. It is only expected to bring about a change in cases such as the Wheat Cactus HAL alignment, where not all genomes in the alignment are directly represented by a single node in the species tree associated with the MLSS.

It is expected that this change would cause the [Wheat Cactus genomic alignment stats page](https://staging-plants.ensembl.org/info/genome/compara/mlss.html?mlss=313160) to display without error.

## Possible complications

This is unlikely to have adverse side effects, as if a genome is not represented in the given species tree, then there won't be any stats for that genome in the species tree.

## Merge conflicts

No merge conflicts detected.

## Related JIRA Issues (EBI developers only)

- NA
