### PR TITLE
Versioned local storage for regulation

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -277,6 +277,7 @@ our $FLANK5_PERC                        = 0.02; # % 5' flanking region for image
 our $FLANK3_PERC                        = 0.02; # % 3' flanking region for images (used for region comparison and location view)
 our $ENSEMBL_ALIGNMENTS_HIERARCHY       = ['LASTZ', 'CACTUS_HAL_PW', 'TBLAT', 'LPATCH'];  # Hierarchy of alignment methods
 # our $ALIGNMENTS_SPECIES_SELECTION_LIMIT = 70;  Remove limit and see if we get lot of Ajax errors in region comparison page
+our $REGULATION_MATRIX_VERSION          = "1.0";
 ###############################################################################
 
 

--- a/htdocs/components/25_ConfigRegMatrixForm.js
+++ b/htdocs/components/25_ConfigRegMatrixForm.js
@@ -95,6 +95,9 @@ Ensembl.Panel.ConfigRegMatrixForm = Ensembl.Panel.ConfigMatrixForm.extend({
               panel.elLk.ajaxError.hide();
             }
             Object.assign(this.json, json);
+            if (json.version) {
+              this.localStorageKey += '-' + json.version
+            }
             $(this.el).find('div.spinner').remove();
             this.trackTab();
             this.populateLookUp();

--- a/modules/EnsEMBL/Web/JSONServer/RegulationData.pm
+++ b/modules/EnsEMBL/Web/JSONServer/RegulationData.pm
@@ -133,6 +133,7 @@ sub json_data {
   $final->{data}->{epigenome}->{'data'} = $cell_types;
   $final->{data}->{epigenome}->{'listType'} = 'alphabetRibbon';
   $final->{dimensions} = ['epigenome', 'evidence'];
+  $final->{version} = $SiteDefs::REGULATION_MATRIX_VERSION;
 
   return $final;
 }


### PR DESCRIPTION
## Description
In order to deal with changes that reg
ulation team are making, it makes sense to have our localstorage versioned rather than asking users to clear the cache for any data change.

## Views affected
Configuration > Activities by cell type

## Possible complications
Users will lose all previous selection data if underlying data changes

## Merge conflicts
NA

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6946
 