### PR TITLE
Update Cactus stats view

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/Compara.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara.pm
@@ -24,6 +24,7 @@ package EnsEMBL::Web::Document::HTML::Compara;
 
 use strict;
 
+use List::Util qw(uniqstr);
 use Math::Round;
 use EnsEMBL::Web::Document::Table;
 use Bio::EnsEMBL::Compara::Utils::SpeciesTree;
@@ -328,6 +329,7 @@ sub get_species_info {
     foreach my $this_leaf (@$all_leaves) {
       my $name = $this_leaf->genome_db->name;
       push @$species_order, $lookup->{$name} if $lookup->{$name};
+      @$species_order = uniqstr(@$species_order);  # polyploid genomes may be represented multiple times in the species-order list
     }
   }
 
@@ -361,7 +363,11 @@ sub get_species_info {
       my $id = $gdb->dbID;
       my @stats = qw(genome_coverage genome_length coding_exon_coverage coding_exon_length);
       foreach (@stats) {
-        $info->{$sp}{$_} = $genome_db_id_2_node_hash && exists $genome_db_id_2_node_hash->{$id} ? $genome_db_id_2_node_hash->{$id}->get_value_for_tag($_) : $mlss->get_value_for_tag($_.'_'.$id);
+        if ($genome_db_id_2_node_hash && exists $genome_db_id_2_node_hash->{$id} && defined $genome_db_id_2_node_hash->{$id}->get_value_for_tag($_)) {
+            $info->{$sp}{$_} = $genome_db_id_2_node_hash->{$id}->get_value_for_tag($_);
+        } else {
+            $info->{$sp}{$_} = $mlss->get_value_for_tag($_.'_'.$id);
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

The Cactus stats view is updated as follows:
- The initial description of the alignment is made more consistent with that of other multiple genome alignments (e.g. "This alignment has been generated in Ensembl Plants release 57.").
- Coverage stats columns 'Genome length (bp)', 'Genome coverage (bp)' and 'Genome coverage (%)' are added to the stats table. These are populated from MLSS coverage stats where available. Where no coverage statistic is available, an `NA` value is displayed.
- A brief description of the coverage calculation method is added, as Cactus alignment coverage is currently calculated in a different way to the coverage of other multiple genome alignment methods (e.g. EPO).
- The species-order list used to populate the Cactus stats table is deduplicated. This is useful in cases such as the Wheat Cactus alignment, where the presence of polyploid genome components results in multiple instances of the same species name in the stats table.

## Views affected

This change affects the stats pages of Cactus alignments such as:
- 26 Rice Cactus: http://wp-np2-25.ebi.ac.uk:5098/info/genome/compara/mlss.html?mlss=312167
- 16 Wheat Cactus: http://wp-np2-25.ebi.ac.uk:5098/info/genome/compara/mlss.html?mlss=313160
- wormbase-ws269 cactus-hal: http://wp-np2-25.ebi.ac.uk:5094/info/genome/compara/mlss.html?mlss=9483

For screenshots of the Plants Cactus stats views, please see [ENSCOMPARASW-6883](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-6883).

## Possible complications

As most of the changes are within the `render_cactus_multiple` method, this PR is unlikely to adversely affect any other view.

## Merge conflicts

Merge tested locally, no conflicts found.

## Related JIRA Issues (EBI developers only)

- [ENSCOMPARASW-6883](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-6883)
