### PR TITLE
Variation summary: show CNV allele type for any source (e110)

### DIFF
--- a/modules/EnsEMBL/Web/Component/StructuralVariation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/StructuralVariation/Summary.pm
@@ -110,8 +110,6 @@ sub get_allele_types {
   my $self   = shift;
   my $source = shift;
   
-  return if $source ne 'DGVa';
-  
   my $object = $self->object;
   my $ssvs   = $object->supporting_sv;
   my (@allele_types, $html);


### PR DESCRIPTION
## Description

Show allele types for any source in Variation summary page. Currently, this only works for variants from DGVa.

## Views affected

- Human (dbVar): [nsv4517655](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/StructuralVariation/Mappings?db=core;r=1:521700-621900;sv=nsv4517655;svf=127710255;vdb=variation) - added allele type compared to [current website](http://ensembl.org/Homo_sapiens/StructuralVariation/Mappings?db=core;r=1:521700-621900;sv=nsv4517655;svf=127710255;vdb=variation)
- Pig (DGVa): [nsv443016](http://wp-np2-11.ebi.ac.uk:6070/Sus_scrofa/StructuralVariation/Mappings?r=7:67148496-67211415;sv=nsv443016;svf=665;vdb=variation) - no change in header compared to [current website](http://ensembl.org/Sus_scrofa/StructuralVariation/Mappings?r=7:67148496-67211415;sv=nsv443016;svf=665;vdb=variation)

For CNVs without supporting variants (and we currently only have those for DGVa and dbVar), no allele type is shown:
- Human (Illumina): [cnvi0117680](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/StructuralVariation/Mappings?r=11:43450606-43451606;sv=cnvi0117680;svf=8;vdb=variation) - no change in header compared to [current website](http://ensembl.org/Homo_sapiens/StructuralVariation/Mappings?r=11:43450606-43451606;sv=cnvi0117680;svf=8;vdb=variation)

**Note:** changes in consequences are related with https://github.com/Ensembl/ensembl-variation/pull/1003.

## Possible complications

No complications expected.

## Related JIRA Issues (EBI developers only)

[ENSVAR-5786](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5786)
