### PR TITLE
Add ensemblQueryR as a binding to Ensembl documentation

### DIFF
--- a/htdocs/info/about/ensembl_powered.html
+++ b/htdocs/info/about/ensembl_powered.html
@@ -199,6 +199,12 @@ and you're not on this list, let us know.
 <p>Whilst we have developed a comprehensive Perl API in-house, we welcome contributions
 in other programming languages from the community.</p>
 
+<h3>R - ensemblQueryR</h3>
+<p>ensemblQueryR provides an R interface to the Ensembl REST API permitting fast, flexible, user-friendly querying. Docker and Singularity images available.</p>
+<ul>
+<li><a href="https://github.com/ainefairbrother/ensemblQueryR">GitHub repository</a></li>
+</ul>
+
 <h3>Ruby</h3>
 
 <p>A Ruby API has been developed by Jan Aerts. A small example, showing what it can do 


### PR DESCRIPTION
Updating the list of projects with bindings to Ensembl to include ensemblQueryR

## Requirements

- [x] Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- [x] Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

We have been discussing with Aine Fairbrother-Browne if we would be happy to promote `ensemblQueryR` as a set of bindings to Ensembl's REST API. We have agreed and updated the documentation as appropriate. Change is in the final API section with text provided by Aine. I have included links to the GitHub repository.

## Views affected

- Ensembl powered. Live link at <https://www.ensembl.org/info/about/ensembl_powered.html>

## Possible complications

None since this is a static HTML edit. Only issue is if I linked to the wrong branch, but according to the requirements I think this is fine since the edits should be applied into 111 and main.

## Merge conflicts

Done directly against main so should be without conflict as far as I have checked

## Related JIRA Issues (EBI developers only)

None
