### PR TITLE
Break down Pan Compara orthologue summary by division

### DIFF
--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -1627,11 +1627,21 @@ sub species_label {
 sub prodnames_to_urls_lookup {
 ## Maps all species' production names to their URLs
   my $self = shift;
+  my $compara_db = shift || 'compara';
   my $names = {'ancestral_sequences' => 'Ancestral sequences'};
-  
-  foreach ($self->valid_species) {
-    $names->{$self->get_config($_, 'SPECIES_PRODUCTION_NAME')} = $_;
+
+  if ($compara_db eq 'compara_pan_ensembl') {
+    my $pan_info = $self->multi_val('PAN_COMPARA_LOOKUP');
+    foreach (keys %$pan_info) {
+      $names->{$_} = $pan_info->{$_}{'species_url'};
+    }
   }
+  else {
+    foreach ($self->valid_species) {
+      $names->{$self->get_config($_, 'SPECIES_PRODUCTION_NAME')} = $_;
+    }
+  }
+
   return $names;
 }
 


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

This PR:
- Adds a `$compara_db` to `EnsEMBL::Web::SpeciesDefs::prodnames_to_urls_lookup`. If this is set to `compara_pan_ensembl`, the returned lookup is equivalent to the `PAN_COMPARA_LOOKUP`.
- Uses the updated `prodnames_to_urls_lookup` in `EnsEMBL::Web::Component::Gene::ComparaOrthologs` module in order to simplify access to the Pan Compara lookup as appropriate.
- Updates method `EnsEMBL::Web::Component::Gene::ComparaOrthologs::species_sets` so that in Pan Compara orthologue views, it fetches Pan `species_set_config` and sets `@compara_groups` to divisions/subdivision.
- Filters out `ancestral_sequences` and species that are absent from the URL lookup (e.g. Human in Ensembl Plants).

## Views affected

_List the website view(s) that you know are affected by this change._
_If possible please provide a URL that shows the change. For Ensembl developers this could be your sandbox._

This PR restores the Pan Compara orthologue summary to its appearance in eg52/e105.

Examples:
- PGIP2 on Plants eg52/e105 archive: https://dec2021-plants.ensembl.org/Arabidopsis_thaliana/Gene/Compara_Ortholog/pan_compara?g=AT5G06870;r=5:2133918-2135168;t=AT5G06870.1
- PGIP2 on eg59/e112 live site: https://plants.ensembl.org/Arabidopsis_thaliana/Gene/Compara_Ortholog/pan_compara?g=AT5G06870;r=5:2133918-2135168;t=AT5G06870.1
- PGIP2 on sandbox: http://wp-np2-25.ebi.ac.uk:5098/Arabidopsis_thaliana/Gene/Compara_Ortholog/pan_compara?g=AT5G06870;r=5:2133918-2135168;t=AT5G06870.1

## Possible complications

As the key changes take effect only if the current view is a Pan Compara orthologue view, no complications are expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
