### PR TITLE
Add MaveDB URL (110)

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -396,6 +396,7 @@ KAT6BDB                     = http://www.lovd.nl/###ID###
 LMDD                        = http://www.lovd.nl/###ID###
 LOVD                        = http://varcache.lovd.nl/redirect/hg38.chr###ID###
 MAGIC                       = http://www.magicinvestigators.org/
+MAVEDB                      = https://www.mavedb.org/#/scoresets/###ID###
 MGI_MP                      = http://www.informatics.jax.org/vocab/mp_ontology/###ID###
 MP                          = http://purl.obolibrary.org/obo/###ID###
 NEXTGEN_POP                 = http://projects.ensembl.org/nextgen/


### PR DESCRIPTION
## Description

Add MaveDB URL. This is used to create hyperlinks from MaveDB plugin results in web VEP: https://github.com/Ensembl/public-plugins/pull/691.

## Views affected

No views affected.

## Possible complications

No complications.

## Related JIRA Issues (EBI developers only)

[ENSVAR-5485](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5485)
