### PR TITLE
Use biotype group to identify ncRNA homologies

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -43,7 +43,8 @@ sub content {
   my $cdb          = shift || $self->param('cdb') || 'compara';
   my $is_pan       = $cdb =~/compara_pan_ensembl/;
   my $availability = $object->availability;
-  my $is_ncrna     = ($object->Obj->biotype =~ /RNA/);
+  my $biotype      = $object->Obj->get_Biotype;  # We expect a Biotype object, though it could be a biotype name.
+  my $is_ncrna     = ( ref $biotype eq 'Bio::EnsEMBL::Biotype' ? $biotype->biotype_group =~ /noncoding$/ : $biotype =~ /RNA/ );
   my $species_name = $species_defs->GROUP_DISPLAY_NAME;
   my $strain_url   = $hub->is_strain ? "Strain_" : "";
   my $strain_param = $hub->is_strain ? ";strain=1" : ""; # initialize variable even if is_strain is false, to avoid warnings

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaParalogs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaParalogs.pm
@@ -40,7 +40,8 @@ sub content {
   my $hub            = $self->hub;
   my $availability   = $self->object->availability;
   my $cdb            = shift || $hub->param('cdb') || 'compara';
-  my $is_ncrna       = ($self->object->Obj->biotype =~ /RNA/);
+  my $biotype        = $self->object->Obj->get_Biotype;  # We expect a Biotype object, though it could be a biotype name.
+  my $is_ncrna       = ( ref $biotype eq 'Bio::EnsEMBL::Biotype' ? $biotype->biotype_group =~ /noncoding$/ : $biotype =~ /RNA/ );
   my $strain_url     = $hub->is_strain ? 'Strain_' : '';
   my %paralogue_list = %{$self->object->get_homology_matches('ENSEMBL_PARALOGUES', 'paralog|gene_split', undef, $cdb)};
 

--- a/modules/EnsEMBL/Web/Component/Gene/HomologAlignment.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/HomologAlignment.pm
@@ -46,7 +46,8 @@ sub content {
   my $text_format  = $hub->param('text_format');
   my (%skipped, $html);
 
-  my $is_ncrna       = ($self->object->Obj->biotype =~ /RNA/);
+  my $biotype        = $self->object->Obj->get_Biotype;  # We expect a Biotype object, though it could be a biotype name.
+  my $is_ncrna       = ( ref $biotype eq 'Bio::EnsEMBL::Biotype' ? $biotype->biotype_group =~ /noncoding$/ : $biotype =~ /RNA/ );
   my $gene_product   = $is_ncrna ? 'Transcript' : 'Peptide';
   my $unit           = $is_ncrna ? 'nt' : 'aa';
   my $identity_title = '% identity'.(!$is_ncrna ? " ($seq)" : '');


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

In homology and homology alignment views, the alignment type (whether coding or noncoding)  is determined based on whether the biotype of the gene contains the string `"RNA"`. This can result in protein-coding alignments being shown in cases where a noncoding biotype lacks this string (e.g. `"ribozyme"`).

This PR changes these views so that ncRNA homologies are identified by biotype group if available, falling back to using the biotype name as before.

## Views affected

This affects ncRNA homology alignment, orthology and paralogy views.

To see the difference it makes, check the alignment links in the orthology/paralogy views, and the summary table of the homology alignment view.

Example homology alignment view:
- Human RMRPP5: [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Homo_sapiens/Gene/Compara_Ortholog/Alignment?db=core;g=ENSG00000223088;g1=ENSPPAG00000011867;hom_id=1568479800;r=9:24905469-24905735) vs [live](https://www.ensembl.org/Homo_sapiens/Gene/Compara_Ortholog/Alignment?db=core;g=ENSG00000223088;g1=ENSPPAG00000011867;hom_id=1568479800;r=9:24905469-24905735)

Example orthology views:
- Human RMRPP5: [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Homo_sapiens/Gene/Compara_Ortholog?db=core;g=ENSG00000223088) vs [live](https://www.ensembl.org/Homo_sapiens/Gene/Compara_Ortholog?db=core;g=ENSG00000223088)
- Mouse Gm24885: [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Mus_musculus/Gene/Compara_Ortholog?db=core;g=ENSMUSG00000089408) vs [live](https://www.ensembl.org/Mus_musculus/Gene/Compara_Ortholog?db=core;g=ENSMUSG00000089408)
- Zebrafish mir214a: [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Danio_rerio/Gene/Compara_Ortholog?db=core;g=ENSDARG00000083042) vs [live](https://www.ensembl.org/Danio_rerio/Gene/Compara_Ortholog?db=core;g=ENSDARG00000083042)

Example paralogy view:
- MGP_SPRETEiJ_T0097601: [sandbox](http://wp-np2-25.ebi.ac.uk:5092//Mus_spretus/Gene/Compara_Paralog?db=core;g=MGP_SPRETEiJ_G0035154) vs [live](https://www.ensembl.org/Mus_spretus/Gene/Compara_Paralog?db=core;g=MGP_SPRETEiJ_G0035154)

## Possible complications

No complications expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

This issue was noticed during work on a Compara issue with ncRNA alignments ([ENSCOMPARASW-7556](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-7556)).
