### PR TITLE
Fetch homology strain type from Compara database

### DIFF
--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -1351,6 +1351,25 @@ sub _summarise_compara_db {
     $sth->execute;
     my ($clusterset_id) = $sth->fetchrow_array;
     $self->db_tree->{$db_name}{'CLUSTERSETS'}{$sp} = $clusterset_id;
+
+    my $sth2 = $dbh->prepare('
+      select distinct sst.value
+        from method_link_species_set mlss
+          join method_link ml using(method_link_id)
+          join species_set ss using(species_set_id)
+          join genome_db gd using(genome_db_id)
+          join species_set_tag sst ON sst.species_set_id = ss.species_set_id
+        where ml.type in ("PROTEIN_TREES", "NC_TREES")
+          and sst.tag = "strain_type"
+          and gd.name = ?
+        limit 1;
+    ');
+    $sth2->bind_param(1,$sp);
+    $sth2->execute;
+    my ($strain_type) = $sth2->fetchrow_array;
+    if ($strain_type) {
+      $self->db_tree->{$db_name}{'STRAIN_TYPES'}{$sp} = $strain_type;
+    }
   }
 
   ###################################################################

--- a/modules/EnsEMBL/Web/Configuration/Gene.pm
+++ b/modules/EnsEMBL/Web/Configuration/Gene.pm
@@ -129,8 +129,10 @@ sub populate_tree {
   # Compara menu for strain (strain menu available on main species but collapse, main menu not available/grey out/collapse on strain page)
   # The node key (Strain_) is used by Component.pm to determine if it is a strain link on the main species page, so be CAREFUL when changing this  
   if($strain || $self->hub->is_strain) {  
-    my $strain_type = ucfirst $species_defs->STRAIN_TYPE;
-    my $strain_compara_menu = $self->create_node('Strain_Compara', $strain_type.'s',
+    my $production_name = $species_defs->SPECIES_PRODUCTION_NAME;
+    my $strain_type = $species_defs->multi_hash->{'DATABASE_COMPARA'}{'STRAIN_TYPES'}{$production_name} || 'strain';
+    my $strain_type_name = ucfirst $strain_type;
+    my $strain_compara_menu = $self->create_node('Strain_Compara', $strain_type_name . 's',
       [qw(strain_button_panel EnsEMBL::Web::Component::Gene::Compara_Portal)],
       {'availability' => 'gene database:compara core', 'closed' => $collapse }
     );


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

In the sidebar menu of a gene view, strain-level homologies can be accessed via a menu item which is named from the strain type of the current organism, specifically from the `strain.type` meta entry of the relevant core database.

This can result in inconsistent display of the homology menu item for different genomes in the same gene-tree collection. For example, in the [USMARC gene view](https://staging.ensembl.org/Sus_scrofa_usmarc/Gene/Summary?g=ENSSSCG00070008574;) the homology menu item is named "Breeds", while in the  [European wild boar gene view](https://staging.ensembl.org/Sus_scrofa_euw1/Gene/Summary?g=ENSSSCG00115007754), the homology menu item is named "Isolates".

This PR addresses the issue by setting the strain-level homology menu item from a `species_set_tag` in the relevant Compara database.

## Views affected

This PR affects the strain-level homology menu item in the gene view, setting its name from a Compara `species_set_tag`.
- Example on sandbox: http://wp-np2-25.ebi.ac.uk:5092/Sus_scrofa_euw1/Gene/Summary?g=ENSSSCG00115007754
- Example on staging: https://staging.ensembl.org/Sus_scrofa_euw1/Gene/Summary?g=ENSSSCG00115007754

## Possible complications

As the `STRAIN_TYPES` config entries are only set for genomes in a species set with a `strain_type` `species_set_tag`, this change is not expected to have complications beyond the additional 1-2kb which would be needed to store the `STRAIN_TYPES` config entries in the `MULTI.db.packed` file.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
