### PR TITLE
Fix strain-level paralogue alignment links

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaParalogs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaParalogs.pm
@@ -41,6 +41,7 @@ sub content {
   my $availability   = $self->object->availability;
   my $cdb            = shift || $hub->param('cdb') || 'compara';
   my $is_ncrna       = ($self->object->Obj->biotype =~ /RNA/);
+  my $strain_url     = $hub->is_strain ? 'Strain_' : '';
   my %paralogue_list = %{$self->object->get_homology_matches('ENSEMBL_PARALOGUES', 'paralog|gene_split', undef, $cdb)};
 
   return '<p>No paralogues have been identified for this gene</p>' unless keys %paralogue_list;
@@ -122,7 +123,7 @@ sub content {
       
       if ($paralogue_desc ne 'DWGA') {          
         my $align_url = $hub->url({
-            action   => 'Compara_Paralog', 
+            action   => $strain_url . 'Compara_Paralog',
             function => "Alignment". ($cdb=~/pan/ ? '_pan_compara' : ''),, 
             hom_id   => $paralogue->{'dbID'},
             g1       => $stable_id


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

Alignment links in strain-level paralogue views are pointing to the default `Compara_Paralog` URL.

For non-reference genomes in strain-level gene-tree collections, clicking on the link leads to a page with the following genomes:
> Sorry, this page is not available for this feature. Please select a valid link from the menu on the left.

(This issue does not manifest in any reference genomes, because they are all in the default collection, so the `Compara_Paralog` URL is valid.)

This PR changes alignment links in strain-level paralogue views to point to the `Strain_Compara_Paralog` URL.

## Views affected

This affects strain-level paralogue views in the Vertebrates and Plants Compara websites.

Examples:
- Rice cultivar ARC: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Oryza_sativa_arc/Gene/Strain_Compara_Paralog?g=OsARC_12g0018840) vs [live site](https://plants.ensembl.org/Oryza_sativa_arc/Gene/Strain_Compara_Paralog?g=OsARC_12g0018840)
- Wheat cultivar Stanley: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum_stanley/Gene/Strain_Compara_Paralog?g=TraesSTA1A03G00157260) vs [live site](https://plants.ensembl.org/Triticum_aestivum_stanley/Gene/Strain_Compara_Paralog?g=TraesSTA1A03G00157260)
- Mouse strain A/J: [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Mus_musculus_A_J/Gene/Strain_Compara_Paralog?g=MGP_AJ_G0019153) vs [live site](https://www.ensembl.org/Mus_musculus_A_J/Gene/Strain_Compara_Paralog?g=MGP_AJ_G0019153)
- Pig breed Berkshire: [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Sus_scrofa_berkshire/Gene/Strain_Compara_Paralog?g=ENSSSCG00065075600) vs [live site](https://www.ensembl.org/Sus_scrofa_berkshire/Gene/Strain_Compara_Paralog?g=ENSSSCG00065075600)

## Possible complications

The changes are restricted to the `ComparaParalogs` module, so no complications are expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
