### PR TITLE
Gencode renderer fix

### DIFF
--- a/modules/EnsEMBL/Web/ImageConfig/gene_summary.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/gene_summary.pm
@@ -83,7 +83,7 @@ sub init_cacheable {
   else {
     $self->modify_configs(
       [ 'transcript_core_ensembl', 'transcript_core_sg' ],
-      { display => 'transcript_label' }
+      { display => 'transcript_nolabel' }
     )
   }
 }

--- a/modules/EnsEMBL/Web/ImageConfig/gene_summary.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/gene_summary.pm
@@ -79,11 +79,15 @@ sub init_cacheable {
     $self->modify_configs(
       [$self->_transcript_types], { display => 'off' }
     );
+    $self->modify_configs(
+      [ 'gencode' ],
+      { display => 'transcript_label' }
+    )
   }
   else {
     $self->modify_configs(
-      [ 'transcript_core_ensembl', 'transcript_core_sg' ],
-      { display => 'transcript_nolabel' }
+      [ 'transcript_core_ensembl', 'transcript_core_sg'],
+      { display => 'transcript_label' }
     )
   }
 }

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -537,7 +537,7 @@ sub add_genes {
   if($self->species_defs->GENCODE_VERSION) {
     # Disable comprehensive geneset track and enable basic gencode ones
     $self->modify_configs(['transcript_core_ensembl'],{ 'display' => 'off' });
-    $self->modify_configs(['gencode'], { 'display' => 'transcript_label' });
+    $self->modify_configs(['gencode'], { 'display' => 'transcript_nolabel' });
 
     # overwriting Genes comprehensive track description to not be the big concatenation of many description (only gencode gene track)
     $self->modify_configs(['transcript_core_ensembl'],{ description => 'The <a class="popup" href="/Help/Glossary?id=487">GENCODE Comprehensive</a> set is the gene set for human and mouse' });

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -537,7 +537,7 @@ sub add_genes {
   if($self->species_defs->GENCODE_VERSION) {
     # Disable comprehensive geneset track and enable basic gencode ones
     $self->modify_configs(['transcript_core_ensembl'],{ 'display' => 'off' });
-    $self->modify_configs(['gencode'], { 'display' => 'transcript_nolabel' });
+    $self->modify_configs(['gencode'], { 'display' => 'transcript_label' });
 
     # overwriting Genes comprehensive track description to not be the big concatenation of many description (only gencode gene track)
     $self->modify_configs(['transcript_core_ensembl'],{ description => 'The <a class="popup" href="/Help/Glossary?id=487">GENCODE Comprehensive</a> set is the gene set for human and mouse' });


### PR DESCRIPTION
Request from Havana to change renderers to transcript with labels for gencode tracks.

http://wp-np2-1e.ebi.ac.uk:9000/Homo_sapiens/Location/View?r=17:63992802-64038237;debug=js
http://wp-np2-1e.ebi.ac.uk:9000/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000108622;r=17:63992802-64038237;t=ENST00000578892
