### PR TITLE
Add base method to fetch orthology ancestral nodes

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -196,6 +196,7 @@ sub content {
   
   @rows = ();
   
+  my $anc_node_ids = $self->fetch_anc_node_ids($cdb);
   foreach my $species (sort { ($a =~ /^<.*?>(.+)/ ? $1 : $a) cmp ($b =~ /^<.*?>(.+)/ ? $1 : $b) } keys %orthologue_list) {
     next unless $species;
     next if $species_not_shown->{$species};
@@ -289,14 +290,6 @@ sub content {
         $alignview = 1;
       }      
      
-      my $tree_url = $hub->url({
-        type   => 'Gene',
-        action => $strain_url . ($cdb =~ /pan/ ? 'PanComparaTree' : 'Compara_Tree'),
-        g1     => $stable_id,
-        anc    => $orthologue->{'gene_tree_node_id'},
-        r      => undef
-      });
-
       # External ref and description
       my $description = encode_entities($orthologue->{'description'});
          $description = 'No description' if $description eq 'NULL';
@@ -331,7 +324,7 @@ sub content {
 
 
       my $tree_links = $self->create_gene_tree_links({
-        gene_availability => $availability, # the gene_availability parameter only becomes relevant in the Metazoa plugin
+        anc_node_ids => $anc_node_ids, # the anc_node_ids parameter only becomes relevant in the Metazoa plugin
         cdb => $cdb,
         stable_id => $stable_id,
         orthologue => $orthologue
@@ -511,6 +504,8 @@ sub species_sets {
 }
 
 sub species_set_config {} # Stub, as it's clade-specific - implement in plugins
+
+sub fetch_anc_node_ids {}  # Another stub, only for specific divisions (e.g. Metazoa)
 
 sub get_strain_refs_html {
   my ($self, $strain_refs, $species_not_shown) = @_;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

In conjunction with [eg-web-metazoa PR 37](https://github.com/EnsemblGenomes/eg-web-metazoa/pull/37), this PR makes it possible to highlight the ancestral node of orthologous genes in all Metazoa gene-tree collections.

## Views affected

Gene-tree links in Ensembl Metazoa orthologue views are affected.

Examples:
- Drosophila melanogaster His3.3A orthologues: [sandbox](http://wp-np2-25.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/Compara_Ortholog?g=FBgn0014857) vs [live site](https://metazoa.ensembl.org/Drosophila_melanogaster/Gene/Compara_Ortholog?g=FBgn0014857)
- Drosophila melanogaster His3.3A Pan Compara orthologues: [sandbox](http://wp-np2-25.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/Compara_Ortholog/pan_compara?g=FBgn0014857) vs [live site](https://metazoa.ensembl.org/Drosophila_melanogaster/Gene/Compara_Ortholog/pan_compara?g=FBgn0014857)
- Mountainous star coral gene LOC110059907 orthologues (with some orthologues lacking a gene-tree link):
[sandbox](http://wp-np2-25.ebi.ac.uk:5094/Orbicella_faveolata_gca002042975v1/Gene/Compara_Ortholog?db=core;g=LOC110059907) vs [live site](https://metazoa.ensembl.org/Orbicella_faveolata_gca002042975v1/Gene/Compara_Ortholog?db=core;g=LOC110059907)

## Possible complications

Because ancestral node_ids are fetched only in Ensembl Metazoa, this PR is not expected to have an effect in any other Ensembl division.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- [ENSCOMPARASW-7253](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-7253)
- [ENSWEB-6878](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6878)