### PR TITLE
Add option to restrict orthologies by gene tree

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -522,7 +522,12 @@ sub get_export_data {
     unless ($cdb) {
       $cdb = $hub->function =~ /pan_compara/ ? 'compara_pan_ensembl' : 'compara';
     }
-    my ($homologies) = $object->get_homologies('ENSEMBL_ORTHOLOGUES', undef, undef, $cdb);
+    my $homologies;
+    if ($flag eq 'genetree') {
+      ($homologies) = $object->get_homologies('ENSEMBL_ORTHOLOGUES', undef, $cdb, 'restrict_to_gene_tree');
+    } else {
+      ($homologies) = $object->get_homologies('ENSEMBL_ORTHOLOGUES', undef, $cdb);
+    }
 
     my %ok_species;
 


### PR DESCRIPTION
## Description

This PR:
- adds an option to restrict homologies returned by `EnsEMBL::Web::Object::Gene::get_homologies` to include only those in a specific gene tree; and
- uses that option in the `get_export_data` method of `EnsEMBL::Web::Component::Gene::ComparaOrthologs` if the export flag is `genetree`, which is currently used only in the case of OrthoXML and PhyloXML download formats.

These changes would cause OrthoXML and PhyloXML orthologue downloads accessed via the "Download orthologues" button to contain orthology data for genes in a specific tree, where the gene tree would be the one selected by by [method get_GeneTree of EnsEMBL::Web::Object::Gene](https://github.com/twalsh-ebi/ensembl-webcode/blob/20fa36a2dca860cee91ee91ba40313c4d7a8418b/modules/EnsEMBL/Web/Object/Gene.pm#L944) based on parameters such as the `clusterset_id`.

The effect of these changes would be:
- to fix a bug whereby OrthoXML/PhyloXML downloads contain all orthologies involving the gene of interest (e.g. when clicking on the "Download orthologues" button in the [Mouse strains orthologues view](https://www.ensembl.org/Mus_musculus/Gene/Strain_Compara_Ortholog?g=ENSMUSG00000017167), a downloaded OrthoXML/PhyloXML file contains orthologues which are not in the Mouse strains collection); and
- to make the behaviour of orthologue downloads consistent for all currently supported download formats. In the context of Metazoa orthologue downloads, this has potential to simplify the provision of a "Gene tree" option allowing the user to select the particular gene tree from which they would like to fetch orthologues.

## Views affected

This would affect the behaviour of "Download orthologues" buttons in all orthologue views. For example:
- Default Vertebrates orthologues: [live site](https://www.ensembl.org/Mus_musculus/Gene/Compara_Ortholog?g=ENSMUSG00000017167) vs [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Mus_musculus/Gene/Compara_Ortholog?g=ENSMUSG00000017167)
- Mouse strain orthologues: [live site](https://www.ensembl.org/Mus_musculus/Gene/Strain_Compara_Ortholog?g=ENSMUSG00000017167) vs [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Mus_musculus/Gene/Strain_Compara_Ortholog?g=ENSMUSG00000017167)
- Pig breed orthologues: [live site](https://www.ensembl.org/Sus_scrofa/Gene/Strain_Compara_Ortholog?g=ENSSSCG00000009657) vs [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Sus_scrofa/Gene/Strain_Compara_Ortholog?g=ENSSSCG00000009657)
- Metazoa orthologues: [staging site](https://staging-metazoa.ensembl.org/Apis_mellifera/Gene/Compara_Ortholog?g=LOC726692) vs [sandbox](http://wp-np2-25.ebi.ac.uk:5094//Apis_mellifera/Gene/Compara_Ortholog?g=LOC726692)

## Possible complications

Because the new functionality requires the `$restrict_to_gene_tree` option to be set and the default behaviour of the `get_homologies` method would not change, this is not expected to introduce any complications.

## Merge conflicts

No merge conflicts detected.

## Related JIRA Issues (EBI developers only)

- [ENSWEB-6874](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6874).
