### PR TITLE
Filter by subgenome as needed when mapping from AlignSlice

### DIFF
--- a/modules/EnsEMBL/Web/Factory/Location.pm
+++ b/modules/EnsEMBL/Web/Factory/Location.pm
@@ -705,6 +705,18 @@ sub _create_from_sub_align_slice {
     my $sub_align_slices = $align_slice->sub_AlignSlice($align_start, $align_end)->get_all_Slices($species);
     
     foreach (@$sub_align_slices) {
+      my $sub_align_slice_genome_component = $_->get_genome_component();
+      if (defined $sub_align_slice_genome_component) {
+        # If a given AlignSlice::Slice from the sub-AlignSlice has a genome component,
+        # then it represents the subgenome component of a polyploid genome, in which
+        # case the slices of the given genome have been grouped per subgenome component.
+        # Since AlignSlice::get_all_Slices filters by $species, we need to additionally
+        # filter by component here, to avoid including slices from other components.
+        my $slice_genome_component = $slice->get_genome_component();
+        unless (defined $slice_genome_component && $slice_genome_component eq $sub_align_slice_genome_component) {
+          next;
+        }
+      }
       foreach (@{$_->get_all_underlying_Slices}) {
         $gap = 1, next if $_->seq_region_name eq 'GAP';
         


### PR DESCRIPTION
## Description

When viewing an image alignment (e.g. in the [Cactus alignment of the Wheat reference genome example region](http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum/Location/Compara_Alignments/Image?r=3D:2585940-2634711;align=313160;db=core)), clicking and dragging on a region in the alignment image triggers a Z-menu with a link saying something like, "Jump to best aligned region on Triticum aestivum".

Clicking on that link should bring the user to a new image alignment of the subregion defined by the clicked-and-dragged area in the original alignment. However, this currently does not always work as expected for the Wheat Cactus alignment, and may instead show a "Region too large" warning box.

![wheat_cactus_subregion_overextension](https://github.com/Ensembl/ensembl-webcode/assets/84317604/a178e3df-adba-41db-88a7-24f1b4e517aa)

For example, in this screenshot, the region which the webcode has attempted to display is much larger than both the selected subregion and the original Wheat example region. This is an artefact of the coordinates from several chromosomes on different genome components (i.e. 3D, 3B and 5A) being used to set the coordinates of a subregion of the original alignment on chromosome 3D. The end coordinate of the displayed subregion (3281454) was not taken from chromosome 3D, but instead was taken from an aligned region on chromosome 3B.

The issue is due to the subregion slice being identified by species. In the case of the Wheat Cactus alignment, the subregion needs to be identified by a combination of species and genome component. This PR adds some code to do that specifically for alignments such as the Wheat Cactus alignment.

## Views affected

The view primarily affected by this change is the display of a subregion of an image alignment such as the [Wheat Cactus alignment](http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum/Location/Compara_Alignments/Image?r=3D:2585940-2634711;align=313160;db=core), such as this: http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum/Location/Compara_Alignments/Image?r=3D:2585940-2634711;align_start=4741;align_end=12559;align=313160;db=core

## Possible complications

This PR changes code that is potentially widely used in the Ensembl website, but the change in behaviour has been restricted to `AlignSlice` objects whose `Slices` have been grouped per subgenome component and which consequently have a defined `genome_component` (e.g. `AlignSlice` objects generated from the Wheat Cactus HAL), so it should not have any side-effects.

## Merge conflicts

No merge conflicts detected.

## Related JIRA Issues (EBI developers only)

- [ENSINT-1635](https://www.ebi.ac.uk/panda/jira/browse/ENSINT-1635)
