### PR TITLE
Unify packing of strain gene-tree collection metadata

### DIFF
--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -1343,7 +1343,7 @@ sub _summarise_compara_db {
         join species_set_header ssh using(species_set_id)
         join species_set_tag sst using(species_set_id)
         join genome_db gd using(genome_db_id)
-      where ml.type IN ("PROTEIN_TREES", "NC_TREES")
+      where ml.type in ("PROTEIN_TREES", "NC_TREES")
         and sst.tag = "strain_type";
   ');
   $sth->execute;


### PR DESCRIPTION
## Description

Some genomes in strain-level gene-tree collections that are also in the default gene-tree collection lack a 'Strains' menu item. This is happening because the ConfigPacker query to fetch the `clusterset_id` of such genomes sometimes returns the `clusterset_id` of the strain collection, and sometimes returns the `clusterset_id` of the default collection.

This PR updates the strain metadata ConfigPacker query to retrieve both the `clusterset_id` and `strain_type`. Because only strain gene-tree collections have a `strain_type` tag, only strain `clusterset_id` values are fetched, so if a strain collection is available for a given genome, its genes will have a 'Strains' homology menu item.

## Views affected

This affects the gene view of genomes that are in both default and strain-level collections.

Here are some examples of such genomes in the Wheat cultivars protein-tree collection:
- Aegilops_tauschii: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Aegilops_tauschii/Gene/Summary?g=AET4Gv20696400) vs [staging](https://staging-plants.ensembl.org/Aegilops_tauschii/Gene/Summary?g=AET4Gv20696400)
- Brachypodium_distachyon: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Brachypodium_distachyon/Gene/Summary?g=BRADI_5g16775v3) vs [staging](https://staging-plants.ensembl.org/Brachypodium_distachyon/Gene/Summary?g=BRADI_5g16775v3)
- Hordeum_vulgare: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Hordeum_vulgare/Gene/Summary?g=HORVU.MOREX.r3.6HG0548430) vs [staging](https://staging-plants.ensembl.org/Hordeum_vulgare/Gene/Summary?g=HORVU.MOREX.r3.6HG0548430)
- Secale_cereale: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Secale_cereale/Gene/Summary?g=SECCE6Rv1G0402470) vs [staging](https://staging-plants.ensembl.org/Secale_cereale/Gene/Summary?g=SECCE6Rv1G0402470)
- Triticum_spelta: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_spelta/Gene/Summary?g=TraesTSP4B01G118100) vs [staging](https://staging-plants.ensembl.org/Triticum_spelta/Gene/Summary?g=TraesTSP4B01G118100)
- Triticum_dicoccoides: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_dicoccoides/Gene/Summary?g=TRIDC1AG012620) vs [staging](https://staging-plants.ensembl.org/Triticum_dicoccoides/Gene/Summary?g=TRIDC1AG012620)
- Triticum_timopheevii: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_timopheevii/Gene/Summary?g=Tritim_EIv0.3_0867710) vs [staging](https://staging-plants.ensembl.org/Triticum_timopheevii/Gene/Summary?g=Tritim_EIv0.3_0867710)
- Triticum_urartu: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_urartu/Gene/Summary?g=TuG1812G0600000132.01) vs [staging](https://staging-plants.ensembl.org/Triticum_urartu/Gene/Summary?g=TuG1812G0600000132.01)

## Possible complications

Because the updated database query depends on the `strain_type` species-set tag to identify strain-level collections, this would make it necessary for all strain-level collections to have that tag. That is the case for those Compara databases with strain collections in release 113 (`ensembl_compara_113` and `ensembl_compara_plants_60_113`), and datacheck `StrainGeneTreeSpeciesSets` has been created ([ensembl-datacheck PR 594](https://github.com/Ensembl/ensembl-datacheck/pull/594)) to ensure it will be the case in future releases.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- [ENSCOMPARASW-7618](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-7618)
