### PR TITLE
Update Regulation section on the release cycle page

### DIFF
--- a/htdocs/info/about/release_cycle.html
+++ b/htdocs/info/about/release_cycle.html
@@ -63,15 +63,9 @@ create variation databases for the relevant species. Currently there
 are around a dozen species with variation data, including human,
 chimp, mouse, rat, dog and zebrafish.
   </li>
-  <li><strong>Regulation</strong><br /> The regulation team collects 
-experimental data from their collaborators and incorporates this into
-the <a href="/info/genome/funcgen/index.html">Regulatory Build</a>. This
-includes regulatory features determined by chromatin
-immuno-precipitation and epigenomic modifications. Currently only human and 
-mouse have a Regulatory Build, whilst fruitfly has other regulation data. Regulation 
-(funcgen) databases exist for other species to support the 
-<a href="/info/genome/microarray_probe_set_mapping.html">microarray mapping</a> 
-data.
+  <li><strong>Regulation</strong><br /> The Regulation team processes public 
+experimental data to generate <a href="/info/genome/funcgen/index.html">Regulatory Annotation</a>, 
+which includes regulatory features, such as promoters and enhancers. 
   </li>
   </ul>
 </li>


### PR DESCRIPTION

## Description

Update Regulation section on the release cycle page.
Sandbox: http://wp-np2-25.ebi.ac.uk:6020/info/about/release_cycle.html

