### PR TITLE
Add a missing dependency

### DIFF
--- a/modules/EnsEMBL/Web/Component/Compara_Alignments.pm
+++ b/modules/EnsEMBL/Web/Component/Compara_Alignments.pm
@@ -27,6 +27,7 @@ use HTML::Entities qw(encode_entities);
 use List::Util qw(min max);
 use EnsEMBL::Web::Document::Table;
 use EnsEMBL::Web::TextSequence::View::ComparaAlignments;
+use EnsEMBL::Web::Utils::FormatText qw(pluralise);
 
 use base qw(EnsEMBL::Web::Component::TextSequence);
 


### PR DESCRIPTION
## Description

This PR fixes an ajax error in the compara alignments for plants. See the [ENSWEB bug report](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6839). The underlying issue appears to be a missing dependency (the method `pluralise`). Presumably this module was previously loaded in a parent module or another dependency but that `use` has been removed during refactoring and we're only now hitting the call in this code path.

## Views affected

[http://staging-plants.ensembl.org/Triticum_aestivum_landmark/Location/Compara_Alignments/Image?align=313160;db=core;r=6B:570561430-570563408](http://staging-plants.ensembl.org/Triticum_aestivum_landmark/Location/Compara_Alignments/Image?align=313160;db=core;r=6B:570561430-570563408)

## Possible complications

The exception could be a symptom of a deeper problem, in which case simply adding the explicit dependency could be masking another issue. Alternatively, this missing dependency might always have been there and we're only now hitting the exception due to a change in the data. 

## Merge conflicts

None known.

## Related JIRA Issues (EBI developers only)

[ENSWEB-6839](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6839)