### PR TITLE
Tweak order of gene-tree highlighting rules

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
@@ -211,8 +211,6 @@ sub _init {
       if( $other_gene && $f->{_genes}->{$other_gene} ){
         $bold = 1;
         $label_colour = "ff6666";
-      } elsif( $other_genome_db_id && $f->{_genome_dbs}->{$other_genome_db_id} ){
-        $bold = 1;
       } elsif( $f->{_genes}->{$current_gene} ){
         $label_colour     = 'red';
         $collapsed_colour = 'red';
@@ -222,6 +220,8 @@ sub _init {
         $label_colour     = 'blue';
         $collapsed_colour = 'blue';
         $bold = defined($other_genome_db_id);
+      } elsif( $other_genome_db_id && $f->{_genome_dbs}->{$other_genome_db_id} ){
+        $bold = 1;
       }
     }
 


### PR DESCRIPTION
## Description

This PR tweaks the order in which gene-tree labels are processed, so in a gene-tree view with a query gene and its homologue highlighted, the query and its homologue highlighting rules are given priority over query-genome and homologue-genome highlighting rules.

In practice, this means that in a gene tree view linked from a homoeologue table, the query gene label will be highlighted in red, as it is in a gene tree linked from an orthologue table.

## Views affected

Though the change is made in a module which affects gene-tree, gene gain/loss and genomic-align tree views, the effects of the change should only be noticeable in gene-tree views with a highlighted query gene and homologue in the same species (e.g. gene tree linked from homoeologue table).

Examples:
- [Homoeologue table](http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum/Gene/Compara_Homoeolog?g=TraesCS3D02G273600) and [a corresponding gene-tree view](http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum/Gene/Compara_Tree?anc=19964110;db=core;g=TraesCS3D02G273600;g1=TraesCS3A02G274400) on a sandbox site.
- [Homoeologue table](https://staging-plants.ensembl.org/Triticum_aestivum/Gene/Compara_Homoeolog?g=TraesCS3D02G273600) and a [corresponding gene-tree view](https://staging-plants.ensembl.org/Triticum_aestivum/Gene/Compara_Tree?anc=19964110;db=core;g=TraesCS3D02G273600;g1=TraesCS3A02G274400) on staging site.

## Possible complications

Here are examples of other _potentially_ affected views, none of which appear to be affected by the change in this PR.

- Default gene tree on [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum/Gene/Compara_Tree?anc=19964021;db=core;g=TraesCS3D02G273600;g1=CEY00_Acc18330) and [staging](https://staging-plants.ensembl.org/Triticum_aestivum/Gene/Compara_Tree?anc=19964021;db=core;g=TraesCS3D02G273600;g1=CEY00_Acc18330).
- Cultivar gene tree on [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum/Gene/Strain_Compara_Tree?db=core;g=TraesCS3D02G273600;g1=AET3Gv20655200) and [staging](https://staging-plants.ensembl.org/Triticum_aestivum/Gene/Strain_Compara_Tree?db=core;g=TraesCS3D02G273600;g1=AET3Gv20655200).
- Pan Compara gene tree on [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Arabidopsis_thaliana/Gene/PanComparaTree?anc=6201892;db=core;g=AT1G07820;g1=AAEL000501) and [staging](https://staging-plants.ensembl.org/Arabidopsis_thaliana/Gene/PanComparaTree?anc=6201892;db=core;g=AT1G07820;g1=AAEL000501).
- Gene gain/loss tree on [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum/Gene/SpeciesTree?g=TraesCS3D02G273600) and [staging](https://staging-plants.ensembl.org/Triticum_aestivum/Gene/SpeciesTree?g=TraesCS3D02G273600).
- Genomic alignment tree on [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Oryza_sativa/Location/Compara_Alignments?r=5:20683551-20684336;align=9910;db=core) and [staging](https://staging-plants.ensembl.org/Oryza_sativa/Location/Compara_Alignments?r=5:20683551-20684336;align=9910;db=core).

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
