### PR TITLE
ENSWEB-6845 Use contigviewbottom configs to save regulation configs

### DIFF
--- a/modules/EnsEMBL/Web/Component/Regulation.pm
+++ b/modules/EnsEMBL/Web/Component/Regulation.pm
@@ -142,19 +142,9 @@ sub nav_buttons {
   my @buttons = (
     {
       img => "navb-reg-summary.png",
-      title => "Summary",
+      title => "Activity",
       action => 'Summary',
-      text => "Summary",
-    },{
-      img => "navb-reg-details.png",
-      title => "Details by cell type",
-      action => 'Cell_line',
-      text => "Details by\ncell type",
-    },{
-      img => "navb-reg-context.png",
-      title => "Feature context",
-      action => 'Context',
-      text => "Feature\ncontext",
+      text => "Activity",
     },{
       img => "navb-reg-sourcedata.png",
       title => "Source Data",

--- a/modules/EnsEMBL/Web/Component/Regulation/FeatureDetails.pm
+++ b/modules/EnsEMBL/Web/Component/Regulation/FeatureDetails.pm
@@ -41,25 +41,25 @@ sub content {
   my $object = $self->object || $self->hub->core_object('regulation'); 
   my ($html, $Configs);
 
-  my $context      = $self->param( 'context' ) || 200; 
-  my $object_slice = $object->get_bound_context_slice($context);
-     $object_slice = $object_slice->invert if $object_slice->strand < 1;
+  # my $context      = $self->param( 'context' ) || 200;
+  # my $object_slice = $object->get_bound_context_slice($context);
+  #    $object_slice = $object_slice->invert if $object_slice->strand < 1;
 
-  my $wuc = $object->get_imageconfig( 'reg_summary_page' );
-  $wuc->set_parameters({
-    'container_width'   => $object_slice->length,
-    'image_width',      => $self->image_width || 800,
-    'slice_number',     => '1|1',
-    'opt_highlight'     => $self->param('opt_highlight') || 0,
-  });
+  # my $wuc = $object->get_imageconfig( 'reg_summary_page' );
+  # $wuc->set_parameters({
+  #   'container_width'   => $object_slice->length,
+  #   'image_width',      => $self->image_width || 800,
+  #   'slice_number',     => '1|1',
+  #   'opt_highlight'     => $self->param('opt_highlight') || 0,
+  # });
 
-  my $image    = $self->new_image( $object_slice, $wuc,[$object->stable_id] );
-      $image->imagemap           = 'yes';
-      $image->{'panel_number'} = 'top';
-      $image->set_button( 'drag', 'title' => 'Drag to select region' );
-  return if $self->_export_image( $image );
+  # my $image    = $self->new_image( $object_slice, $wuc,[$object->stable_id] );
+  #     $image->imagemap           = 'yes';
+  #     $image->{'panel_number'} = 'top';
+  #     $image->set_button( 'drag', 'title' => 'Drag to select region' );
+  # return if $self->_export_image( $image );
 
-  $html .= $image->render;
+  # $html .= $image->render;
 
   my $reg_feat = $object->fetch_by_stable_id;
   my $active_epigenomes = $reg_feat->get_epigenomes_by_activity('ACTIVE');

--- a/modules/EnsEMBL/Web/Component/Regulation/FeatureDetails.pm
+++ b/modules/EnsEMBL/Web/Component/Regulation/FeatureDetails.pm
@@ -41,26 +41,6 @@ sub content {
   my $object = $self->object || $self->hub->core_object('regulation'); 
   my ($html, $Configs);
 
-  # my $context      = $self->param( 'context' ) || 200;
-  # my $object_slice = $object->get_bound_context_slice($context);
-  #    $object_slice = $object_slice->invert if $object_slice->strand < 1;
-
-  # my $wuc = $object->get_imageconfig( 'reg_summary_page' );
-  # $wuc->set_parameters({
-  #   'container_width'   => $object_slice->length,
-  #   'image_width',      => $self->image_width || 800,
-  #   'slice_number',     => '1|1',
-  #   'opt_highlight'     => $self->param('opt_highlight') || 0,
-  # });
-
-  # my $image    = $self->new_image( $object_slice, $wuc,[$object->stable_id] );
-  #     $image->imagemap           = 'yes';
-  #     $image->{'panel_number'} = 'top';
-  #     $image->set_button( 'drag', 'title' => 'Drag to select region' );
-  # return if $self->_export_image( $image );
-
-  # $html .= $image->render;
-
   my $reg_feat = $object->fetch_by_stable_id;
   my $active_epigenomes = $reg_feat->get_epigenomes_by_activity('ACTIVE');
   my $num_active = scalar( @{$active_epigenomes});

--- a/modules/EnsEMBL/Web/Configuration/Regulation.pm
+++ b/modules/EnsEMBL/Web/Configuration/Regulation.pm
@@ -57,17 +57,6 @@ sub populate_tree {
     { 'availability' => 'regulation', 'concise' => 'Activity' }
   );
 
-  # $self->create_node('Cell_line', 'Details by cell type',
-  #   [qw( buttons    EnsEMBL::Web::Component::Regulation::Buttons
-  #        cell_line EnsEMBL::Web::Component::Regulation::FeaturesByCellLine )],
-  #   { 'availability' => 'regulation', 'concise' => 'Details by cell type' }
-  # );
-
-  # $self->create_node('Context', 'Feature Context',
-  #   [qw( feature_summary EnsEMBL::Web::Component::Regulation::FeatureSummary )],
-  #   { 'availability' => 'regulation', 'concise' => 'Feature context' }
-  # );
-  
   $self->create_node('Evidence', 'Source Data',
     [qw( evidence EnsEMBL::Web::Component::Regulation::Evidence )],
     { 'availability' => 'regulation', 'concise' => 'Source data' }

--- a/modules/EnsEMBL/Web/Configuration/Regulation.pm
+++ b/modules/EnsEMBL/Web/Configuration/Regulation.pm
@@ -52,22 +52,21 @@ sub set_default_action {
 
 sub populate_tree {
   my $self = shift;
-  $self->create_node('Summary', 'Summary',
-    [qw(        buttons EnsEMBL::Web::Component::Regulation::SummaryButtons
-        feature_details EnsEMBL::Web::Component::Regulation::FeatureDetails )],
-    { 'availability' => 'regulation', 'concise' => 'Summary' }
+  $self->create_node('Summary', 'Activity',
+    [qw(feature_details EnsEMBL::Web::Component::Regulation::FeatureDetails )],
+    { 'availability' => 'regulation', 'concise' => 'Activity' }
   );
 
-  $self->create_node('Cell_line', 'Details by cell type',
-    [qw( buttons    EnsEMBL::Web::Component::Regulation::Buttons
-         cell_line EnsEMBL::Web::Component::Regulation::FeaturesByCellLine )],
-    { 'availability' => 'regulation', 'concise' => 'Details by cell type' }
-  );
+  # $self->create_node('Cell_line', 'Details by cell type',
+  #   [qw( buttons    EnsEMBL::Web::Component::Regulation::Buttons
+  #        cell_line EnsEMBL::Web::Component::Regulation::FeaturesByCellLine )],
+  #   { 'availability' => 'regulation', 'concise' => 'Details by cell type' }
+  # );
 
-  $self->create_node('Context', 'Feature Context',
-    [qw( feature_summary EnsEMBL::Web::Component::Regulation::FeatureSummary )],
-    { 'availability' => 'regulation', 'concise' => 'Feature context' }
-  );
+  # $self->create_node('Context', 'Feature Context',
+  #   [qw( feature_summary EnsEMBL::Web::Component::Regulation::FeatureSummary )],
+  #   { 'availability' => 'regulation', 'concise' => 'Feature context' }
+  # );
   
   $self->create_node('Evidence', 'Source Data',
     [qw( evidence EnsEMBL::Web::Component::Regulation::Evidence )],

--- a/modules/EnsEMBL/Web/ViewConfig/Regulation/FeatureDetails.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Regulation/FeatureDetails.pm
@@ -38,7 +38,7 @@ sub init_cacheable {
     map {( "opt_ft_$_" => 'on' )} keys %$analyses
   });
 
-  $self->image_config_type('reg_summary_page');
+  $self->image_config_type('contigviewbottom');
   $self->title('Summary');
 }
 


### PR DESCRIPTION
## Description
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6845

- Remove track image component from regulation views
- When saving configs in regulation view, update location view config so that the tracks can be seen in location view.
- Remove Feature context and Details by cell types pages

http://wp-np2-1e.ebi.ac.uk:9000/Homo_sapiens/Regulation/Summary?db=funcgen;fdb=funcgen;r=8:37966115-37968453;rf=ENSR00001137252

## Views affected
Regulation