### PR TITLE
[r113] Deactivate activity track for Reg. feature with no activity in funcgen

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/fg_regulatory_features.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/fg_regulatory_features.pm
@@ -280,6 +280,8 @@ sub colour_key {
     my $regact = $f->regulatory_activity_for_epigenome($epigenome);
     if ($regact) {
       $activity  = $regact->activity;
+    } else {
+      $activity = 'na';
     }
   }
 


### PR DESCRIPTION
## Description

Reg. features with no activity in `funcgen` appear as `active` in the Browser.
This PR fixes this, setting the activity for these features to `na`.

## Views affected

Location View, with at least one `Cell/Type - Epigenomic activity` enabled.
http://wp-np2-25.ebi.ac.uk:6020/Homo_sapiens/Location/View?r=17:63992802-64038237

## Related JIRA Issues (EBI developers only)

[ENSREGULATION-2265](https://www.ebi.ac.uk/panda/jira/browse/ENSREGULATION-2265)
