### PR TITLE
[r112] Update the Regulation pane in Species index page

### DIFF
--- a/modules/EnsEMBL/Web/Component/Info/HomePage.pm
+++ b/modules/EnsEMBL/Web/Component/Info/HomePage.pm
@@ -365,8 +365,8 @@ sub funcgen_text {
         %s
       </div>
       <h2>Regulation</h2>
-      <p><strong>What can I find?</strong> DNA methylation, transcription factor binding sites, histone modifications, and regulatory features such as enhancers and repressors, and microarray annotations.</p>
-      <p><a href="/info/genome/funcgen/" class="nodeco">%sMore about the %s regulatory build</a> and <a href="/info/genome/microarray_probe_set_mapping.html" class="nodeco">microarray annotation</a></p>
+      <p><strong>What can I find?</strong> Regulatory features like enhancers and promoters, and regulatory activity including ATAC-seq and ChIP-seq tracks.</p>
+      <p><a href="/info/genome/funcgen/" class="nodeco">%sMore about the %s regulatory annotation</a></p>
       <p><a href="%s" class="nodeco">%sExperimental data sources</a></p>
       %s %s',
       
@@ -384,13 +384,6 @@ sub funcgen_text {
         '<p><a href="%s/regulation/%s/" class="nodeco">%sDownload all regulatory features</a> (GFF)</p>', ## Link to FTP site
         $ftp, $species_prod_name, sprintf($self->{'icon'}, 'download')
       ) : '',
-    );
-  } else {
-    return sprintf('
-      <h2>Regulation</h2>
-      <p><strong>What can I find?</strong> Microarray annotations.</p>
-      <p><a href="/info/genome/microarray_probe_set_mapping.html" class="nodeco">%sMore about the %s microarray annotation strategy</a></p>',
-      sprintf($self->{'icon'}, 'info'), $species_defs->ENSEMBL_SITETYPE
     );
   }
 }


### PR DESCRIPTION
## Description

Update the Regulation pane text in Species index page.

## Views affected

Current: https://www.ensembl.org/Homo_sapiens/Info/Index
Updated: http://wp-np2-25.ebi.ac.uk:6020/Homo_sapiens/Info/Index

## Possible complications

None.

## Merge conflicts

None.

## Related JIRA Issues (EBI developers only)

[ENSREGULATION-2080](https://www.ebi.ac.uk/panda/jira/browse/ENSREGULATION-2080)
