### PR TITLE
Fix human self-alignment synteny

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/Vsynteny.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/Vsynteny.pm
@@ -67,6 +67,7 @@ sub _init {
   my $synteny_data          = $self->{'container'}->{'synteny'};
   my $other_species         = $self->{'container'}->{'other_species'};
   my $other_species_text    = $species_defs->get_config($other_species, 'SPECIES_SCIENTIFIC_NAME');
+  my $self_production_name = $species_defs->production_name();
   my $other_production_name = $species_defs->get_config($other_species, 'SPECIES_PRODUCTION_NAME');
   my %other_chrs            = map {( $_, 1 )} @{$species_defs->get_config($other_species, 'ENSEMBL_CHROMOSOMES')}; # This is the list of chromosomes we will be drawing
   my $chr_length            = $sa->fetch_by_region('toplevel', $chr)->length; 
@@ -102,9 +103,12 @@ sub _init {
 
   foreach my $synteny_region (@$synteny_data) {
     my ($main_dfr, $other_dfr);
-    
+
     foreach my $dfr (@{$synteny_region->get_all_DnaFragRegions}) {
-      if ($dfr->dnafrag->genome_db->name eq $other_production_name) {
+      if (lc($self_production_name) eq lc($dfr->dnafrag->genome_db->name) and $dfr->dnafrag->genome_db->name eq $other_production_name) {
+        $main_dfr = $dfr;
+        $other_dfr = $dfr;
+      } elsif ($dfr->dnafrag->genome_db->name eq $other_production_name) {
         $other_dfr = $dfr;
       } else {
         $main_dfr = $dfr;

--- a/modules/EnsEMBL/Web/Component/Location/SyntenyImage.pm
+++ b/modules/EnsEMBL/Web/Component/Location/SyntenyImage.pm
@@ -151,7 +151,7 @@ sub species_form {
   my @values;
 
   foreach my $next (@sorted) {
-    next if $next->{'name'} eq $hub->species and $next->{'name'} ne 'Homo_sapiens'; # Homo sapiens is the only vertebrate that has self-synteny
+    next if ($next->{'name'} eq $hub->species and $next->{'name'} ne 'Homo_sapiens'); # Homo sapiens has self-synteny, so should be visible in the species dropdown even when already on the Human page
     push @values, { caption => $next->{'display'}, value => $next->{'name'} };
   }
 

--- a/modules/EnsEMBL/Web/Component/Location/SyntenyImage.pm
+++ b/modules/EnsEMBL/Web/Component/Location/SyntenyImage.pm
@@ -151,7 +151,7 @@ sub species_form {
   my @values;
 
   foreach my $next (@sorted) {
-    next if $next->{'name'} eq $hub->species;
+    next if $next->{'name'} eq $hub->species and $next->{'name'} ne $hub->param('otherspecies');
     push @values, { caption => $next->{'display'}, value => $next->{'name'} };
   }
 

--- a/modules/EnsEMBL/Web/Component/Location/SyntenyImage.pm
+++ b/modules/EnsEMBL/Web/Component/Location/SyntenyImage.pm
@@ -151,7 +151,7 @@ sub species_form {
   my @values;
 
   foreach my $next (@sorted) {
-    next if $next->{'name'} eq $hub->species and $next->{'name'} ne $hub->param('otherspecies');
+    next if $next->{'name'} eq $hub->species and $next->{'name'} ne 'Homo_sapiens'; # Homo sapiens is the only vertebrate that has self-synteny
     push @values, { caption => $next->{'display'}, value => $next->{'name'} };
   }
 


### PR DESCRIPTION
## Description
The code to display a synteny alignment view is assuming that the alignment can only be done between two different species, and thus breaks when tasked to show a human self-alignment. Meanwhile, we are displaying a link to human self-alignment synteny page on a Compara help&docs page: https://www.ensembl.org/info/genome/compara/analyses.html

The changes in this PR are:
- handle the case when the "main species" is the same as the "other species" in `GlyphSet/Vsynteny.pm`
- make sure Human always shows up int the dropdown of species available for alignment view

## Views affected
Synteny for Human aligned against Human

http://wp-np2-1e.ebi.ac.uk:8410/Homo_sapiens/Location/Synteny?r=8:26291508-26372680;otherspecies=Homo_sapiens

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6820