### PR TITLE
Add stub to modify Cactus AlignSlice transcript tracks

### DIFF
--- a/modules/EnsEMBL/Web/ImageConfig/alignsliceviewbottom.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/alignsliceviewbottom.pm
@@ -80,6 +80,8 @@ sub init_cacheable {
     ]}
   );
 
+  $self->_modify_cactus_db_transcript_tracks();
+
   $self->modify_configs(
     [ 'conservation' ],
     { menu => 'no' }
@@ -132,5 +134,8 @@ sub species_list {
 
   return $self->{'species_list'};
 }
+
+
+sub _modify_cactus_db_transcript_tracks {}  # Stub for specific divisions (e.g. Plants)
 
 1;


### PR DESCRIPTION
## Description

Wheat Cactus alignments are taking time to load on the Ensembl Plants website.

In conjunction with [eg-web-plants PR 70](https://github.com/EnsemblGenomes/eg-web-plants/pull/70), this PR aims to reduce the loading time of the Wheat Cactus alignment by switching off alternative gene model tracks by default.

## Views affected

This PR (along with its counterpart in `eg-web-plants`) affects the Wheat Cactus image alignment in the Ensembl Plants website, switching off alternative gene model tracks by default, and noticeably reducing the load time.

Example: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum_landmark/Location/Compara_Alignments/Image?r=6B:570561430-570611430;db=core;align=314995) vs [RC site](https://rc-plants.ensembl.org/Triticum_aestivum_landmark/Location/Compara_Alignments/Image?r=6B:570561430-570611430;db=core;align=314995)

## Possible complications

Because the changes in this repo are in the form of a stub, and the corresponding `eg-web-plants` PR restricts the changes to the Wheat `CACTUS_DB` image alignment on the Ensembl Plants website, that is the only view expected to be significantly affected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- [ENSCOMPARASW-7793](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-7793)
