### PR TITLE
change lane order of regulatory build

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/fg_regulatory_features.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/fg_regulatory_features.pm
@@ -84,9 +84,10 @@ sub get_data {
   }
   my $row_lookup = {
                     'promoter' => 0,
-                    'enhancer' => 1,
-                    'open_chromatin' => 1,
-                    'tf_binding' => 1,
+                    'enhancer' => 0,
+                    'open_chromatin' => 0,
+                    'tf_binding' => 0,
+                    'emar' => 1,
                     'ctcf' => 2,
                     }; 
 


### PR DESCRIPTION
## Description

For 113, a new regulatory feature called EMAR was added (epigenetically-modified accessible region)

The following reordering of the lane was suggested 

Top: promoter, enhancer, open chromatin
Middle: EMAR
Bottom: CTCF

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6948

## Views affected
Views that show regulatory builds - like location view, genoverse, gene page etc.

## Possible complications
Probably no.
