### PR TITLE
Show component in Wheat GenomicAlignTree leaf name

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
@@ -876,7 +876,8 @@ sub features {
     $f->{_subtree_ref} = 1 if exists $tree->{_subtree}->{_supertree};
   } elsif ($tree->is_leaf  && $tree->isa('Bio::EnsEMBL::Compara::GenomicAlignTree')) {
     my $genomic_align = $tree->get_all_genomic_aligns_for_node->[0];
-    my $name = $genomic_align->genome_db->name;
+    my $leaf_genome_db = $tree->get_genome_db_for_node;
+    my $name = $leaf_genome_db->name;
 
     #Get the cigar_line for the GenomicAlignGroup (passed in via highlights structure)
     my $cigar_line = shift @$slice_cigar_lines;
@@ -885,7 +886,11 @@ sub features {
     if ($cigar_line =~ /M/) {
       $f->{'_cigar_line'} = $cigar_line;
     }
-    $f->{'label'} = $species_defs->get_config($lookup->{$name}, 'SPECIES_DISPLAY_NAME');
+    if ($leaf_genome_db->genome_component) {
+      $f->{'label'} = $leaf_genome_db->display_name;
+    } else {
+      $f->{'label'} = $species_defs->get_config($lookup->{$name}, 'SPECIES_DISPLAY_NAME');
+    }
     if ($low_coverage_species && $low_coverage_species->{$genomic_align->genome_db->dbID}) {
      $f->{'_gat'}{'colour'} = 'brown';
     }


### PR DESCRIPTION
## Description

With the introduction in e111 of the polyploid GenomicAlignTree for the Wheat Cactus alignment, different leaves of the Wheat Cactus GenomicAlignTree can represent different subgenome components of polyploid Wheat genomes.

The leaves of the Wheat Cactus tree are currently labelled with the genome name. This PR would allow them to be labelled additionally with the subgenome component name, as in the following image:

![wheat_cactus_tree_with_components](https://github.com/Ensembl/ensembl-webcode/assets/84317604/c932d740-ecd3-4c8b-b22e-528846281b65)

## Views affected

This affects the GenomicAlignTree view shown above Wheat Cactus multiple sequence text alignments, and the text alignment view of any polyploid-aware Cactus multiple genome alignment introduced in future.

Example on Plants sandbox: http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum/Location/Compara_Alignments?r=3D:2585940-2634711;align=313160;db=core

## Possible complications

No complications are expected, as the changes in this PR are in a block of code which is only executed on the condition (given in [line 877 of ensembl-webcode/modulesEnsEMBL/Draw/GlyphSet/genetree.pm](https://github.com/Ensembl/ensembl-webcode/blob/0735dbdf37264aafd3a4bfd6c527e99c03436786/modules/EnsEMBL/Draw/GlyphSet/genetree.pm#L877)) that the given tree node is a leaf (`$tree->is_leaf`) and that it is a `GenomicAlignTree` object (`$tree->isa('Bio::EnsEMBL::Compara::GenomicAlignTree')`), so it is relevant only to `GenomicAlignTree` leaf nodes.

## Merge conflicts

No merge conflicts detected.

## Related JIRA Issues (EBI developers only)

- [ENSINT-1635](https://www.ebi.ac.uk/panda/jira/browse/ENSINT-1635)