### PR TITLE
New privacy notice

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -144,7 +144,7 @@ our $ENSEMBL_WARN_DATABASES         = 0; # Shows missing databases in EnsEMBL::W
 ###############################################################################
 our $GDPR_VERSION                 = '';
 our $GDPR_COOKIE_NAME             = '';
-our $GDPR_POLICY_URL              = 'https://www.ebi.ac.uk/data-protection/ensembl/privacy-notice';
+our $GDPR_POLICY_URL              = 'https://www.ensembl.org/info/about/legal/privacy.html';
 our $GDPR_TERMS_URL               = 'https://www.ebi.ac.uk/about/terms-of-use';
 
 ###############################################################################

--- a/htdocs/info/about/legal/privacy.html
+++ b/htdocs/info/about/legal/privacy.html
@@ -1,41 +1,194 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
 <meta name="index" content="NO INDEX" />
-<title>Privacy Statement</title>
+<title>Ensembl Privacy Statement</title>
 </head>
 
 <body>
-
-<h1>Ensembl Privacy Statement</h1>
-
-<p>Information provided to or gathered by ensembl.org is controlled by the Ensembl Project, 
-based at the <a href="http://www.ebi.ac.uk/">European Bioinformatics Institute</a> near Cambridge, UK.</p>
-
-<p>Ensembl.org gathers information about users solely to improve the usability and usefulness of the site,
-and not for any commercial purposes. No use is made of users' contact information except when
-directly requested by them, e.g. to sign up for a mailing list or activate a user account.
-Other information collected during the course of your usage of the site, such as pages visited, may be
-collected in server log files and used for statistical analysis of traffic patterns.</p>
-
-<p>Ensembl and its satellite sites (including archives) conform to the
-<a href="http://www.ebi.ac.uk/about/terms-of-use">EBI terms of use</a>. .</p>
-
-<h2>Use of Cookies</h2>
-
-<p>A full list of cookies used by EBI sites, including ones from Ensembl, may be found
-on the <a href="http://www.ebi.ac.uk/about/cookie-control">EBI cookie control page</a>,
-along with instructions on how to manage cookies in your web browser.</p>
-
-<h2>Additional information held in user accounts</h2>
-
-<p>All Ensembl data that is publically available for download is also freely available via the website.
-For the convenience of users we have introduced a wholly voluntary system of user accounts, through which
-we can offer additional services such as saved configurations and user groups. Of necessity, all user 
-accounts are accessible to the Ensembl web database administrators. However
-passwords are stored in one-way encrypted format and cannot be retrieved by staff.</p>
-
-<p>The public release of the Ensembl database includes a <b>blank</b> copy of the user database,
-for use in setting up a local copy if required.</p>
-
+  <h1>Ensembl Privacy Notice</h1>
+  <p><b>Version 3.0.0</b></p>
+  <p>
+    This privacy statement is a plain English description of how Ensembl collects and processes your personal data. Individual privacy statements are available for each individual service Ensembl provides. For more information on these please see the end of this statement. If this statement and the individual statements disagree, the individual statements take precedence.
+  </p>
+  <p>
+    Ensembl and its satellite sites (including archives) conform to the <a href="https://www.ebi.ac.uk/about/terms-of-use">EBI terms of use</a>.
+  </p>
+  <h2>What Information Does Ensembl Collect?</h2>
+  <p>
+    We collect information related to our legitimate interests in providing services to you, to help improve our resources and for the purposes of day to day running of the Ensembl resources and underlying infrastructure. Information collected may remain stored beyond the life of the service. We retain personal information for as short a time as possible but may retain this to comply with internal and external audits.
+  </p>
+  <h3>Information from website browsers and clients</h3>
+  <p>
+    When browsing our websites we collect information about your IP address, date/time of visit, page visited, browser type, data transferred and success of the request. For most websites this collection and processing is done by EMBL-EBI. See later in this document for a list of exceptions to our processing of browser and client data.
+  </p>
+  <p>
+    In addition we use IP addresses on our REST APIs to implement rate limiting. This is to ensure service stability. This collection is non-optional and a requirement of using the services. Your IP is removed from our rate limiting storage layer once every two hours.
+  </p>
+  <h4>Why do we collect this?</h4>
+  <p>
+    We collect this information to better understand how our website visitors use Ensembl, to create summary reports, to monitor, protect the security and stability of our website resources.
+  </p>
+  <h3>Information from accounts</h3>
+  <p>
+    When you create an account you must provide a name and an email address. On sign-up you should agree to this privacy statement, specifically <a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-website-accounts">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-website-accounts</a> for ensembl.org and <a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-mirrors-accounts">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-mirrors-accounts</a> for our AWS mirrors. During account creation you can provide your organisation, country and sign-up to our mailing lists. These are all are optional fields. Accounts are not necessary to use Ensembl. You may delete your account at any time by emailing helpdesk@ensembl.org.
+  </p>
+  <h4>Why do we collect this?</h4>
+  <p>
+    We need your personal information to create an account and to provide additional services.
+  </p>
+  <p>
+    We use your personal information to identify you when logging into our systems.
+  </p>
+  <h3>Email addresses</h3>
+  <p>
+    We capture email addresses in four distinct locations on our Ensembl websites. When they are captured they are retained for a limited purpose. Email addresses linked to accounts are used to communicate with you about your account, the site and our terms of use. Email addresses captured through “Contact us” are stored in our Request Tracker helpdesk system and are used to contact you about your support ticket. Email addresses captured through the BioMart tool are used to send a single result link back to you. Our blog also captures email when you post a comment on a blog post. You can flag if you wish to receive notifications for follow-up comments or new posts. Email addresses are viewable by EMBL-EBI staff with login to our Wordpress blog system for the sole purpose of contacting you concerning your comment.
+  </p>
+  <h4>Why do we collect this?</h4>
+  <p>
+    We need to be able to communicate back to you, to deliver a range of services, which is not possible to do so without your email address.
+  </p>
+  <h3>Mailing Lists</h3>
+  <p>
+    Ensembl maintains two public mailing lists, dev@ensembl.org and announce@ensembl.org, and a set of private mailing lists maintained by mailchimp. You are free to subscribe and unsubscribe from these communication channels. Our public mailing list settings can be managed at <a href="https://lists.ensembl.org/mailman/listinfo">https://lists.ensembl.org/mailman/listinfo</a> You can <a href="https://ensembl.us17.list-manage.com/subscribe?u=e08f33c50eeea4a07027e8ba6&id=f989c8c865">subscribe to our Mailchimp targeted communications</a> and <a href="https://ensembl.us17.list-manage.com/unsubscribe?u=e08f33c50eeea4a07027e8ba6&id=f989c8c865">unsubscribe accordingly</a>.
+  </p>
+  <h4>Why do we collect this?</h4>
+  <p>
+    We want to keep you informed about our services and offer you support. This is not possible to do so without your email address.
+  </p>
+  <h2>Basis for Collection</h2>
+  <p>
+    We collect and process data on a legitimate basis i.e. we do so to provide the Ensembl service and associated services. When consent is required we process your data on a consent basis i.e. during account creation.
+  </p>
+  <h2>How we share the information we collect</h2>
+  <p>
+    Ensembl does not sell, rent or trade personal data. We do not disclose personal information to others including third party services. We do collect non-identifiable aggregated data from our services for grant, service and institutional purposes.
+  </p>
+  <h3>Our Use of Third Party Services</h3>
+  <p>
+    Ensembl uses third parties in a number of circumstances to:
+    <ul>
+      <li>Host a subset of our websites</li>
+      <li>To provide communication preferences</li>
+      <li>To provide additional user analytics</li>
+    </ul>
+    When Ensembl uses these third party services, we do not transfer or link your account or personal information held on Ensembl to these resources. When a third party resource requests and processes your personal data they do so on their own authority and in accordance to their privacy statement.
+  </p>
+  <h4>Website Hosting</h4>
+  <p>
+    We use GitHub and Prime Hosting to host a subset of our websites. Please see later in this statement for more information.
+  </p>
+  <h4>Communication Preferences</h4>
+  <p>
+    We use Mailchimp to provide communication preferences i.e. what kind of email do you want to receive from Ensembl.
+  </p>
+  <h4>User Analytics</h4>
+  <p>
+    We use Google Analytics for user analytics. Please see later in this statement for more information.
+  </p>
+  <h3>Why we use Third Party Services</h3>
+  <p>
+    Third party services can offer levels of service or key features that are not possible with internally developed solutions and are used as required.
+  </p>
+  <h2>Cookies and Tracking</h2>
+  <h3>Cookies</h3>
+  <p>
+    Ensembl uses cookies to ensure continuity of the site across visits e.g. tracking your browser, tracking changes you have made to the website and data displayed. We also use cookies to log your user account information if you are logged in. The cookies Ensembl uses are essential for the operation of the website, or are used for performance or functionality. By using our website, you agree that we can place these types of cookies on your computer or device. If you disable your browser or device’s ability to accept cookies your ability to use our services will suffer. You can view more details about the cookies in use on our sites from <a href="https://www.ebi.ac.uk/about/cookie-control">https://www.ebi.ac.uk/about/cookie-control</a>.
+  </p>
+  <h3>Google Analytics</h3>
+  <p>
+    Ensembl uses Google Analytics as a third party tracking service, but we don’t use it to track you individually or collect personal data. Instead it collects information about website performance and how users navigate through and use our sites helping us design better interfaces.
+  </p>
+  <p>
+    Google Analytics gathers certain simple, non-personally identifying information over time, such as your anonymised IP address, browser type, internet service provider, referring and exit pages, time stamp and similar information. We do not link this information to any of your personal data.
+  </p>
+  <p>
+    Google provides further information about its own privacy practices and <a href="https://tools.google.com/dlpage/gaoptout">offers a browser add-on to opt out of Google Analytics tracking</a>.
+  </p>
+  <h2>Your rights regarding personal data</h2>
+  <p>
+    You have the right to:
+    <ol>
+      <li>Not be subject to decisions based solely on an automated processing of data (i.e. without human intervention) without you having your views taken into consideration.</li>
+      <li>Request at reasonable intervals and without excessive delay or expense, information about the personal data processed about you. Under your request we will inform you in writing about, for example, the origin of the personal data or the preservation period.</li>
+      <li>Request information to understand data processing activities when the results of these activities are applied to you.</li>
+      <li>Object at any time to the processing of your personal data unless we can demonstrate that we have legitimate reasons to process your personal data.</li>
+      <li>Request free of charge and without excessive delay rectification or erasure of your personal data if we have not been processing it respecting the EMBL Internal Policy for Data Protection.</li>
+    </ol>
+  </p>
+  <p>
+    It must be clarified that rights 4 and 5 are only available whenever the processing of your personal data is not necessary to:
+    <ol>
+      <li>Comply with a legal obligation.</li>
+      <li>Perform a task carried out in the public interest.</li>
+      <li>Exercise authority as a data controller.</li>
+      <li>Archive for purposes in the public interest, or for historical research purposes, or for statistical purposes.</li>
+      <li>Establish, exercise or defend legal claims.</li>
+    </ol>
+  </p>
+  <h2>Resolving Complaints</h2>
+  <p>
+    Should you have any concerns about the way Ensembl handles your personal data you can write to the EMBL Data Protection Officer at <a href="mailto:dpo@embl.org">dpo@embl.org</a>.
+  </p>
+  <h2>Exceptions to this Privacy Statement</h2>
+  <h3>Websites where anonymous browsing details are collected by a third party</h3>
+  <p>These are sites where details concerning your anonymous browsing is collected by an organisation who is not EMBL-EBI. Where applicable these sites have been listed by the organisation collecting said data with their privacy policy indicated and a list of sites</p>
+  <ul>
+    <li>Collected by Google Analytics</li>
+    <ul>
+      <li>Ensembl divisions: www.ensembl.org, plants.ensembl.org, bacteria.ensembl.org, fungi.ensembl.org, protists.ensembl.org, metazoa.ensembl.org, grch37.ensembl.org, rapid.ensembl.org</li>
+      <li>Ensembl AWS mirrors: asia.ensembl.org, useast.ensembl.org</li>
+      <li>Ensembl blog</li>
+      <li>Selected Ensembl archives: mar2016-plants.ensembl.org, vega.archive.ensembl.org</li>
+    </ul>
+    <li>Collected by GitHub (<a href="https://help.github.com/articles/github-privacy-statement/">https://help.github.com/articles/github-privacy-statement/</a>)</li>
+    <ul>
+      <li><a href="https://training.ensembl.org">https://training.ensembl.org</a></li>
+      <li><a href="https://projects.ensembl.org">https://projects.ensembl.org</a></li>
+    </ul>
+    <li>Collected by United Hosting</li>
+    <ul>
+      <li><a href="https://www.ensembl.info">https://www.ensembl.info</a></li>
+    </ul>
+  </ul>
+  <h2>Service Specific Privacy Statements</h2>
+  <ul>
+    <li>Ensembl.org including www, plants, metazoa, fungi, bacteria, protists, FTP, REST, MySQL, blog</li>
+    <ul>
+      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-website-accounts">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-website-accounts</a></li>
+      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-website-browsing">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-website-browsing</a></li>
+      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-website-contact">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-website-contact</a></li>
+      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-website-mart">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-website-mart</a></li>
+    </ul>
+    <li>AWS Mirrors</li>
+    <ul>
+      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-mirrors-accounts">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-mirrors-accounts</a></li>
+      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-mirrors-browsing">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-mirrors-browsing</a></li>
+      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-mirrors-mart">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-mirrors-mart</a></li>
+    </ul>
+    <li>Ensembl Archives Release 87 and older</li>
+    <ul>
+      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-embassy-accounts">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-embassy-accounts</a></li>
+      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-embassy-browsing">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-embassy-browsing</a></li>
+      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-embassy-mart">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-embassy-mart</a></li>
+    </ul>
+    <li>Ensembl Genomes Apollo</li>
+    <ul>
+      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensemblgenomes-apollo">https://www.ebi.ac.uk/data-protection/privacy-notice/ensemblgenomes-apollo</a></li>
+    </ul>
+    <li>Mailing Lists</li>
+    <ul>
+      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-mailing-lists">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-mailing-lists</a></li>
+    </ul>
+    <li>Targeted Emails</li>
+    <ul>
+      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-contact-signup">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-contact-signup</a></li>
+    </ul>
+    <li>IGSR/1000 Genomes Browsers</li>
+    <ul>
+      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-1000g-browsing">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-1000g-browsing</a></li>
+      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-1000g-contact">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-1000g-contact</a></li>
+    </ul>
+  </ul>
 </body>
 </html>

--- a/htdocs/info/about/legal/privacy_old.html
+++ b/htdocs/info/about/legal/privacy_old.html
@@ -1,0 +1,41 @@
+<html>
+<head>
+<meta name="index" content="NO INDEX" />
+<title>Privacy Statement</title>
+</head>
+
+<body>
+
+<h1>Ensembl Privacy Statement</h1>
+
+<p>Information provided to or gathered by ensembl.org is controlled by the Ensembl Project, 
+based at the <a href="http://www.ebi.ac.uk/">European Bioinformatics Institute</a> near Cambridge, UK.</p>
+
+<p>Ensembl.org gathers information about users solely to improve the usability and usefulness of the site,
+and not for any commercial purposes. No use is made of users' contact information except when
+directly requested by them, e.g. to sign up for a mailing list or activate a user account.
+Other information collected during the course of your usage of the site, such as pages visited, may be
+collected in server log files and used for statistical analysis of traffic patterns.</p>
+
+<p>Ensembl and its satellite sites (including archives) conform to the
+<a href="http://www.ebi.ac.uk/about/terms-of-use">EBI terms of use</a>. .</p>
+
+<h2>Use of Cookies</h2>
+
+<p>A full list of cookies used by EBI sites, including ones from Ensembl, may be found
+on the <a href="http://www.ebi.ac.uk/about/cookie-control">EBI cookie control page</a>,
+along with instructions on how to manage cookies in your web browser.</p>
+
+<h2>Additional information held in user accounts</h2>
+
+<p>All Ensembl data that is publically available for download is also freely available via the website.
+For the convenience of users we have introduced a wholly voluntary system of user accounts, through which
+we can offer additional services such as saved configurations and user groups. Of necessity, all user 
+accounts are accessible to the Ensembl web database administrators. However
+passwords are stored in one-way encrypted format and cannot be retrieved by staff.</p>
+
+<p>The public release of the Ensembl database includes a <b>blank</b> copy of the user database,
+for use in setting up a local copy if required.</p>
+
+</body>
+</html>


### PR DESCRIPTION
## Description

Our current notice will be expiring. This is an attempt to move the notice to Ensembl.org. Other sites can be redirected to here (we will setup a redirect at EBI) or path directly here like www.ensembl.org which is given an absolute URL

## Views affected

- www.ensembl.org
- All other sites

## Possible complications

None really but the default URL for privacy notices needs to change

## Merge conflicts

I don't beleive there are any I have seen

## Related JIRA Issues (EBI developers only)

ENSWEB-6949
