### PR TITLE
Increase Pig breed count in Vertebrates genome list

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/GenomeList.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/GenomeList.pm
@@ -282,7 +282,7 @@ sub get_featured_genomes {
             'url'   => 'Sus_scrofa/Info/Breeds/',
             'img'   => 'Sus_scrofa.png',
             'name'  => 'Pig breeds',
-            'more'  => qq(<a href="/Sus_scrofa/" class="nodeco">Pig reference genome</a> and <a href="Sus_scrofa/Info/Breeds/" class="nodeco">12 additional breeds</a>),
+            'more'  => qq(<a href="/Sus_scrofa/" class="nodeco">Pig reference genome</a> and <a href="Sus_scrofa/Info/Breeds/" class="nodeco">20 additional breeds</a>),
            },
           );
 }


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

This PR increases the Pig breed count in the Vertebrates genome list to match the number of Pig breeds represented in Ensembl 113 (less the Pig reference genome).

## Views affected

This affects the genome list view in the Ensembl Vertebrates homepage.

## Possible complications

This is a straightforward HTML text update, so no complications are expected. 

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
