### PR TITLE
Hide non-reference gene tracks in Cactus image alignments

### DIFF
--- a/modules/EnsEMBL/Web/ImageConfig/alignsliceviewbottom.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/alignsliceviewbottom.pm
@@ -101,6 +101,19 @@ sub init_cacheable {
     [ 'variation_legend' ],
     { accumulate => 'yes' }
   );
+
+  my $align_params = $self->hub->referer->{'params'}{'align'}[0];
+  my ($align) = split '--', $align_params;
+  my $align_type = $self->species_defs->multi_hash->{'DATABASE_COMPARA'}{'ALIGNMENTS'}{$align}{'type'};
+  if ($align_type eq 'CACTUS_DB') {
+    my $node = $self->get_node('transcript');
+    my @transcript_tracks = grep { $_->get_data('node_type') eq 'track' } @{$node->get_all_nodes};
+    foreach my $transcript_track (@transcript_tracks) {
+      if ($species ne $self->hub->referer->{'ENSEMBL_SPECIES'}) {
+        $transcript_track->set_data('display', 'off');
+      }
+    }
+  }
 }
 
 sub species_list {


### PR DESCRIPTION
## Description

Some `CACTUS_DB` alignment views take a significant amount of time to load, leading to apparent timeout errors in some cases.

In some cases, much of this loading time is devoted to the loading of transcript tracks.

This PR would switch off transcript tracks by default in all but the `AlignSlice` reference genome shown at the top of the Viewbottom image.

## Views affected

This affects all Cactus image alignments.
- Wheat Lancer cultivar: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum_lancer/Location/Compara_Alignments/Image?r=2B:4300000-4325000;db=core;align=314995) vs [RC site](http://rc-metazoa.ensembl.org/Triticum_aestivum_lancer/Location/Compara_Alignments/Image?r=2B:4300000-4325000;db=core;align=314995)
- Drosophila melanogaster: [sandbox](http://wp-np2-25.ebi.ac.uk:5094/Drosophila_melanogaster/Location/Compara_Alignments/Image?r=2L:5055058-5080058;db=core;align=316089) vs [RC site](http://rc-metazoa.ensembl.org/Drosophila_melanogaster/Location/Compara_Alignments/Image?r=2L:5055058-5080058;db=core;align=316089)

## Possible complications

As this change is applied only to transcript tracks in `CACTUS_DB` alignments, it is not expected to impact significantly on other image alignment views.

## Merge conflicts

- None detected.

## Related JIRA Issues (EBI developers only)

- NA
