### PR TITLE
Add exons to gene-tree export params

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -357,7 +357,7 @@ sub content {
 
   ## Parameters to pass into export form
   $image->{'export_params'} = [['gene_name', $gene_name],['align', 'tree']];
-  my @extra_params = qw(g1 anc collapse);
+  my @extra_params = qw(g1 anc collapse exons);
   foreach (@extra_params) {
     push @{$image->{'export_params'}}, [$_, $self->param($_)];
   }


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

If accepted, this PR would add the `exons` parameter to the `@extra_params` array (and indirectly to `export_params`) in the [ensembl-webcode ComparaTree](https://github.com/Ensembl/ensembl-webcode/blob/507432c684afb3ad760b61863cc7ff3d478e904e/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm#L360), effectively ensuring that this parameter is passed to the gene-tree image export functionality.

In short, it would enable exon ticks to be drawn in exported gene-tree images on the Ensembl Vertebrates website.

## Views affected

This change affects the image export functionality of default and strains gene trees.

To confirm success of this change on the Compara sandbox, gene-tree image export was tested in the following cases:
- [Mouse Cntnap1 in default Vertebrates gene tree](http://wp-np2-25.ebi.ac.uk:5092/Mus_musculus/Gene/Compara_Tree?g=ENSMUSG00000017167)
- [Mouse Cntnap1 in Murinae gene tree](http://wp-np2-25.ebi.ac.uk:5092/Mus_musculus/Gene/Strain_Compara_Tree?g=ENSMUSG00000017167)

Exon ticks were drawn in all downloaded images.

## Possible complications

As well as the `add_image_export_icon` method of `EnsEMBL::Web::Document::Image`, the value of `export_params` is also used in the `add_export_icon` method, raising the question of whether the `exons` parameter would affect the data export functionality of the gene-tree view.

This question was addressed by comparing files downloaded in each format, before and after the proposed change, from the default gene tree view of an example gene in the Vertebrates sandbox. For these checks, the sandbox was set up with a modified version of `ensembl-compara` code which had deterministic data serialisation, so that the same gene-tree data downloaded in the same format would — inasmuch as possible — result in the same file being downloaded.

The only differences observed between gene-tree data files exported before and after the proposed change were unrelated to the presence of the `exons` parameter. These were:
1. in the Nexus format download, the ordering of the characters in the `symbols` was different; and
2. in the MSF format, the downloaded files had different timestamps.

## Merge conflicts

_At certain stages of the release there is potential for many people to be working on the same modules. To avoid merge conflicts please confirm you have tested for this before submitting the pull request, eg by updating your feature branch and checking that the only changes being submitted are ones from you._

No merge conflicts detected.

## Related JIRA Issues (EBI developers only)

- [ENSCOMPARASW-7184](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-7184)
