### PR TITLE
Adding G2P config

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -370,6 +370,7 @@ DBSNPSS                     = http://www.ncbi.nlm.nih.gov/SNP/snp_ss.cgi?subsnp_
 DBSNPSSID                   = http://www.ncbi.nlm.nih.gov/projects/SNP/snp_viewTable.cgi?handle=###ID###
 DBVAR                       = https://www.ncbi.nlm.nih.gov/dbvar
 DDG2P                       = https://www.ebi.ac.uk/gene2phenotype/
+G2P                         = https://www.ebi.ac.uk/gene2phenotype/
 DECIPHER                    = https://www.deciphergenomics.org/patient/###ID###
 DECIPHER_BROWSER            = https://www.deciphergenomics.org/browser#q/###ID###
 DGVA                        = https://www.ebi.ac.uk/dgva/


### PR DESCRIPTION

## Description

We changed the DDG2P source to G2P source 

## Views affected

 https://www.ensembl.org/Homo_sapiens/Gene/Phenotype?db=core;g=ENSG00000134532;r=12:23529504-24562544 - The G2P source is not a link

