### PR TITLE
More readable names for rf epigenomes in variation pages (e114)

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
@@ -366,9 +366,11 @@ sub content {
         };
 
         my @epigenomes = @{$rf->get_epigenomes_by_activity('ACTIVE')||[]};
+        my $epi_notfound_str = $rf->feature_so_term eq 'CTCF_binding_site' ?
+                          'Activity is not available for features of this type' : 'Not active in any cell lines';
         my $epi_string = scalar @epigenomes 
-                          ? join ', ', map { $_->name} @epigenomes 
-                          : 'Not active in any cell lines';
+                          ? join ', ', map { $_->short_name} @epigenomes
+                          : $epi_notfound_str;
 
         $row->{'cell_type'} = $epi_string;
 


### PR DESCRIPTION
## Description

- Use "short name" for regulatiry features epigenoems in Variation views. Currently "name" is used which is less readable.
- For CTCF binding site change the string "Not active in any cell lines" to "Activity is not available for features of this type" when no activity found.

## Views affected

Variation views.

## Possible complications

N/A

## Merge conflicts

N/A

## Related JIRA Issues (EBI developers only)

https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6436
