### PR TITLE
Enable gencode basic

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/TranscriptsImage.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/TranscriptsImage.pm
@@ -57,8 +57,12 @@ sub content {
 
   # Enable gencode basic track
   if ($self->hub->species_defs->GENCODE_VERSION) {
+    my $key  = $image_config->get_track_key('transcript', $object);
+    my $node = $image_config->get_node(lc $key);
+    $node->set('display', 'off');
+
     $node = $image_config->get_node('gencode');
-    $node->set('display', 'transcript_label') if $node && $node->get('display') eq 'off';
+    $node->set('display', 'gene_label') if $node && $node->get('display') eq 'off';
   }
 
   if ( $self->hub->species_defs->databases->{'DATABASE_FUNCGEN'} ) {

--- a/modules/EnsEMBL/Web/Component/Gene/TranscriptsImage.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/TranscriptsImage.pm
@@ -51,9 +51,15 @@ sub content {
     slice_number    => '1|1',
   });
 
-  # Enable gencode basic track
-  my $node = $image_config->get_node('gencode');
+  my $key  = $image_config->get_track_key('transcript', $object);
+  my $node = $image_config->get_node(lc $key);
   $node->set('display', 'transcript_label') if $node && $node->get('display') eq 'off';
+
+  # Enable gencode basic track
+  if ($self->hub->species_defs->GENCODE_VERSION) {
+    $node = $image_config->get_node('gencode');
+    $node->set('display', 'transcript_label') if $node && $node->get('display') eq 'off';
+  }
 
   if ( $self->hub->species_defs->databases->{'DATABASE_FUNCGEN'} ) {
     $image_config->{'data_by_cell_line'} = $self->new_object('Slice', $gene_slice, $object->__data)->get_cell_line_data_closure($image_config) if keys %{$self->hub->species_defs->databases->{'DATABASE_FUNCGEN'}{'tables'}{'cell_type'}{'ids'}};

--- a/modules/EnsEMBL/Web/Component/Gene/TranscriptsImage.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/TranscriptsImage.pm
@@ -51,9 +51,8 @@ sub content {
     slice_number    => '1|1',
   });
 
-  my $key  = $image_config->get_track_key('transcript', $object);
-  my $node = $image_config->get_node(lc $key);
-  
+  # Enable gencode basic track
+  my $node = $image_config->get_node('gencode');
   $node->set('display', 'transcript_label') if $node && $node->get('display') eq 'off';
 
   if ( $self->hub->species_defs->databases->{'DATABASE_FUNCGEN'} ) {

--- a/modules/EnsEMBL/Web/ImageConfig/gene_summary.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/gene_summary.pm
@@ -74,9 +74,18 @@ sub init_cacheable {
     { display => 'off' }
   );
 
-  $self->modify_configs(
-    [$self->_transcript_types], { display => 'off' }
-  );
+  # Disable comprehensive genesets for gencode
+  if ($self->species_defs->GENCODE_VERSION) {
+    $self->modify_configs(
+      [$self->_transcript_types], { display => 'off' }
+    );
+  }
+  else {
+    $self->modify_configs(
+      [ 'transcript_core_ensembl', 'transcript_core_sg' ],
+      { display => 'transcript_label' }
+    )
+  }
 }
 
 1;

--- a/modules/EnsEMBL/Web/ImageConfig/gene_summary.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/gene_summary.pm
@@ -74,9 +74,8 @@ sub init_cacheable {
     { display => 'off' }
   );
 
-  $self->modify_configs(	
-    [ 'transcript_core_ensembl', 'transcript_core_sg' ],
-    { display => 'transcript_label' }
+  $self->modify_configs(
+    [$self->_transcript_types], { display => 'off' }
   );
 }
 

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -454,6 +454,7 @@ sub add_genes {
         colours   => $colours,
         strand    => $t eq 'gene' ? 'r' : 'b',
         label_key => '[biotype]',
+        display     => "off",
         renderers => ($t eq 'transcript' || $t eq 'longreads') ? $renderers : $t eq 'rnaseq' ? [
          'off',                'Off',
          'transcript_nolabel', 'Expanded without labels',
@@ -472,7 +473,7 @@ sub add_genes {
   if (my $gencode_version = $self->species_defs->GENCODE_VERSION || "") {
     $self->add_track('transcript', 'gencode', "Basic Gene Annotations from $gencode_version", '_gencode', {
       labelcaption  => "Genes (Basic set from $gencode_version)",
-      display       => 'off',
+      display       => 'on',
       description   => 'The GENCODE set is the gene set for human and mouse. <a href="/Help/Glossary?id=500" class="popup">GENCODE Basic</a> is a subset of representative transcripts (splice variants).',
       sortable      => 1,
       colours       => $colours,

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -454,7 +454,6 @@ sub add_genes {
         colours   => $colours,
         strand    => $t eq 'gene' ? 'r' : 'b',
         label_key => '[biotype]',
-        display     => $self->species_defs->GENCODE_VERSION ? "off" : "transcript_label",
         renderers => ($t eq 'transcript' || $t eq 'longreads') ? $renderers : $t eq 'rnaseq' ? [
          'off',                'Off',
          'transcript_nolabel', 'Expanded without labels',
@@ -473,7 +472,7 @@ sub add_genes {
   if (my $gencode_version = $self->species_defs->GENCODE_VERSION || "") {
     $self->add_track('transcript', 'gencode', "Basic Gene Annotations from $gencode_version", '_gencode', {
       labelcaption  => "Genes (Basic set from $gencode_version)",
-      display       => 'on',
+      display       => 'off',
       description   => 'The GENCODE set is the gene set for human and mouse. <a href="/Help/Glossary?id=500" class="popup">GENCODE Basic</a> is a subset of representative transcripts (splice variants).',
       sortable      => 1,
       colours       => $colours,
@@ -535,8 +534,15 @@ sub add_genes {
   # Need to add the gene menu track here
   $self->add_track('information', 'gene_legend', 'Gene Legend', 'gene_legend', { strand => 'r' }) if $flag;
 
-  # overwriting Genes comprehensive track description to not be the big concatenation of many description (only gencode gene track)
-  $self->modify_configs(['transcript_core_ensembl'],{ description => 'The <a class="popup" href="/Help/Glossary?id=487">GENCODE Comprehensive</a> set is the gene set for human and mouse' }) if($self->species_defs->GENCODE_VERSION);
+  if($self->species_defs->GENCODE_VERSION) {
+    # Disable comprehensive geneset track and enable basic gencode ones
+    $self->modify_configs(['transcript_core_ensembl'],{ 'display' => 'off' });
+    $self->modify_configs(['gencode'], { 'display' => 'transcript_label' });
+
+    # overwriting Genes comprehensive track description to not be the big concatenation of many description (only gencode gene track)
+    $self->modify_configs(['transcript_core_ensembl'],{ description => 'The <a class="popup" href="/Help/Glossary?id=487">GENCODE Comprehensive</a> set is the gene set for human and mouse' });
+  }
+
 }
 
 sub add_trans_associated {

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -454,15 +454,15 @@ sub add_genes {
         colours   => $colours,
         strand    => $t eq 'gene' ? 'r' : 'b',
         label_key => '[biotype]',
-        display     => "off",
+        display     => $self->species_defs->GENCODE_VERSION ? "off" : "transcript_label",
         renderers => ($t eq 'transcript' || $t eq 'longreads') ? $renderers : $t eq 'rnaseq' ? [
          'off',                'Off',
          'transcript_nolabel', 'Expanded without labels',
          'transcript_label',   'Expanded with labels',
         ] : [
-         'off',          'Off',
-         'gene_nolabel', 'No labels',
-	 'gene_label', 'With labels'
+          'off',          'Off',
+          'gene_nolabel', 'No labels',
+	        'gene_label',   'With labels'
         ]
       });
       $flag = 1;


### PR DESCRIPTION
## Description

The Manual Genome Annotation team have added a large amount of transcripts. In some cases 600 total transcripts. These transcripts will be seen on the comprehensive filter but not the basic.

Task: Update Gene and location pages to switch the default Gene and transcript filter from "Comprehensive" to "Basic gencode"

## Views affected

Location and Gene summary

## Possible complications
Nothing that I am aware

## Merge conflicts
No
 
## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6951
