### PR TITLE
Add spaces between elements in homolog table cells

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -299,18 +299,18 @@ sub content {
         $description   .= sprintf '[Source: %s; acc: %s]', $edb, $hub->get_ExtURL_link($acc, $edb, $acc) if $acc;
       }
       
-      my $id_info;
+      my @id_info_parts;
       if ($orthologue->{'display_id'}) {
         if ($orthologue->{'display_id'} eq 'Novel Ensembl prediction') {
-          $id_info = qq{<p class="space-below"><a href="$link_url">$stable_id</a></p>};
+          push(@id_info_parts, qq{<p class="space-below"><a href="$link_url">$stable_id</a></p>});
         } else {
-          $id_info = qq{<p class="space-below">$orthologue->{'display_id'}&nbsp;&nbsp;<a href="$link_url">($stable_id)</a></p>};
+          push(@id_info_parts, qq{<p class="space-below">$orthologue->{'display_id'}&nbsp;&nbsp;<a href="$link_url">($stable_id)</a></p>});
         }
       } else {
- 	$id_info = qq{<p class="space-below"><a href="$link_url">$stable_id</a></p>};	
+        push(@id_info_parts, qq{<p class="space-below"><a href="$link_url">$stable_id</a></p>});
       }
  
-      $id_info .= qq{<p class="space-below">$region_link</p><p class="space-below">$alignment_link</p>};
+      push(@id_info_parts, (qq{<p class="space-below">$region_link</p>}, qq{<p class="space-below">$alignment_link</p>}));
 
       ##Location - split into elements to reduce horizonal space
       my $location_link = $hub->url({
@@ -330,11 +330,13 @@ sub content {
         orthologue => $orthologue
       });
 
+      my @homology_type_parts = (glossary_helptip($hub, ucfirst $orthologue_desc, ucfirst "$orthologue_desc orthologues"));
+      push(@homology_type_parts, $tree_links) if $self->html_format;
 
       my $table_details = {
         'Species'    => join('<br />(', split(/\s*\(/, $species_label)),
-        'Type'       => $self->html_format ? glossary_helptip($hub, ucfirst $orthologue_desc, ucfirst "$orthologue_desc orthologues"). $tree_links : glossary_helptip($hub, ucfirst $orthologue_desc, ucfirst "$orthologue_desc orthologues") ,
-        'identifier' => $self->html_format ? $id_info : $stable_id,
+        'Type'       => join(' ', @homology_type_parts),
+        'identifier' => $self->html_format ? join(' ', @id_info_parts) : $stable_id,
         'Target %id' => qq{<span class="$target_class">}.sprintf('%.2f&nbsp;%%', $target).qq{</span>},
         'Query %id'  => qq{<span class="$query_class">}.sprintf('%.2f&nbsp;%%', $query).qq{</span>},
         'goc_score'  => qq{<span class="$goc_class">$goc_score</span>},

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaParalogs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaParalogs.pm
@@ -134,7 +134,7 @@ sub content {
           push(@compare_link_parts, (
             sprintf('<li><a href="%s" class="notext">Alignment (protein)</a></li>', $align_url),
             sprintf('<li><a href="%s" class="notext">Alignment (cDNA)</a></li>', $align_url.';seq=cDNA'),
-          );
+          ));
         }
         
         ($target, $query) = ($paralogue->{'target_perc_id'}, $paralogue->{'query_perc_id'});


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

To facilitate testing, this PR — in conjunction with [eg-web-common PR 123](https://github.com/EnsemblGenomes/eg-web-common/pull/123) — adds spacing between elements within the same cell of an orthology/paralogy/homoeology table view.

## Views affected

This set of changes primarily affects the spacing of elements within text files downloaded from orthologue, paralogue and homoeologue views.

Examples:
- Orthologues: [sandbox](http://wp-np2-25.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/Compara_Ortholog?g=FBgn0014857) vs [staging site](https://staging-metazoa.ensembl.org/Drosophila_melanogaster/Gene/Compara_Ortholog?g=FBgn0014857)
- Paralogues: [sandbox](http://wp-np2-25.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/Compara_Paralog?g=FBgn0014857) vs [staging site](https://staging-metazoa.ensembl.org/Drosophila_melanogaster/Gene/Compara_Paralog?g=FBgn0014857)
- Homoeologues: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum/Gene/Compara_Homoeolog?g=TraesCS3D02G273600) vs [live site](https://plants.ensembl.org/Triticum_aestivum/Gene/Compara_Homoeolog?g=TraesCS3D02G273600)

## Possible complications

No complications expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
