### PR TITLE
Tweak Cactus image alignment legend

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/alignscalebar.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/alignscalebar.pm
@@ -271,7 +271,7 @@ sub render_align_bar {
       $config->{'alignslice_legend'}{$colour} = {
         priority => $self->_pos,
         legend   => $legend
-      } if $legend && $self->{container}->coord_system()->version() !~ /(EPO|PECAN)/;
+      } if $legend && $self->{container}->coord_system()->version() !~ /(EPO|PECAN|CACTUS_DB(?!_PW)|CACTUS_HAL(?!_PW))/;
     }
     
     $last_end = $se;
@@ -281,9 +281,9 @@ sub render_align_bar {
     $last_chr = $s2t;
     $last_slice = $s2;
   }
-  
+
   # alignment legend for multiple alignment (show everything)
-  if ($self->{container}->coord_system()->version() =~ /(EPO|PECAN)/) { 
+  if ($self->{container}->coord_system()->version() =~ /(EPO|PECAN|CACTUS_DB(?!_PW)|CACTUS_HAL(?!_PW))/) {
     my $all_legend = [
                    { colour => 'black', title => 'AlignSlice Break; Breakpoint in alignment', legend => 'Breakpoint between chromosomes'},
                    { colour => 'dodgerblue', title => 'AlignSlice Break; Inversion in chromosome', legend => 'Inversion on chromosome'},      


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

The legend of Cactus multiple image alignments currently includes the name of the last genome in the alignment having a particular feature.

This PR would change the legend of Cactus multiple image alignments to show a generic description of alignment features, similarly to EPO and Pecan views.

## Views affected

Examples:
- Rice Cactus: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Oryza_sativa/Location/Compara_Alignments/Image?r=5:20683301-20683900;align=312167;db=core) vs [staging](https://staging-plants.ensembl.org/Oryza_sativa/Location/Compara_Alignments/Image?r=5:20683301-20683900;align=312167;db=core)

## Possible complications

No complications are expected, as this change is restricted to the `alignscalebar` module and applies to `CACTUS_DB` and `CACTUS_HAL` alignments, but explicitly excludes their pairwise counterparts.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
