### PR TITLE
Give preference to default gene-tree stats

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/Compara/GeneTrees.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara/GeneTrees.pm
@@ -51,7 +51,11 @@ sub format_gene_tree_stats {
 
   my $mlss_adaptor    = $compara_db->get_adaptor('MethodLinkSpeciesSet');
   my $all_mlsss       = $mlss_adaptor->fetch_all_by_method_link_type($method);
-  my ($mlss)          = sort {$b->species_set->size <=> $a->species_set->size} @$all_mlsss;  # The mouse-strains trees are not very interesting. Take the largest set instead
+  # Give preference to default gene-tree collection(s), if available.
+  my @default_mlsss   = grep { $_->species_set->name  =~ /^(collection-)?default$/ } @$all_mlsss;
+  $all_mlsss          = \@default_mlsss if (@default_mlsss);
+  # Take the largest relevant gene-tree collection.
+  my ($mlss)          = sort {$b->species_set->size <=> $a->species_set->size} @$all_mlsss;
   return unless $mlss;
 
   my $species_tree_adaptor = $compara_db->get_adaptor('SpeciesTree');


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

This PR would ensure that gene-tree stats are displayed for the default gene-tree collection in general, and the default Metazoa protein-tree collection in particular. It would fix [ENSWEB-6881](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6881).

## Views affected

The code added in this PR would be used in protein-tree and ncRNA-tree stats on all Ensembl sites.
However, it would only affect the Metazoa protein-tree stats view, because that is the only Ensembl division
in which the default protein-tree collection is not the largest one.

Metazoa protein-tree stats on sandbox: http://wp-np2-25.ebi.ac.uk:5094/info/genome/compara/prot_tree_stats.html
Metazoa protein-tree stats on staging site: https://staging-metazoa.ensembl.org/info/genome/compara/prot_tree_stats.html

## Possible complications

No complications expected, as the method containing this change (`format_gene_tree_stats`) is currently only called in the context of gene-tree stats views.

## Merge conflicts

No conflicts detected.

## Related JIRA Issues (EBI developers only)

- [ENSWEB-6881](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6881)
