### PR TITLE
Add stopgap fix for Stockholm format alignment export

### DIFF
--- a/modules/EnsEMBL/Web/Command/DataExport/Output.pm
+++ b/modules/EnsEMBL/Web/Command/DataExport/Output.pm
@@ -393,6 +393,20 @@ sub write_alignment {
       print $align_io $alignment;
     }
 
+    if (lc($format) eq 'stockholm') {
+      # In BioPerl 1.6.x, a bug in the Stockholm alignment writer resulted in sequence identifiers running on into
+      # the accession field. This has been fixed by @muffato ( https://github.com/bioperl/bioperl-live/pull/122 ), but
+      # has not yet been deployed. As a stopgap, we modify Stockholm output here to insert the missing space as needed
+      # between the sequence ID and the accession field.
+      my @export_lines = split(/\n/, $export);
+      foreach my $i (0 .. $#export_lines) {
+        if (substr($export_lines[$i], 0, 4) eq '#=GS') {
+          $export_lines[$i] =~ s/^(#=GS \S+)(AC unknown)$/$1 $2/;
+        }
+      }
+      $export = join("\n", @export_lines);
+    }
+
     $result = $self->write_line($export);
   }
   return $result->{'error'} || undef;


### PR DESCRIPTION
## Description

Because of a bug in the Stockholm alignment writer in BioPerl 1.6.x, homologue alignment downloads in Stockholm format have sequence identifiers that run on into the accession field:
```
# STOCKHOLM 1.0
#=GF ID NoName
#=GS ENSMUSP00000089009_Mmus/1-3623AC unknown
#=GS ENSMUSP00000087102_Mmus/1-435AC unknown
#=GS ENSMUSP00000152236_Mmus/1-540AC unknown
#=GS ENSMUSP00000099398_Mmus/1-1385AC unknown
```
This prevents the alignment from being loaded into (for example) Biopython, making it more difficult to process downloaded Stockholm files automatically.

This bug was fixed in [bioperl-live PR 122](https://github.com/bioperl/bioperl-live/pull/122), so code incorporating a bugfix is available in the event of an upgrade to BioPerl 1.7.0+.

In the meantime, this PR corrects the issue by fixing the generated Stockholm alignment string, making it easier for Compara team members to test — and Ensembl users to work with — downloaded Stockholm files.

## Views affected

This affects export of Stockholm format alignments of homologues.

To see the effect of this PR, try previewing or downloading Stockholm alignments for the following two examples:
- Human BRCA2 orthologues: [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Homo_sapiens/Gene/Compara_Ortholog?g=ENSG00000139618) vs [live site](https://www.ensembl.org/Homo_sapiens/Gene/Compara_Ortholog?g=ENSG00000139618)
- Mouse Cntnap1 paralogues: [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Mus_musculus/Gene/Compara_Paralog?g=ENSMUSG00000017167) vs [live site](https://www.ensembl.org/Mus_musculus/Gene/Compara_Paralog?g=ENSMUSG00000017167)

## Possible complications

As these changes only have an effect on the `GS` lines of Stockholm-format alignments in which the sequence identifier runs on into the accession field, no complications are expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
