### PR TITLE
Export strain data in OrthoXML and PhyloXML format

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -623,7 +623,8 @@ sub get_export_data {
   
   ## First, get tree
   if ($gene && $type && $type eq 'genetree') { 
-    $tree = $gene->get_GeneTree($cdb, 1);
+    my $strain_tree  = $hub->species_defs->get_config($hub->species,'RELATED_TAXON') if $hub->param('strain');
+    $tree = $gene->get_GeneTree($cdb, 1, $strain_tree);
   }
   elsif ($hub->species eq 'Multi' && $self->param('gt')) {
     my $gene_tree = $hub->builder->create_object('GeneTree');


### PR DESCRIPTION
## Description

This PR adjusts the gene-tree fetching code in `genetree` export mode (used for OrthoXML and PhyloXML) to fetch the strain tree if the `strain` parameter has been set.

Currently, when the user tries to export gene-tree data from a strain/breed/cultivar tree in OrthoXML or PhyloXML format, the downloaded file contains data for the default gene-tree collection.

## Views affected

This change affects OrthoXML/PhyloXML export functionality in all strain/breed/cultivar views.

Example of Mouse Cntnap1 strain tree:
- Compara sandbox: http://wp-np2-25.ebi.ac.uk:5092/Mus_musculus/Gene/Summary?g=ENSMUSG00000017167
- RC site: https://rc.ensembl.org/Mus_musculus/Gene/Strain_Compara_Tree?g=ENSMUSG00000017167

Example of Pig PPP2R2A strain tree:
- Compara sandbox: http://wp-np2-25.ebi.ac.uk:5092/Sus_scrofa/Gene/Strain_Compara_Tree?g=ENSSSCG00000009657
- RC site: https://rc.ensembl.org/Sus_scrofa/Gene/Strain_Compara_Tree?g=ENSSSCG00000009657

## Possible complications

The change made in this PR takes effect only if the export type is `genetree`, so it is very unlikely to introduce complications.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
