### PR TITLE
[r114] Remove deprecated regulation Peaks functions

### DIFF
--- a/modules/EnsEMBL/Web/Object/Slice.pm
+++ b/modules/EnsEMBL/Web/Object/Slice.pm
@@ -414,7 +414,6 @@ sub get_data {
   my $lookup        = $self->hub->species_defs->databases->{'DATABASE_FUNCGEN'}{'peak_calling'};
   my $bigbed_lookup = $self->hub->species_defs->databases->{'DATABASE_FUNCGEN'}{'tables'}{'epigenome_track'};
   my $pc_adaptor    = $hub->get_adaptor('get_PeakCallingAdaptor', 'funcgen');
-  my $peak_adaptor  = $hub->get_adaptor('get_PeakAdaptor', 'funcgen');
   my $data_file_adaptor  = $hub->get_adaptor('get_DataFileAdaptor', 'funcgen');
   my %feature_sets_on;
 
@@ -454,9 +453,6 @@ sub get_data {
             $bigbed_file_subpath;
 
           $data->{$cell_line}{$ftype_name}{'block_features'}{$key} = $full_bigbed_file_path if $bigbed_file_subpath;
-        } else {
-          my $block_features = $peak_adaptor->fetch_all_by_Slice_PeakCalling($self->Obj, $peak_calling);
-          $data->{$cell_line}{$ftype_name}{'block_features'}{$key} = $block_features || [];
         }
       }
 

--- a/modules/EnsEMBL/Web/ZMenu/FeatureEvidence.pm
+++ b/modules/EnsEMBL/Web/ZMenu/FeatureEvidence.pm
@@ -31,18 +31,7 @@ sub content {
   my ($chr, $start, $end) = split /\:|\-/, $hub->param('pos'); 
   my $length              = $end - $start + 1;
   my $slice               = $hub->database('core')->get_SliceAdaptor->fetch_by_region('toplevel', $chr, $start, $end);
-  my @peaks               = @{$db_adaptor->get_PeakAdaptor->fetch_all_by_Slice($slice)};
-  my $peak;
-  
-  foreach (@peaks) { 
-    if ($_->peak_calling_id eq $peak_calling->dbID && $_->start == 1 && $_->end == $length) {
-      $peak = $_;
-      last;
-    }
-  }
-
-  my $summit   = $peak->summit || 'undetermined';
-  
+   
   $self->caption($peak_calling->get_FeatureType->evidence_type_label);
   
   $self->add_entry({
@@ -78,8 +67,6 @@ sub content {
   }
 
   $self->_add_nav_entries($hub->param('evidence')||0);
-
-  $self->_add_motif_feature_table($self->get_motif_features_by_peak($peak));
 
 }
 


### PR DESCRIPTION
## Description

Remove deprecated regulation peaks functions:
- Peaks are now being retrieved from a file for all assemblies, thus the `funcgen` DB `peak` table interaction is no longer required.

## Views affected

- http://wp-np2-25.ebi.ac.uk:6020/Homo_sapiens/Location/View?r=17:63992802-64038237 (Enable at least one Cell/Tissue peaks track).
- Z-menu associated with a Peak.

## Possible complications

If no peak files are registered in `funcgen`, peaks will be missing.

## Related JIRA Issues (EBI developers only)

- [ENSREGULATION-2281](https://www.ebi.ac.uk/panda/jira/browse/ENSREGULATION-2281)
