### PR TITLE
Add more information near the page caption

### DIFF
--- a/htdocs/components/16_Interaction.js
+++ b/htdocs/components/16_Interaction.js
@@ -23,7 +23,6 @@ Ensembl.Panel.Interaction = Ensembl.Panel.extend({
 
   init: function () {
     var panel = this;
-    
     this.base();
     var data = $('input[name="intr_metadata"]', this.el).val();
     this.elLk.metadataLink = $('.interactions-right .label a');
@@ -34,7 +33,15 @@ Ensembl.Panel.Interaction = Ensembl.Panel.extend({
 
     this.elLk.metadataLink.click(function() {
       panel.displayMetadata();
-    })
+    });
+
+    // Add more info near the page caption
+    var sub_title = "Cross-species interactions imported from PHI-base, HPIDB and PlasticDB with exact matches to proteins in Ensembl.";
+    var subtitleHtml = $('<span />').addClass('interactionsSubTitle').html(sub_title);
+    var navHeading = $(this.el).parent().siblings('.nav-heading').addClass('interactionsNavHeading')
+    var navHeadingCaption = navHeading.find('.caption'); 
+    console.log(navHeadingCaption);
+    navHeadingCaption.after(subtitleHtml);
   },
 
   displayMetadata: function() {

--- a/htdocs/components/16_Interaction.js
+++ b/htdocs/components/16_Interaction.js
@@ -35,7 +35,7 @@ Ensembl.Panel.Interaction = Ensembl.Panel.extend({
       panel.displayMetadata();
     });
 
-    // Add more info near the page caption
+    // Add description text near the page caption. [Quick and dirty hack]
     var sub_title = "Cross-species interactions imported from PHI-base, HPIDB and PlasticDB with exact matches to proteins in Ensembl.";
     var subtitleHtml = $('<span />').addClass('interactionsSubTitle').html(sub_title);
     var navHeading = $(this.el).parent().siblings('.nav-heading').addClass('interactionsNavHeading')

--- a/htdocs/components/16_Interaction.js
+++ b/htdocs/components/16_Interaction.js
@@ -40,7 +40,6 @@ Ensembl.Panel.Interaction = Ensembl.Panel.extend({
     var subtitleHtml = $('<span />').addClass('interactionsSubTitle').html(sub_title);
     var navHeading = $(this.el).parent().siblings('.nav-heading').addClass('interactionsNavHeading')
     var navHeadingCaption = navHeading.find('.caption'); 
-    console.log(navHeadingCaption);
     navHeadingCaption.after(subtitleHtml);
   },
 

--- a/htdocs/components/99.Interaction.css
+++ b/htdocs/components/99.Interaction.css
@@ -52,3 +52,11 @@
   width: 270px;
   display: inline-block;
 }
+
+.interactionsNavHeading {
+  display: flex;
+}
+
+.interactionsSubTitle {
+  padding: 10px 20px;
+}


### PR DESCRIPTION
From user feedback, microbes team decided to add a small piece of text to the interactions pages that clarifies the sources and criteria we used. 

As per the XD screenshot below, 
![Screenshot 2023-04-14 at 17 44 29](https://user-images.githubusercontent.com/6347854/232106093-797b350a-681e-4d17-b182-0af214d69863.png)

Note, I personally dont like the code I added :-)  But as this is just a one off feature added for Interactions page I am OK. What you guys think?
To have a proper reusable solution, we may have to dive into [this component](https://github.com/Ensembl/ensembl-webcode/blob/main/modules/EnsEMBL/Web/Document/Panel.pm#L57).  Not sure if it is really necessary