### PR TITLE
Update variation summary page for GENCODE primary (e113)

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -98,7 +98,7 @@ sub feature_summary {
                       $avail->{has_uniq_transcripts} eq "1" ? "transcript" : "transcripts"
                   ) if($avail->{has_uniq_transcripts});
   push @str_array, sprintf('%s<a class="dynamic-link" href="%s">%s %s</a>',
-                      $avail->{has_uniq_transcripts} ? '' : 'overlaps ',
+                      $avail->{has_uniq_transcripts} ? '' : 'has predicted consequences for ',
                       $transcript_url,
                       $avail->{has_regfeats},
                       $avail->{has_regfeats} eq "1" ? "regulatory feature" : "regulatory features"

--- a/modules/EnsEMBL/Web/Component/Variation/Summary.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Summary.pm
@@ -92,7 +92,7 @@ sub feature_summary {
  
   my @str_array;
   
-  push @str_array, sprintf('overlaps <a class="dynamic-link" href="%s">%s %s</a>', 
+  push @str_array, sprintf('has predicted consequences for <a class="dynamic-link" href="%s">%s %s</a>', 
                       $transcript_url, 
                       $avail->{has_uniq_transcripts}, 
                       $avail->{has_uniq_transcripts} eq "1" ? "transcript" : "transcripts"


### PR DESCRIPTION
## Description

Replace the 'overlap' text with 'has predicted consequences for' in the Variation summary page.
Test -
http://wp-np2-11.ebi.ac.uk:7070/Homo_sapiens/Variation/Explore?r=1:230709548-230710548;v=rs699;vdb=variation;vf=11
http://wp-np2-11.ebi.ac.uk:7070/Homo_sapiens/Variation/Explore?db=core;r=Y:14328321-14329321;v=rs745378073;vdb=variation;vf=1169235343

## Views affected

Variation summary page.

## Possible complications

None. It is a static update.

## Merge conflicts

None

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6423
