### PR TITLE
Add Open Targets Genetics links (e111)

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -404,6 +404,7 @@ OIVD                        = http://www.lovd.nl/###ID###
 OLS                         = http://www.ebi.ac.uk/ols/search?q=###ID###
 OMIA                        = https://omia.org/###ID###/###TAX###/
 OMIM                        = http://www.omim.org/entry/###ID###
+OPENTARGETSGENETICS_GENE    = https://genetics.opentargets.org/gene/###ID###
 OPENTARGETSGENETICS_VARIANT = https://genetics.opentargets.org/variant/###ID###
 ORDO                        = http://www.orpha.net/ORDO/###ID###
 ORPHANET                    = http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=###ID###

--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -404,6 +404,7 @@ OIVD                        = http://www.lovd.nl/###ID###
 OLS                         = http://www.ebi.ac.uk/ols/search?q=###ID###
 OMIA                        = https://omia.org/###ID###/###TAX###/
 OMIM                        = http://www.omim.org/entry/###ID###
+OPENTARGETSGENETICS_VARIANT = https://genetics.opentargets.org/variant/###ID###
 ORDO                        = http://www.orpha.net/ORDO/###ID###
 ORPHANET                    = http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=###ID###
 PAHDB                       = http://www.pahdb.mcgill.ca/PahdbSearch.php?SearchValue=###ID###&SearchField=mut_name&SearchOrderedField=id_mut&SearchAscDesc=ASC&Submit=Submit&MenuSelection=Mutation


### PR DESCRIPTION
## Description

Add Open Targets Genetics link to gene and variant pages, required to link external results in web VEP.

## Views affected

Used for the `Open Targets L2G` column in web VEP to link to external resource: http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Tools/VEP/Results?tl=5tybNB2ISXldSibO-38

## Possible complications

No complications expected.

## Related JIRA Issues (EBI developers only)

[ENSVAR-5840](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5840)