### PR TITLE
Repair broken supertrees dynamically

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
@@ -870,7 +870,10 @@ sub features {
     $f->{'_name'}       = $tree->name;
     $f->{'_cigar_line'}   = $tree->tree->{_consensus_cigar_line_hash}->{$tree->node_id};
     $f->{'_cigar_line'} ||= $tree->consensus_cigar_line if UNIVERSAL::can($tree, 'consensus_cigar_line');   # Until all the EG divisions have updated their database
-  } elsif ($tree->is_leaf && $tree->isa('Bio::EnsEMBL::Compara::GeneTreeNode')) {
+  } elsif ($tree->is_leaf
+      && $tree->isa('Bio::EnsEMBL::Compara::GeneTreeNode')
+      && exists $tree->{_subtree}
+      && defined $tree->{_subtree}) {
     my $name = $tree->{_subtree}->stable_id;
     $name = $tree->{_subtree}->get_tagvalue('model_id') unless $name;
     $f->{label} =  $f->{'_display_id'} = sprintf('%s (%d genes)', $name, $tree->{_subtree_size});

--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -1018,7 +1018,7 @@ sub get_GeneTree {
                 # If minimising the supertree results in a
                 # non-branching structure, disavow it altogether.
                 my $num_supertree_nodes = scalar(@{$parent_root->get_all_nodes()});
-                $disavowing_supertree = 1 if ($num_supertree_nodes <= 3);
+                $disavowing_supertree = 1 if ($num_supertree_nodes < 3);
             } else {
                 warn "Cannot find subtree for supertree leaf node $leaf_node_id, skipping\n";
             }


### PR DESCRIPTION
## Description

In `ensembl_compara_113`, supertrees `RF00001` and `RF00413` have topology issues which are currently causing an error in the gene tree view of a combined total of 54,719 genes.

Work is in progress to fix the issue from e114 ([ENSCOMPARASW-7520](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-7520)), and a `SupertreeTopology` datacheck has been developed to catch supertree topology issues in future.

This PR  would put in place a `release/113`-only code fix which would mend these broken supertrees dynamically.

## Views affected

This affects the gene-tree view of genes in supertrees `RF00001` and `RF00413`.
- Example of RF00001 gene: [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Scophthalmus_maximus/Gene/Compara_Tree?g=ENSSMAG00000028123) vs [RC site](https://rc.ensembl.org/Scophthalmus_maximus/Gene/Compara_Tree?g=ENSSMAG00000028123)
- Example of RF00413 gene: [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Mus_musculus/Gene/Compara_Tree?db=core;g=ENSMUSG00000084686) vs [RC site](https://rc.ensembl.org/Mus_musculus/Gene/Compara_Tree?db=core;g=ENSMUSG00000084686)

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- [ENSCOMPARASW-7628](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-7628)
