### PR TITLE
Check if projection parent is in ref core database

### DIFF
--- a/modules/EnsEMBL/Web/Component/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Summary.pm
@@ -196,15 +196,19 @@ sub get_extra_rows {
       if ($species) { #needed because some attributes are not valid e! stable IDs
         my $ga = Bio::EnsEMBL::Registry->get_adaptor($species,$db_type,'gene');
         my $gene = $ga->fetch_by_stable_id($ref_gene);
-        my $ref_gene_name = $gene->display_xref->display_id;
+        if ($gene) {  # needed because some projection parents may not exist in the current ref core database
+          my $ref_gene_name = $gene->display_xref->display_id;
 
-        my $ref_url  = $hub->url({
-          species => $species,
-          type    => 'Gene',
-          action  => 'Summary',
-          g       => $ref_gene
-        });
-        push @rows, ["Reference $strain_type equivalent", qq{<a href="$ref_url">$ref_gene_name</a>}];
+          my $ref_url  = $hub->url({
+            species => $species,
+            type    => 'Gene',
+            action  => 'Summary',
+            g       => $ref_gene
+          });
+          push @rows, ["Reference $strain_type equivalent", qq{<a href="$ref_url">$ref_gene_name</a>}];
+        } else {
+          push @rows, ["Reference $strain_type equivalent","None"];
+        }
       }
       else {
         push @rows, ["Reference $strain_type equivalent","None"];


### PR DESCRIPTION
## Description

The gene summary of projected genes may contain a link to a "reference strain equivalent" (e.g. a link to 'Cntnap1' in the gene summary of [MGP_AJ_G0019153](http://jan2024.archive.ensembl.org/Mus_musculus_A_J/Gene/Summary?g=MGP_AJ_G0019153)).

The generation of this link involves an initial lookup of the stable ID database, followed by the gene being fetched from the core database of the projection reference genome.

This can go wrong in a couple of ways:
1. If the stable ID is no longer current in the reference genome, an error message appears in the gene summary, though most of the gene web page is still shown. This less severe issue affects 44,648 Mouse strain genes in Ensembl 112.
2. If the stable ID clashes with that of another genome, a more severe error occurs which prevents the gene page from being displayed. This more severe issue likely affects ~34 Mouse strain genes as of Ensembl 112.

This PR addresses both issues by checking that a gene object has successfully retrieved from the reference core database before proceeding to generate the link.

## Views affected

This affects gene web pages for genes which have been annotated by projection.

Example of the less severe issue:
- on the Vertebrates 112 RC site: https://rc.ensembl.org/Mus_musculus_A_J/Gene/Summary?db=core;g=MGP_AJ_G0008045
- on the Compara sandbox: http://wp-np2-25.ebi.ac.uk:5092/Mus_musculus_A_J/Gene/Summary?db=core;g=MGP_AJ_G0008045

Example of the more severe issue:
- on the Vertebrates 112 RC site: https://rc.ensembl.org/Mus_musculus_PWK_PhJ/Gene/Summary?db=core;g=MGP_PWKPhJ_G0028089
- on the Compara sandbox: http://wp-np2-25.ebi.ac.uk:5092/Mus_musculus_PWK_PhJ/Gene/Summary?db=core;g=MGP_PWKPhJ_G0028089

## Possible complications

Complications are unlikely, since the updated code should only be executed for genes annotated by projection.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
