### PR TITLE
Relax component regex in OrthoXML export

### DIFF
--- a/modules/EnsEMBL/Web/Command/DataExport/Output.pm
+++ b/modules/EnsEMBL/Web/Command/DataExport/Output.pm
@@ -496,7 +496,7 @@ sub write_orthoxml {
   my ($data)  = $component->get_export_data('genetree');
 
   my $method_type;
-  if (ref($component) =~ /ComparaTree/) {
+  if (ref($component) =~ /Tree/) {  # e.g. ComparaTree
     $method_type = ref($data) =~ /Node/ ? 'subtrees' : 'trees';     
   }
   else {


### PR DESCRIPTION
## Description

Gene-tree export functionality is not currently available for non-default Metazoa gene trees.

[eg-web-metazoa PR 36](https://github.com/EnsemblGenomes/eg-web-metazoa/pull/36) makes it possible to export data in most formats for the affected Metazoa gene trees.

This PR takes things a step further, by making it possible to export OrthoXML data.

## Views affected

This adjustment makes it possible to download OrthoXML tree data from the following Metazoa gene-tree views:
- [D. melanogaster His3.3A Protostomes tree](http://wp-np2-25.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/Protostomes_Tree?db=core;g=FBgn0014857)
- [D. melanogaster His3.3A Insects tree](http://wp-np2-25.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/Insects_Tree?db=core;g=FBgn0014857)
- [D. melanogaster His3.3A Drosophila pangenome](http://wp-np2-25.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/Drosophilidae_Tree?db=core;g=FBgn0014857)

## Possible complications

This is not expected to have negative effects on other views. In principle, the relaxed regex removes a theoretical brake against OrthoXML export of a gene/gain loss tree (with component `SpeciesTree`), but an OrthoXML download option is not currently offered for gene/gain loss trees anyway.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- [ENSWEB-6875](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6875)
