### PR TITLE
Change drawing style for regulation peak tracks

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/fg_multi_wiggle.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/fg_multi_wiggle.pm
@@ -295,7 +295,7 @@ sub get_features {
                                                     'feat_name' => $feature_name,
                                                   });
         my $bigbed_data = $self->EnsEMBL::Draw::GlyphSet::bigbed::get_data($bigbed_file_path, $subtrack->{'metadata'});
-        $drawing_style = 'EnsEMBL::Draw::Style::Feature::MultiBlocks';
+        $drawing_style = 'EnsEMBL::Draw::Style::Feature::Structured';
         my $bigbed_metadata = $bigbed_data->[0]{'metadata'};
         $subtrack->{'features'} = $bigbed_data->[0]{'features'};
         while (my ($key, $value) = each %{$bigbed_metadata || {}}) {


### PR DESCRIPTION
## Description
This PR changes the style of regulation peak tracks from `Style::Feature::MultiBlocks` to `Style::Feature::Structured`. The reason being that `Style::Feature::Structured` is the style we use custom user tracks, and it supports gaps in the way that Regulation wants.

## Views affected
**Sandbox:**
http://wp-np2-1e.ebi.ac.uk:8410/Sus_scrofa/Location/View?r=1:162511400-162515687;time=1679479911277.277;db=core

To see gapped peaks, set:
- Cell/tissue: cerebellum (m, 6mo), and
- Experiment: H3K4me1 histone

To see narrow peaks, set:
- Cell/tissue: adipose tissue (m, 6 mo)
- no need to change the experiment

Here's what you should see:

![image](https://user-images.githubusercontent.com/6834224/231101439-5ba2544f-2f77-4961-991a-5692476c8224.png)


## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6832?jql=order%20by%20lastViewed%20DESC