### PR TITLE
Update rapid site retirement message

### DIFF
--- a/htdocs/components/99_announcement_banner.css
+++ b/htdocs/components/99_announcement_banner.css
@@ -40,3 +40,10 @@
     margin:0;
     font-weight: normal;
 }
+
+
+.banner_msg {
+  background-color: #f7e4b7;
+  text-align: center;
+  padding: 16px;
+}

--- a/htdocs/ssi/rapid_release.html
+++ b/htdocs/ssi/rapid_release.html
@@ -1,8 +1,9 @@
 <div id="rapidbox">
   <h2>Ensembl Rapid Release</h2>
-  <p><b>New assemblies with gene and protein annotation every two weeks</b>.</p>
-  <p>Note: species that already exist on this site will continue to be updated with the full range of annotations.</p>
-  <p class="button center" rel="external"><a class="nodeco" href="https://rapid.ensembl.org">Go</a></p>
-  <p>The Ensembl Rapid Release website provides annotation for recently produced, publicly available vertebrate and non-vertebrate genomes from biodiversity initiatives such as Darwin Tree of Life, the Vertebrate Genomes Project and the Earth BioGenome Project.</p>
-  <p class="right"><a href="http://www.ensembl.info/tag/rapid-release/">Rapid Release news</a> on our blog</p>
+  <p><b>New genome assemblies are now being released to the <a href="http://beta.ensembl.org">Ensembl Beta site</a> </b>.</p>
+  <p>All Rapid Release data, including release 65, has been uploaded into the new Ensembl Beta site.</p>
+  <p>The Ensembl Rapid Release website will remain active for the foreseeable future, however, the data and species set will no longer be updated.</p>
+  <p>Note: Species that already exist on the site will continue to be updated with the full range of annotations.</p>
+  <p class="right">Find out more on our <a href="http://www.ensembl.info/tag/rapid-release/">blog</a></p>
 </div>
+ 

--- a/htdocs/ssi/rapid_release.html
+++ b/htdocs/ssi/rapid_release.html
@@ -3,7 +3,7 @@
   <p><b>New genome assemblies are now being released to the <a href="http://beta.ensembl.org">Ensembl Beta site</a> </b>.</p>
   <p>All Rapid Release data, including release 65, has been uploaded into the new Ensembl Beta site.</p>
   <p>The Ensembl Rapid Release website will remain active for the foreseeable future, however, the data and species set will no longer be updated.</p>
-  <p>Note: Species that already exist on the site will continue to be updated with the full range of annotations.</p>
+  <p>Note: Species that already exist on the site will continue to be available.</p>
   <p class="right">Find out more on our <a href="http://www.ensembl.info/tag/rapid-release/">blog</a></p>
 </div>
  

--- a/modules/EnsEMBL/Web/Document/Element/TmpMessage.pm
+++ b/modules/EnsEMBL/Web/Document/Element/TmpMessage.pm
@@ -43,7 +43,6 @@ sub init {
 
 sub content {
   my $self = shift;
-
   my $popup_message = $self->{'file'}{'message'} ? $self->dom->create_element('div', {
     'id'        => 'tmp_message',
     'children'  => [{
@@ -72,9 +71,10 @@ sub content {
     }]
   })->render : '';
 
+  my $element_id = !$self->{'file'}{'class'} ? 'announcement-banner' : '';
   my $announcement_banner_message = $self->{'file'}{'banner_message'} ? $self->dom->create_element('div', {
-    'id'          => 'announcement-banner',
-    'class'       => $self->{'file'}{'colour'},
+    'id'          => $element_id,
+    'class'       => $self->{'file'}{'class'}, # add class to override default styles
     'inner_HTML'  => $self->{'file'}{'banner_message'}
   })->render : '';
 
@@ -83,8 +83,6 @@ sub content {
     'popup_message' => $popup_message,
     'announcement_banner_message' => $announcement_banner_message 
   }
-
-
 }
 
 1;


### PR DESCRIPTION
Rapid retirement message
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2608

For Rapid site banner, we just need to create a text file with name ensembl_tmp_message on to tmp dir root with below content.

`banner_message <h3 style="color:red;">We will be retiring Ensembl Rapid Release</h3><div>All Rapid Release data, including release 65, has been uploaded into the new Ensembl Beta site. </div><div>New genome data will only be released to the new Ensembl Beta site. We will no longer release data to the Ensembl Rapid Release browser.</div><br><div><b>Go to <a href="http://beta.ensembl.org" target="_blank">beta.ensembl.org</a> now</b></div><br><div>If you feel that this change will have a significant impact on your analyses, please <a href="https://rapid.ensembl.org/Help/Contact">get in touch</a></div>
class banner_msg`