### PR TITLE
Update regulation matrix behaviour and change zmenu label

### DIFF
--- a/modules/EnsEMBL/Web/JSONServer/RegulationData.pm
+++ b/modules/EnsEMBL/Web/JSONServer/RegulationData.pm
@@ -53,7 +53,7 @@ sub json_data {
     set => 'reg_feats',
     renderer => "normal",
     popupType => "column-cell",
-    defaultState => "track-on"
+    defaultState => "track-off"
   };
 
   $final->{data}->{segmentation_features} = {
@@ -116,22 +116,30 @@ sub json_data {
           };
           push @$cell_evidence, $hash;
 
-          # Add regulatory features only of it is available.
+          # Add epigenomic activity if needed
           if ($db_tables->{'cell_type'}{'ids'}->{$id_key}) {
-            foreach my $k (@{$final->{extra_dimensions}}) {
-              my $ex = $final->{data}->{$k};
-              if (!$tmp_hash->{$ex->{label}}) {
-                # print Data::Dumper::Dumper $tmp_hash;
-                $tmp_hash->{$ex->{label}} = 1;
-                $hash =  {
-                  dimension => $k,
-                  val => $ex->{label},
-                  set => $ex->{set},
-                  defaultState => $ex->{defaultState} || "track-off"
-                };
-                push @$cell_evidence, $hash;
-              }
-            }
+            my $epigenomic_activity = $final->{data}->{epigenomic_activity};
+            $hash =  {
+              dimension => "epigenomic_activity",
+              val => $epigenomic_activity->{label},
+              set => $epigenomic_activity->{set},
+              defaultState => $epigenomic_activity->{defaultState} || "track-off"
+            };
+            push @$cell_evidence, $hash;
+          }
+
+          # Add segmentation features if available
+          my ($segmentation_lookup_key) = split(":", $id_key); # the id_key here is a colon-separated epigenome short name and epigenome id; see ConfigPacker for details
+          $segmentation_lookup_key = "Segmentation:$segmentation_lookup_key";
+          if ($db_tables->{'segmentation'}{$segmentation_lookup_key}) { # i.e. if the cell line actually has segmentation features
+            my $segmentation_features = $final->{data}->{segmentation_features};
+            $hash =  {
+              dimension => "segmentation_features",
+              val => $segmentation_features->{label},
+              set => $segmentation_features->{set},
+              defaultState => $segmentation_features->{defaultState} || "track-off"
+            };
+            push @$cell_evidence, $hash;
           }
         }
       }

--- a/modules/EnsEMBL/Web/ZMenu/Regulation.pm
+++ b/modules/EnsEMBL/Web/ZMenu/Regulation.pm
@@ -42,7 +42,7 @@ sub content {
   my $object         = $self->new_object('Regulation', $reg_feature, $self->object->__data);
   
   $self->add_entry({
-    type  => 'Stable ID',
+    type  => 'ID',
     label => $object->stable_id,
     link  => $object->get_summary_page_url
   });


### PR DESCRIPTION
## Description
1. Update behaviour of the regulation matrix
- Do not enable epigenomic activity track by default
- Filter out segmentation features tracks if they are not available for a given cell line
2. Replace the "Stable ID" label with just "ID", because not all identifiers of regulatory features are truly stable (see ENSWEB-6827, section 2)

## Views affected
- Region view for Pig (shouldn't see any available segmentation features track):
http://wp-np2-1e.ebi.ac.uk:8410/Sus_scrofa/Location/View?r=1:162511400-162515687;time=1679479911277.277;db=core
- Region view for Human (shouldn't see any changes):
http://wp-np2-1e.ebi.ac.uk:8410/Homo_sapiens/Location/View?r=8:26291508-26372680;debug=js;time=1681285452321.321

To check zmenu label:
- http://wp-np2-1e.ebi.ac.uk:8410/Sus_scrofa/Regulation/Summary?db=core;fdb=funcgen;r=14:10195351-10284707;rf=ENSSSCR00000166796
- http://wp-np2-1e.ebi.ac.uk:8410/Homo_sapiens/Regulation/Summary?db=funcgen;fdb=funcgen;r=8:37966115-37968453;rf=ENSR00001137252

## Related JIRA Issues
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6827