### PR TITLE
Human patches fix

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/patch_ref_alignment.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/patch_ref_alignment.pm
@@ -36,12 +36,8 @@ sub _init {
   my $join_colour   = $self->my_colour(lc $self->{'container'}->assembly_exception_type, 'join'); 
 
   if (scalar @$features) {
-    my $patch_start   = $self->{'container'}->get_all_AssemblyExceptionFeatures->[0]->start; 
-    my $patch_end     = $self->{'container'}->get_all_AssemblyExceptionFeatures->[0]->end; 
-    $patch_start      = 1 if $patch_start < 1;
-    my $patch_length  = $patch_end - $patch_start +1;
-    $patch_length     = $length if $patch_length > $length;
-
+    my $patch_start   = 1; # Patch start should always be 1
+    my $patch_length  = $self->{'container'}->seq_region_length;
     foreach (0, 8) {
       $self->push($self->Rect({
         x         => $patch_start -1,


### PR DESCRIPTION
## Description

Message from Jose:
The assembly_exception table in the core database used to contain the coordinates of the patches with respect to the corresponding reference chromosome. This was because patches were represented as fake chromosomes in the genome browser. Since release 110, patches are on its own, so the assembly exceptions don’t make sense anymore and have been deleted from the database.
I am not sure about the implications of this in the context of the webcode. Perhaps the patch start should always be 1 and the patch end be the patch length in this new scenario?

Adjusting the patch start and end fixed.

## Views affected

Region comparison and Region in detail

Sandbox for testing http://wp-np2-1e.ebi.ac.uk:9000/


## Possible complications
Dont know

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6751
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6915
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6887