### PR TITLE
[r113] Update descriptions on regulation feature view

### DIFF
--- a/modules/EnsEMBL/Web/Component/Regulation/Evidence.pm
+++ b/modules/EnsEMBL/Web/Component/Regulation/Evidence.pm
@@ -75,13 +75,13 @@ sub content {
   
   $table->add_rows(@rows);
 
+  my $text = '<p>More details can be found <a href="' . sprintf("https://regulation.ensembl.org/%s/source_data/%s", $object->species_defs->ENSEMBL_VERSION, $object->species) . '">here</a>.</p>';
+
   if(scalar keys %$evidence_data) {
-    my $source_url = sprintf("https://regulation.ensembl.org/%s/source_data/%s", $object->species_defs->ENSEMBL_VERSION, $object->species);
-    return '<p>More details can be found <a href="' . $source_url . '">here</a>.</p>' . $table->render;
+    return $text . $table->render;
   } else {
-    return "<p>There is no evidence for this regulatory feature in the selected cell lines</p>";
+    return $text;
   }
 }
-
 
 1;

--- a/modules/EnsEMBL/Web/Component/Regulation/Evidence.pm
+++ b/modules/EnsEMBL/Web/Component/Regulation/Evidence.pm
@@ -76,7 +76,8 @@ sub content {
   $table->add_rows(@rows);
 
   if(scalar keys %$evidence_data) {
-    return $table->render;
+    my $source_url = sprintf("https://regulation.ensembl.org/%s/source_data/%s", $object->species_defs->ENSEMBL_VERSION, $object->species);
+    return '<p>More details can be found <a href="https://regulation.ensembl.org/' . $source_url . '">here</a>.</p>' . $table->render;
   } else {
     return "<p>There is no evidence for this regulatory feature in the selected cell lines</p>";
   }

--- a/modules/EnsEMBL/Web/Component/Regulation/Evidence.pm
+++ b/modules/EnsEMBL/Web/Component/Regulation/Evidence.pm
@@ -77,7 +77,7 @@ sub content {
 
   if(scalar keys %$evidence_data) {
     my $source_url = sprintf("https://regulation.ensembl.org/%s/source_data/%s", $object->species_defs->ENSEMBL_VERSION, $object->species);
-    return '<p>More details can be found <a href="https://regulation.ensembl.org/' . $source_url . '">here</a>.</p>' . $table->render;
+    return '<p>More details can be found <a href="' . $source_url . '">here</a>.</p>' . $table->render;
   } else {
     return "<p>There is no evidence for this regulatory feature in the selected cell lines</p>";
   }

--- a/modules/EnsEMBL/Web/Component/Regulation/FeatureDetails.pm
+++ b/modules/EnsEMBL/Web/Component/Regulation/FeatureDetails.pm
@@ -57,7 +57,6 @@ sub content {
 
   ## Now that we have so many cell lines, it's quicker to show activity in a table
   $html .= '<p>A feature is <i>Active</i> if an open chromatin peak overlaps the feature in that epigenome.</p>
-            <br />
             <h3>Summary of Regulatory Activity
               <a title="Click to show or hide the table" rel="celltype_regfeature_table" href="#" class="toggle_link toggle new_icon open _slide_toggle">Hide</a>
             </h3>';

--- a/modules/EnsEMBL/Web/Component/Regulation/FeatureDetails.pm
+++ b/modules/EnsEMBL/Web/Component/Regulation/FeatureDetails.pm
@@ -56,7 +56,9 @@ sub content {
   }
 
   ## Now that we have so many cell lines, it's quicker to show activity in a table
-  $html .= '<h3>Summary of Regulatory Activity
+  $html .= '<p>A feature is <i>Active</i> if an open chromatin peak overlaps the feature in that epigenome.</p>
+            <br />
+            <h3>Summary of Regulatory Activity
               <a title="Click to show or hide the table" rel="celltype_regfeature_table" href="#" class="toggle_link toggle new_icon open _slide_toggle">Hide</a>
             </h3>';
 


### PR DESCRIPTION
## Description

Update `Activity` and `Source` tabs on the Regulation Feature view.

- `Activity`: Add a descriptive note for features that have activity (so, not for CTCF and EMARs).

- `Source`: Add a link to the regulation subsite.


## Views affected

- http://wp-np2-25.ebi.ac.uk:6020/Homo_sapiens/Regulation/Summary?db=core;fdb=funcgen;r=17:63992802-64038237;rf=ENSR17_9XDSZ
- http://wp-np2-25.ebi.ac.uk:6020/Homo_sapiens/Regulation/Evidence?db=core;fdb=funcgen;r=17:63992802-64038237;rf=ENSR17_9XDSZ

## Related JIRA Issues (EBI developers only)

[ENSREGULATION-2273](https://www.ebi.ac.uk/panda/jira/browse/ENSREGULATION-2273)
