### PR TITLE
Add default caption to gene-tree node ZMenu

### DIFF
--- a/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
@@ -68,20 +68,26 @@ sub content {
   }
 
   my $tagvalues       = $node->get_tagvalue_hash;
-  my $speciesTreeNode = $node->species_tree_node();
-  my $taxon_name      = $speciesTreeNode->get_scientific_name;
-  my $taxon_mya       = $speciesTreeNode->get_divergence_time;
-  my $taxon_alias     = $speciesTreeNode->get_common_name;
 
   my $caption         = 'Taxon: ';
-  
-  if (defined $taxon_alias) {
-    $caption .= $taxon_alias;
-    $caption .= sprintf ' ~%d MYA', $taxon_mya if defined $taxon_mya;
-    $caption .= " ($taxon_name)";
+  my $speciesTreeNode = $node->species_tree_node();
+  if (defined $speciesTreeNode) {
+
+    my $taxon_name      = $speciesTreeNode->get_scientific_name;
+    my $taxon_mya       = $speciesTreeNode->get_divergence_time;
+    my $taxon_alias     = $speciesTreeNode->get_common_name;
+
+    if (defined $taxon_alias) {
+      $caption .= $taxon_alias;
+      $caption .= sprintf ' ~%d MYA', $taxon_mya if defined $taxon_mya;
+      $caption .= " ($taxon_name)";
+    } else {
+      $caption .= $taxon_name;
+      $caption .= sprintf ' ~%d MYA', $taxon_mya if defined $taxon_mya;
+    }
+
   } else {
-    $caption .= $taxon_name;
-    $caption .= sprintf ' ~%d MYA', $taxon_mya if defined $taxon_mya;
+    $caption .= 'unknown';
   }
   
   $self->caption($caption);


### PR DESCRIPTION
## Description

For gene-tree nodes with a corresponding species-tree node, the gene-tree ZMenu caption is taken from the taxon name or alias of the species-tree node.

For gene-tree nodes lacking a corresponding species-tree node, the ZMenu fails to load. This PR restores a previously used default caption, "Taxon: unknown", which has the effect of allowing a ZMenu to be displayed in such cases.

## Views affected

This update changes code which is used in the ZMenu of all gene-tree views.

However, its effects should be restricted to the ZMenu of those gene-tree nodes lacking a corresponding species-tree node.

To see the effect of this PR, select the `ftga_it_nj` tree of each of the example gene tree views, and click on the root node:
- Example on RC site: [ENSPANG00000013968](https://rc.ensembl.org/Papio_anubis/Gene/Compara_Tree?collapse=none;db=core;g=ENSPANG00000013968)
- Example on sandbox: [ENSPANG00000013968](http://wp-np2-25.ebi.ac.uk:5092/Papio_anubis/Gene/Compara_Tree?collapse=none;db=core;g=ENSPANG00000013968)

## Possible complications

Changes are restricted to gene-tree nodes lacking a species-tree node, so complications are unlikely.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
