### PR TITLE
Fix invalid module import

### DIFF
--- a/modules/EnsEMBL/Web/Configuration/Location.pm
+++ b/modules/EnsEMBL/Web/Configuration/Location.pm
@@ -63,7 +63,7 @@ sub populate_tree {
   $self->create_node('Overview', 'Region overview',
     [qw(
       summary EnsEMBL::Web::Component::Location::Summary
-      nav     EnsEMBL::Web::Component::Location::ViewBottomNav/region
+      nav     EnsEMBL::Web::Component::Location::ViewBottomNav
       top     EnsEMBL::Web::Component::Location::Region
     )],
     { 'availability' => 'slice'}


### PR DESCRIPTION
### Description
Remove invalid module import syntax that is generating server errors.
See [this slack thread](https://genomes-ebi.slack.com/archives/C0MUF0C3Y/p1729703830150509) for context.

### Sandbox
http://wp-np2-1d.ebi.ac.uk:1640