### PR TITLE
Show Strain menu iff genome has strain gene trees

### DIFF
--- a/modules/EnsEMBL/Web/Configuration/Gene.pm
+++ b/modules/EnsEMBL/Web/Configuration/Gene.pm
@@ -128,7 +128,7 @@ sub populate_tree {
   
   # Compara menu for strain (strain menu available on main species but collapse, main menu not available/grey out/collapse on strain page)
   # The node key (Strain_) is used by Component.pm to determine if it is a strain link on the main species page, so be CAREFUL when changing this  
-  if($strain || $self->hub->is_strain) {  
+  if($strain) {
     my $production_name = $species_defs->SPECIES_PRODUCTION_NAME;
     my $strain_type = $species_defs->multi_hash->{'DATABASE_COMPARA'}{'STRAIN_TYPES'}{$production_name} || 'strain';
     my $strain_type_name = ucfirst $strain_type;


### PR DESCRIPTION

## Description

Some genomes that have strain metadata in their core database but are not in a strain-level gene-tree collection. Currently a Strains submenu is shown for these genomes, but this Strains submenu is unnecessary in such cases and could be removed.

This PR removes the Strains submenu in such cases.

## Views affected

This affects the gene view of genomes that have strain metadata but are not in a strain-level gene-tree collection.

Here are some examples of such genomes. In these cases, a Strains menu is not needed:

- Brassica rapa Z1: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Brassica_rapa_z1/Gene/Summary?g=A02g21140.2_BraZ1) vs [RC site](https://rc-plants.ensembl.org/Brassica_rapa_z1/Gene/Summary?g=A02g21140.2_BraZ1)
- Sheep - Texel: [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Ovis_aries_texel/Gene/Summary?g=ENSOARG00000019179) vs [RC site](https://rc.ensembl.org/Ovis_aries/Gene/Summary?g=ENSOARG00000019179)
- Pig - Meishan (GCA_017957985.1): [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Sus_scrofa_meishan_GCA_017957985.1/Gene/Summary?g=ENSSSCG00040046295) vs [RC site](https://rc.ensembl.org/Sus_scrofa_meishan_GCA_017957985.1/Gene/Summary?g=ENSSSCG00040046295)
- Dog - Great Dane: [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Canis_lupus_familiarisgreatdane/Gene/Summary?g=ENSCAFG00040023596) vs [RC site](https://rc.ensembl.org/Canis_lupus_familiarisgreatdane/Gene/Summary?g=ENSCAFG00040023596)

For comparison, here are some examples of genomes in the Wheat cultivars protein-tree collection, for which a Strains menu _is_ expected to appear:
- Aegilops_tauschii: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Aegilops_tauschii/Gene/Summary?g=AET4Gv20696400) vs [RC site](https://rc-plants.ensembl.org/Aegilops_tauschii/Gene/Summary?g=AET4Gv20696400)
- Brachypodium_distachyon: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Brachypodium_distachyon/Gene/Summary?g=BRADI_5g16775v3) vs [RC site](https://rc-plants.ensembl.org/Brachypodium_distachyon/Gene/Summary?g=BRADI_5g16775v3)
- Hordeum_vulgare: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Hordeum_vulgare/Gene/Summary?g=HORVU.MOREX.r3.6HG0548430) vs [RC site](https://rc-plants.ensembl.org/Hordeum_vulgare/Gene/Summary?g=HORVU.MOREX.r3.6HG0548430)
- Secale_cereale: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Secale_cereale/Gene/Summary?g=SECCE6Rv1G0402470) vs [RC site](https://rc-plants.ensembl.org/Secale_cereale/Gene/Summary?g=SECCE6Rv1G0402470)
- Triticum_spelta: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_spelta/Gene/Summary?g=TraesTSP4B01G118100) vs [RC site](https://rc-plants.ensembl.org/Triticum_spelta/Gene/Summary?g=TraesTSP4B01G118100)
- Triticum_dicoccoides: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_dicoccoides/Gene/Summary?g=TRIDC1AG012620) vs [RC site](https://rc-plants.ensembl.org/Triticum_dicoccoides/Gene/Summary?g=TRIDC1AG012620)
- Triticum_timopheevii: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_timopheevii/Gene/Summary?g=Tritim_EIv0.3_0867710) vs [RC site](https://rc-plants.ensembl.org/Triticum_timopheevii/Gene/Summary?g=Tritim_EIv0.3_0867710)
- Triticum_urartu: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_urartu/Gene/Summary?g=TuG1812G0600000132.01) vs [RC site](https://rc-plants.ensembl.org/Triticum_urartu/Gene/Summary?g=TuG1812G0600000132.01)

Here are some further examples of genomes in the Pig breeds protein-tree collection, for which a Strains menu is expected to appear:
- Pig - euw1 (european wild boar): [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Sus_scrofa_euw1/Gene/Summary?g=ENSSSCG00115007754) vs [RC site](https://rc.ensembl.org/Sus_scrofa_euw1/Gene/Summary?g=ENSSSCG00115007754)
- Cow: [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Bos_taurus/Gene/Summary?g=ENSBTAG00000018317) vs [RC site](https://rc.ensembl.org/Bos_taurus/Gene/Summary?g=ENSBTAG00000018317)
- Sheep - Rambouillet: [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Ovis_aries_rambouillet/Gene/Summary?g=ENSOARG00020000881) vs [RC site](https://rc.ensembl.org/Ovis_aries_rambouillet/Gene/Summary?g=ENSOARG00020000881)

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- [ENSCOMPARASW-7676](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-7676)