### PR TITLE
Update rsync command for symlinks

### DIFF
--- a/htdocs/info/data/ftp/rsync.html
+++ b/htdocs/info/data/ftp/rsync.html
@@ -25,7 +25,7 @@ in your web browser to locate the files you need, then alter the FTP URL as foll
 to the current directory:</p>
 
 <pre class="code">
-rsync -av rsync://ftp.ebi.ac.uk/ensemblorg/pub/current_embl/homo_sapiens .
+rsync -Lav rsync://ftp.ebi.ac.uk/ensemblorg/pub/current_embl/homo_sapiens .
 </pre>
 </li>
 
@@ -34,7 +34,7 @@ rsync -av rsync://ftp.ebi.ac.uk/ensemblorg/pub/current_embl/homo_sapiens .
     to the current directory:</p>
     
     <pre class="code">
-rsync -av rsync://ftp.ebi.ac.uk/ensemblgenomes/pub/plants/current/fasta/actinidia_chinensis/ .
+rsync -Lav rsync://ftp.ebi.ac.uk/ensemblgenomes/pub/plants/current/fasta/actinidia_chinensis/ .
     </pre>
     </li>
 


### PR DESCRIPTION
## Description

The rsync command would be wrong for any directory with symlinks. Added -L to resolve them.

## Possible complications

Considering no one noticed the original issue, I imagine none.


