### PR TITLE
Filter Pan Compara homologies by Pan Compara lookup

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -589,7 +589,7 @@ sub get_export_data {
 
     if (keys %ok_species) {
       # It's the lower case species url name which is passed through the data export URL
-      my $lookup = $hub->species_defs->prodnames_to_urls_lookup;
+      my $lookup = $hub->species_defs->prodnames_to_urls_lookup($cdb);
       return [grep {$ok_species{lc($lookup->{$_->get_all_Members->[1]->genome_db->name})}} @$homologies];
     }
     else {


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

Currently Pan Compara OrthoXML and PhyloXML downloads are filtered by the URL lookup of the host division, resulting in OrthoXML/PhyloXML download files that lack homologies being displayed in the Pan Compara orthologue table of the same gene.

This PR ensures that the Pan Compara URL lookup is used for Pan Compara orthologue downloads, by passing the `$cdb` parameter to the `prodnames_to_urls_lookup` method.

## Views affected

This affects Pan Compara orthologue downloads. To see an example, go to the orthologue table views via the following example links, click on the button to "Download orthologues", select "OrthoXML" as the file format, and click "Download".

The number of `<orthologGroup>` elements in the file downloaded from the sandbox matches the number of orthologues in the given orthologue table.

Example in Compara sandbox: http://wp-np2-25.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/Compara_Ortholog/pan_compara?g=FBgn0014857
Example in Metazoa live site: https://metazoa.ensembl.org/Drosophila_melanogaster/Gene/Compara_Ortholog/pan_compara?g=FBgn0014857

## Possible complications

None anticipated.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
