### PR TITLE
Access Pan member genome by production name

### DIFF
--- a/modules/EnsEMBL/Web/QueryStore/Source/Adaptors.pm
+++ b/modules/EnsEMBL/Web/QueryStore/Source/Adaptors.pm
@@ -163,8 +163,8 @@ sub pancompara_member {
   ## Pass species in case this site has single-species compara
   my $gda = $self->_get_adaptor('get_GenomeDBAdaptor', $compara, $species);
   return undef unless $gda;
-  #my $prod_name = $self->{_sd}->get_config($species_url, 'SPECIES_PRODUCTION_NAME');
-  my $genome_db = $gda->fetch_by_name_assembly($species);
+  my $prod_name = $self->{_sd}->get_config($species, 'SPECIES_PRODUCTION_NAME');
+  my $genome_db = $gda->fetch_by_name_assembly($prod_name);
   return undef unless $genome_db;
 
   my $gma = $self->_get_adaptor('get_GeneMemberAdaptor', $compara, $species);


### PR DESCRIPTION
## Description

Pan-taxonomic Compara links have been inactive for several Ensembl releases in two Metazoa species of the Pan Compara set: Brugia malayi (Nematode, FR3) and Schistosoma mansoni (Flatworm). The most recent archive in which these species have been confirmed to have live Pan Compara links is Ensembl 105.

This PR tweaks the `Adaptors::pancompara_member` method to fetch the `$genome_db` by production name, just as is done in the `Adaptors::compara_member` method. For species whose `species.url` differs from their production name, such as these two species, this ensures that the relevant `$genome_db` can be accessed correctly.

## Views affected

This table contains example gene pages in the Metazoa sandbox, RC site and Ensembl 105 archive. The Pan Compara links are active in the sandbox and archive, but not in the RC site.

| Species                        | Links |
|--------------------------------|-------|
| Brugia malayi (Nematode, FR3) | [sandbox](http://wp-np2-25.ebi.ac.uk:5094/Brugia_malayi_prjna10729/Gene/Summary?g=WBGene00224532) vs [RC site](https://rc-metazoa.ensembl.org/Brugia_malayi_prjna10729/Gene/Summary?g=WBGene00224532) vs [e105 site](https://dec2021-metazoa.ensembl.org/Brugia_malayi/Gene/Summary?g=WBGene00224532)
| Schistosoma mansoni (Flatworm) | [sandbox](http://wp-np2-25.ebi.ac.uk:5094/Schistosoma_mansoni_prjea36577/Gene/Summary?g=Smp_035270) vs [RC site](https://rc-metazoa.ensembl.org/Schistosoma_mansoni_prjea36577/Gene/Summary?g=Smp_035270) vs [e105 site](https://dec2021-metazoa.ensembl.org/Schistosoma_mansoni/Gene/Summary?g=Smp_035270)

## Possible complications

No complications are expected, as Pan Compara links were working — and continue to work after this change — for other relevant Metazoa genomes.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A