### PR TITLE
Tweak supertree links in gene tree view

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
@@ -253,6 +253,7 @@ sub _init {
         action      => "ComparaTreeNode$skey",
         node        => $f->{'_id'},
         genetree_id => $Config->get_parameter('genetree_id'),
+        strain      => $Config->get_parameter('strain'),
         collapse    => $collapsed_nodes_str
       });
     }

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -71,7 +71,8 @@ sub content_sub_supertree {
     container_width => 400,
     image_width     => 400,
     slice_number    => '1|1',
-    cdb             => $cdb
+    cdb             => $cdb,
+    strain          => $self->param('strain'),
   });
   my $image = $self->new_image($parent->root, $super_image_config, []);
   $image->image_type       = 'genetree';
@@ -94,6 +95,7 @@ sub content {
   my $hub         = $self->hub;
   my $object      = $self->object || $self->hub->core_object('gene');
   my $is_genetree = $object && $object->isa('EnsEMBL::Web::Object::GeneTree') ? 1 : 0;
+  my $is_strain   = $hub->is_strain || $hub->param('strain') || $hub->action =~ /Strain_/;
   my ($gene, $member, $tree, $node, $test_tree);
 
   my $type   = $self->param('data_type') || $hub->type;
@@ -146,7 +148,7 @@ sub content {
   if (defined $parent) {
 
     if ($vc->get('super_tree') eq 'on' || $self->param('super_tree') eq 'on') {
-      my $super_url = $self->ajax_url('sub_supertree',{ cdb => $cdb, update_panel => undef });
+      my $super_url = $self->ajax_url('sub_supertree',{ cdb => $cdb, update_panel => undef, strain => $is_strain });
       $html .= qq(<div class="ajax"><input type="hidden" class="ajax_load" value="$super_url" /></div>);
     } else {
       $html .= $self->_info(
@@ -273,7 +275,8 @@ sub content {
     container_width => $image_width,
     image_width     => $image_width,
     slice_number    => '1|1',
-    cdb             => $cdb
+    cdb             => $cdb,
+    strain          => $is_strain,
   });
   
   # Keep track of collapsed nodes


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.


## Description

This PR tweaks supertree views, making it possible to follow most supertree view "Switch to that tree" links, including in Pan Compara gene trees, non-default Metazoa gene-tree views, Vertebrate strain trees, and, in conjunction with [eg-web-common PR 122](https://github.com/EnsemblGenomes/eg-web-common/pull/122), Non-Vertebrate strain tree views.

A key change is that preference is given to showing the `Multi` gene-tree view if a gene-tree stable ID is available. This circumvents having to deal with Pan Compara as a special case, since in practice all Pan Compara gene trees have a stable ID.

## Views affected

- An example gene tree: [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Camelus_dromedarius/Gene/Compara_Tree?db=core;g=ENSCDRG00005014444) vs [live site](https://www.ensembl.org/Camelus_dromedarius/Gene/Compara_Tree?db=core;g=ENSCDRG00005014444)
- Pan Compara gene tree: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Solanum_lycopersicum/Gene/PanComparaTree?db=core;g=Solyc04g009550.3) vs [live site](https://plants.ensembl.org/Solanum_lycopersicum/Gene/PanComparaTree?db=core;g=Solyc04g009550.3)
- Drosophila pangenome tree without stable ID: [sandbox](http://wp-np2-25.ebi.ac.uk:5094/Drosophila_albomicans_gca009650485v2rs/Gene/Drosophilidae_Tree?g=LOC127565835) vs [live site](https://metazoa.ensembl.org/Drosophila_albomicans_gca009650485v2rs/Gene/Drosophilidae_Tree?g=LOC127565835)
- Mouse strain gene tree without stable ID: [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Mus_musculus/Gene/Strain_Compara_Tree?g=ENSMUSG00000057461) vs [live site](https://www.ensembl.org/Mus_musculus/Gene/Strain_Compara_Tree?g=ENSMUSG00000057461)
- Wheat cultivar gene tree: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum_arinalrfor/Gene/Strain_Compara_Tree?g=TraesARI1B03G00343780) vs [live site](https://plants.ensembl.org/Triticum_aestivum_arinalrfor/Gene/Strain_Compara_Tree?g=TraesARI1B03G00343780)

## Possible complications

In the case of a nested supertree such as that mentioned in [ENSCOMPARASW-7495](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-7495), the effect of this PR is to make it possible for the `PTHR31235_SF5` Zmenu link to appear. However, the link to "Switch to that tree" leads to a broken Multi tree view.

This is due to the fact that `PTHR31235_SF5` is itself a supertree, a separate issue which [ensembl-webcode PR 1016](https://github.com/Ensembl/ensembl-webcode/pull/1016) aims to address.

In a small proportion of cases, even after the changes in this PR, supertree links may fail to appear for gene trees lacking a stable ID (e.g. the [LotgiG227894 protostomes tree](http://wp-np2-25.ebi.ac.uk:5094/Lottia_gigantea/Gene/Protostomes_Tree?db=core;g=LotgiG227894)). This is most likely due to a separate issue in Compara code ([ENSCOMPARASW-7520](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-7520)).

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

[ENSWEB-6883](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6883)
