### PR TITLE
Add funding message

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -35,8 +35,8 @@ use Sys::Hostname::Long;
 ###############################################################################
 ## Ensembl Version and release dates (these get updated every release)
 our $ENSEMBL_VERSION        = 111;            # Ensembl release number
-our $ARCHIVE_VERSION        = 'Nov2023';     # Archive site for this version
-our $ENSEMBL_RELEASE_DATE   = 'November 2023'; # As it would appear in the copyright/footer
+our $ARCHIVE_VERSION        = 'Jan2024';     # Archive site for this version
+our $ENSEMBL_RELEASE_DATE   = 'January 2024'; # As it would appear in the copyright/footer
 ###############################################################################
 
 

--- a/htdocs/info/about/credits.html
+++ b/htdocs/info/about/credits.html
@@ -16,7 +16,10 @@
       <div class="column-two column-first">
         <div class="column-left center">
           <div class="center">
-            <p style="padding:16px 16px 16px 16px"><a href="http://www.wellcome.ac.uk/"><img src="/img/credits/wellcome-logo-blue.png" alt="logo" title="Wellcome Trust" /></a></p>
+            <p style="padding:16px 16px 16px 16px">
+                <a href="http://www.wellcome.ac.uk/">
+                    <img src="/img/credits/wellcome-logo-blue.png" alt="logo" title="Wellcome Trust" /><br />Funded by Wellcome</a>
+            </p>
             <p><a href="http://www.embl.de/"><img src="/img/credits/embl_logo.png" alt="logo" title="European Molecular Biology Laboratory" /></a></p>
             <p><a href="http://www.bbsrc.ac.uk/"><img src="/img/credits/bbsrc_logo.gif" alt="logo" title="Biotechnology and Biological Sciences Research Council" /></a></p>
             <p><a href="http://www.genome.gov/"><img src="/img/credits/nhgri_logo.gif" alt="logo" title="National Human Genome Research Institute" /></a></p>

--- a/htdocs/info/about/credits.html
+++ b/htdocs/info/about/credits.html
@@ -18,7 +18,7 @@
           <div class="center">
             <p style="padding:16px 16px 16px 16px">
                 <a href="http://www.wellcome.ac.uk/">
-                    <img src="/img/credits/wellcome-logo-blue.png" alt="logo" title="Wellcome Trust" /><br />Funded by Wellcome</a>
+                  <img src="/img/credits/wellcome-logo-blue.png" alt="logo" title="Wellcome Trust" /></a><br />Funded by Wellcome
             </p>
             <p><a href="http://www.embl.de/"><img src="/img/credits/embl_logo.png" alt="logo" title="European Molecular Biology Laboratory" /></a></p>
             <p><a href="http://www.bbsrc.ac.uk/"><img src="/img/credits/bbsrc_logo.gif" alt="logo" title="Biotechnology and Biological Sciences Research Council" /></a></p>


### PR DESCRIPTION

## Description

Changes to the guidance around the use of Wellcome logos require us to add a message explicitly saying that funding was provided by Wellcome. This PR adds a note under the logo on the "credits" page of the website.

## Views affected

Acknowledgements page: http://wp-np2-1f.ebi.ac.uk:8800/info/about/credits.html

## Possible complications

None

## Merge conflicts

None

## Related JIRA Issues (EBI developers only)

[ENSWEB-6923](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6923) 