### PR TITLE
Jk ensweb 6724

### DIFF
--- a/htdocs/info/website/browsers.html
+++ b/htdocs/info/website/browsers.html
@@ -18,7 +18,7 @@
   <li>Firefox 108+</li>
   <li>Safari 15.6+</li>
 </ul>
-<p>Some features of the site such as AlphaFold will benifit from OpenGL compatible graphics cards.</p>
+<p>Some features of the site such as AlphaFold will benefit from OpenGL compatible graphics cards.</p>
 <p>We recommend <a href="http://www.mozilla.org/en-US/firefox/fx/" title="Get Firefox!">Firefox</a> for browsing Ensembl.</p>
 </body>
 </html>

--- a/htdocs/info/website/browsers.html
+++ b/htdocs/info/website/browsers.html
@@ -11,23 +11,14 @@
 <img src="/img/firefox_logo.png" /><br/>
 <img src="/img/safari_logo.png" />
 </div>
-<p>The following browsers are fully supported, i.e. all site features including JavaScript and CSS styles should work properly:</p>
+<p>The following desktop browsers are fully supported, i.e. all site features including JavaScript and CSS styles should work properly:</p>
 <ul>
-  <li>Chrome</li>
-  <li>Firefox 3.5+</li>
-  <li>Internet Explorer 8+</li>
-  <li>Safari</li>
+  <li>Edge 108+</li>
+  <li>Chrome 109+</li>
+  <li>Firefox 108+</li>
+  <li>Safari 16.1+</li>
 </ul>
+<p>Some features of the site such as AlphaFold will benifit from OpenGL compatible graphics cards.</p>
 <p>We recommend <a href="http://www.mozilla.org/en-US/firefox/fx/" title="Get Firefox!">Firefox</a> for browsing Ensembl.</p>
-
-<h2>Other browsers</h2>
-<p>The following are not officially supported but should work with most or all of the site's current features:</p>
-<ul>
-  <li>Firefox 3</li>
-  <li>Internet Explorer 6 and 7</li>
-  <li>Camino</li>
-  <li>Opera 9+</li>
-</ul>
-
 </body>
 </html>

--- a/htdocs/info/website/browsers.html
+++ b/htdocs/info/website/browsers.html
@@ -16,7 +16,7 @@
   <li>Edge 108+</li>
   <li>Chrome 109+</li>
   <li>Firefox 108+</li>
-  <li>Safari 16.1+</li>
+  <li>Safari 15.6+</li>
 </ul>
 <p>Some features of the site such as AlphaFold will benifit from OpenGL compatible graphics cards.</p>
 <p>We recommend <a href="http://www.mozilla.org/en-US/firefox/fx/" title="Get Firefox!">Firefox</a> for browsing Ensembl.</p>


### PR DESCRIPTION
This PR is to update the supported browser list page. The changes can be viewed here http://wp-np2-1f.ebi.ac.uk:10000/info/website/browsers.html. 

The list was generated by looking browser usage stats here https://caniuse.com/usage-table. Safari includes a bigger drop to account for the penultimate version of macOS being locked to version 15.6. 

More details can be seen in the ticket here https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6724

The ticket mentions that molstar should be taken into consideration. Sadly I could not find any minimum browser requirements so I just added a note about hardware acceleration 