### PR TITLE
Remove alphafold id manipulation

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
@@ -750,7 +750,8 @@ sub detail_panel {
             ( $value_url ) = $value =~ /(.+)\./;
           } elsif ($key =~ '^AFDB-ENSP') {
             $key = "ALPHAFOLD";
-            ( $value ) = $value =~ /(.+)\./; # remove chain from AlphaFold ID
+            # an AlphaFold id is formatted as "AF-uniprot_id-fragment_number";
+            # urls will use the uniprot id
             ( $value_url ) = $value =~ /-(.+)-/;
           } elsif ($key eq 'GENE3D') {
             $value_url = "G3DSA:$value" unless $value =~ /^G3DSA:/;


### PR DESCRIPTION
## Description
The way Ensembl databases are storing Alphaford ids has changed. Previously, Ensembl was adding `.A` (to represent protein chain) to an alphafold identifier, like so:

```
mysql> select protein_feature.hit_name from protein_feature join analysis on protein_feature.analysis_id = analysis.analysis_id where analysis.logic_name = "alphafold_import" limit 10;
+--------------------+
| hit_name           |
+--------------------+
| AF-A0A024RCN7-F1.A |
| AF-A0A024RCN7-F1.A |
| AF-A0A024RCN7-F1.A |
| AF-A0A024RCN7-F1.A |
| AF-A0A024RCN7-F1.A |
| AF-A0A024RCN7-F1.A |
| AF-A0A024RCN7-F1.A |
| AF-A0A024RCN7-F1.A |
| AF-A0A024RCN7-F1.A |
| AF-A0A024RBG1-F1.A |
+--------------------+
```

This was a bad idea, and starting from 110, Ensembl dbs store plain Alphafold identifiers:

```
mysql> select protein_feature.hit_name from protein_feature join analysis on protein_feature.analysis_id = analysis.analysis_id where analysis.logic_name = "alphafold" limit 10;
+------------------+
| hit_name         |
+------------------+
| AF-A6NMX2-F1     |
| AF-A6NMX2-F1     |
| AF-A6NMX2-F1     |
| AF-A0A494BWY4-F1 |
| AF-A0A804HL73-F1 |
| AF-E5RFQ2-F1     |
| AF-D6RBX8-F1     |
| AF-F5GY79-F1     |
| AF-G3V4A2-F1     |
| AF-H3BTP3-F1     |
+------------------+
```

This PR, as well as the related one in public plugins, removes the code that was manipulating identifier strings to remove the `.A` for presentation purposes.

**Related PRs:**
- https://github.com/Ensembl/public-plugins/pull/688

## Related JIRA Issues
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6763