### PR TITLE
Fix to have feature url appear in zmenu for tracks from a trackhub

### DIFF
--- a/modules/EnsEMBL/Web/Utils/HubParser.pm
+++ b/modules/EnsEMBL/Web/Utils/HubParser.pm
@@ -236,7 +236,7 @@ sub get_tracks {
       # Deal with key=value attributes.
       # These are in the form key1=value1 key2=value2, but values can be quotes strings with spaces in them.
       # Short and long labels may contain =, but in these cases the value is just a single string
-      if ($value =~ /=/ && $key !~ /^(short|long)Label$/) {
+      if ($value =~ /=/ && $key ne 'url' && $key !~ /^(short|long)Label$/) {
         my ($k, $v);
         my @pairs = split /\s([^=]+)=/, " $value";
         shift @pairs;


### PR DESCRIPTION
## Description
With current code, when trackhub data gets parsed, the `link_template` field, which is used to generate a link to the feature might get transformed into a hash:

```
      'link_template' => {
        'http://srv00.recas.ba.infn.it/cgi/atlas/getpage_dev.py?rel' => 'hg38&acc=$$'
      },
```

This transformation will prevent the generation of a link; so this PR adds the `url` field name to the list of names for which such transformation should never be done.

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6955

