### PR TITLE
Ensure context presence in availability queries

### DIFF
--- a/modules/EnsEMBL/Web/Query.pm
+++ b/modules/EnsEMBL/Web/Query.pm
@@ -67,11 +67,13 @@ sub _run_phase {
 
 sub run_miss {
   my ($self,$args,$build) = @_;
+
+  my $context = $self->{_context};
       
   my %a_gen = %$args;
-  $self->_run_phase(\%a_gen,undef,'pre_generate');
+  $self->_run_phase(\%a_gen, $context, 'pre_generate');
   my $part = $self->{'impl'}->get(\%a_gen);
-  $self->_run_phase($part,undef,'post_generate',[\%a_gen]);
+  $self->_run_phase($part, $context, 'post_generate',[\%a_gen]);
   $self->_check_unblessed($part);
   $self->{'store'}->_set_cache(ref($self->{'impl'}),$args,$part,$build);
   return $part;
@@ -79,6 +81,7 @@ sub run_miss {
 
 sub go {
   my ($self,$context,$args) = @_;
+  $self->{_context} = $context;
 
   my $orig_args = {%$args};
   $args = {%$args};


### PR DESCRIPTION
## Description
_This PR is in support of https://github.com/EnsemblGenomes/eg-web-metazoa/pull/25. See the full description of the problem there._

In availability queries, it was impossible to access to the hub, and from it, other things that might be useful. Curiously, this was possible in other kinds of queries, for example in glyphset queries ([link](https://github.com/Ensembl/ensembl-webcode/blob/release/110/modules/EnsEMBL/Web/Query/GlyphSet/Transcript.pm#L276-L277)) or in sequence queries ([link](https://github.com/Ensembl/ensembl-webcode/blob/release/110/modules/EnsEMBL/Web/Query/Sequence/Transcript.pm#L85)).

It turned out that the Query.pm module sometimes [calls the relevant method providing the context](https://github.com/Ensembl/ensembl-webcode/blob/release/110/modules/EnsEMBL/Web/Query.pm#L89), which is the hub; and other times [passes `undef` instead of the context](https://github.com/Ensembl/ensembl-webcode/blob/release/110/modules/EnsEMBL/Web/Query.pm#L72). This made the hub unavailable in availability queries.