### PR TITLE
remove experimentally verified from zmenu

### DIFF
--- a/modules/EnsEMBL/Web/ZMenu/MotifFeature.pm
+++ b/modules/EnsEMBL/Web/ZMenu/MotifFeature.pm
@@ -33,7 +33,7 @@ sub content {
   $self->caption('Motif Feature');
   my $id = $hub->param('feature_id');
   $self->add_entry({
-                    type        => 'Stable ID',
+                    type        => 'ID',
                     label       => $id, 
                   });
 
@@ -62,12 +62,6 @@ sub content {
   $self->add_entry({
                     type        => 'Transcription factors',
                     label       => join (', ', @transcription_factors), 
-                  });
-  my @epigenomes = split(',', $hub->param('epigenomes'));
-  @epigenomes = ('none') unless scalar @epigenomes;
-  $self->add_entry({
-                    type        => 'Experimentally verified in',
-                    label       => join(', ', @epigenomes), 
                   });
 }
 


### PR DESCRIPTION

## Description
Changes requested from regulation:

_We will be removing experimentally validated links from motifs to epigenomes in the funcgen database.  
Therefore, we need to remove the "experimentally verified in" information from the motif z-menu (see below) in release 113.
For consistency with regulatory features, please also change "Stable ID" to "ID"._


## Views affected
Regulation track zmenu

## Possible complications
NA

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6921
