### PR TITLE
Add Gencode Primary track and disable Gencode Basic by default

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/_gencode_basic.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/_gencode_basic.pm
@@ -17,7 +17,7 @@ limitations under the License.
 
 =cut
 
-package EnsEMBL::Draw::GlyphSet::_gencode;
+package EnsEMBL::Draw::GlyphSet::_gencode_basic;
 
 ### Module for drawing the gencode track inheriting from _transcript.pm, we dont have any web data in the database for gencode. Its a workaround to create a separate track for attribute type gencode.
 

--- a/modules/EnsEMBL/Draw/GlyphSet/_gencode_primary.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/_gencode_primary.pm
@@ -1,0 +1,34 @@
+=head1 LICENSE                                                                                                                                                                                                                                                                  
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2024] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Draw::GlyphSet::_gencode_primary;
+
+### Module for drawing the gencode track inheriting from _transcript.pm, we dont have any web data in the database for gencode. Its a workaround to create a separate track for attribute type gencode.
+
+use strict;
+
+use List::Util qw(min max);
+
+use base qw(EnsEMBL::Draw::GlyphSet::_transcript);
+
+sub max_label_rows { return $_[0]->my_config('max_label_rows') || 2; }
+
+sub only_attrib { return 'gencode_primary'; }
+
+1;

--- a/modules/EnsEMBL/Draw/GlyphSet_transcript.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet_transcript.pm
@@ -38,7 +38,8 @@ sub render_normal                  { $_[0]->render_transcripts(1);           }
 sub render_transcript              { $_[0]->render_transcripts(1);           }
 sub render_transcript_label        { $_[0]->render_transcripts(1);           }
 sub render_transcript_label_coding { $_[0]->render_transcripts(1);           }
-sub render_transcript_gencode_basic{ $_[0]->render_transcripts(1);           }
+sub render_transcript_gencode_basic   { $_[0]->render_transcripts(1);           }
+sub render_transcript_gencode_primary { $_[0]->render_transcripts(1);           }
 sub render_transcript_nolabel      { $_[0]->render_transcripts(0);           }
 sub render_collapsed_label         { $_[0]->render_collapsed(1);             }
 sub render_collapsed_nolabel       { $_[0]->render_collapsed(0);             }

--- a/modules/EnsEMBL/Draw/GlyphSet_transcript_new.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet_transcript_new.pm
@@ -41,7 +41,8 @@ sub render_normal                  { $_[0]->render_transcripts(1);           }
 sub render_transcript              { $_[0]->render_transcripts(1);           }
 sub render_transcript_label        { $_[0]->render_transcripts(1);           }
 sub render_transcript_label_coding { $_[0]->render_transcripts(1,1);         }
-sub render_transcript_gencode_basic{ $_[0]->render_transcripts(1);           }
+sub render_transcript_gencode_basic   { $_[0]->render_transcripts(1);           }
+sub render_transcript_gencode_primary { $_[0]->render_transcripts(1);           } 
 sub render_transcript_nolabel      { $_[0]->render_transcripts(0);           }
 sub render_collapsed_label         { $_[0]->render_collapsed(1);             }
 sub render_collapsed_nolabel       { $_[0]->render_collapsed(0);             }

--- a/modules/EnsEMBL/Web/Component/Gene/TranscriptsImage.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/TranscriptsImage.pm
@@ -61,7 +61,7 @@ sub content {
     my $node = $image_config->get_node(lc $key);
     $node->set('display', 'off');
 
-    $node = $image_config->get_node('gencode');
+    $node = $image_config->get_node('gencode_primary');
     $node->set('display', 'gene_label') if $node && $node->get('display') eq 'off';
   }
 

--- a/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
@@ -248,6 +248,7 @@ sub content {
 
   ## add gencode basic info
   $table->add_row('GENCODE basic gene', qq(This transcript is a member of the <a href="/Help/Glossary?id=500" class="popup">Gencode basic</a> gene set.)) if(@{$transcript->get_all_Attributes('gencode_basic')});
+  $table->add_row('GENCODE primary gene', qq(This transcript is a member of the <a href="/Help/Glossary?id=500" class="popup">Gencode Primary</a> gene set.)) if(@{$transcript->get_all_Attributes('gencode_primary')});
 
   return $table->render;
 }

--- a/modules/EnsEMBL/Web/ImageConfig/gene_summary.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/gene_summary.pm
@@ -80,9 +80,13 @@ sub init_cacheable {
       [$self->_transcript_types], { display => 'off' }
     );
     $self->modify_configs(
-      [ 'gencode' ],
+      [ 'gencode_basic' ],
+      { display => 'off' }
+    );
+    $self->modify_configs(
+      [ 'gencode_primary' ],
       { display => 'transcript_label' }
-    )
+    );
   }
   else {
     $self->modify_configs(

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -470,7 +470,7 @@ sub add_genes {
 
   # Adding gencode basic track, this has been moved from each image config to this generic one
   if (my $gencode_version = $self->species_defs->GENCODE_VERSION || "") {
-    $self->add_track('transcript', 'gencode', "Basic Gene Annotations from $gencode_version", '_gencode', {
+    $self->add_track('transcript', 'gencode_basic', "Basic Gene Annotations from $gencode_version", '_gencode_basic', {
       labelcaption  => "Genes (Basic set from $gencode_version)",
       display       => 'off',
       description   => 'The GENCODE set is the gene set for human and mouse. <a href="/Help/Glossary?id=500" class="popup">GENCODE Basic</a> is a subset of representative transcripts (splice variants).',
@@ -489,6 +489,29 @@ sub add_genes {
         'transcript_label_coding', 'Coding transcripts only (in coding genes)',
       ],
     });
+  }
+
+  # Adding gencode primary track
+  if (my $gencode_version = $self->species_defs->GENCODE_VERSION || "") {
+    $self->add_track('transcript', 'gencode_primary', "Primary Gene Annotations from $gencode_version", '_gencode_primary', {
+      labelcaption  => "Genes (Primary set from $gencode_version)",
+      display       => 'transcript_label',
+      description   => 'The GENCODE set is the gene set for human and mouse. <a href="/Help/Glossary?id=500" class="popup">GENCODE Primary</a> is a subset of representative transcripts (splice variants).',
+      sortable      => 1,
+      colours       => $colours,                                                                                                                                                                                                                                                
+      label_key     => '[biotype]',
+      logic_names   => ['proj_ensembl',  'proj_ncrna', 'proj_havana_ig_gene', 'havana_ig_gene', 'ensembl_havana_ig_gene', 'proj_ensembl_havana_lincrna', 'proj_havana', 'ensembl', 'mt_genbank_import', 'ensembl_havana_lincrna', 'proj_ensembl_havana_ig_gene', 'ncrna', 'assembly_patch_ensembl', 'ensembl_havana_gene', 'ensembl_lincrna', 'proj_ensembl_havana_gene', 'havana'],
+      renderers     =>  [
+        'off',                     'Off',
+        'gene_nolabel',            'No exon structure without labels',
+        'gene_label',              'No exon structure with labels',
+        'transcript_nolabel',      'Expanded without labels',
+        'transcript_label',        'Expanded with labels',
+        'collapsed_nolabel',       'Collapsed without labels',
+        'collapsed_label',         'Collapsed with labels',
+        'transcript_label_coding', 'Coding transcripts only (in coding genes)',
+      ],   
+    });  
   }
   
   # Adding MANE tracks (Only for Humans)
@@ -535,9 +558,9 @@ sub add_genes {
   $self->add_track('information', 'gene_legend', 'Gene Legend', 'gene_legend', { strand => 'r' }) if $flag;
 
   if($self->species_defs->GENCODE_VERSION) {
-    # Disable comprehensive geneset track and enable basic gencode ones
+    # Disable comprehensive geneset track and enable primary gencode ones
     $self->modify_configs(['transcript_core_ensembl'],{ 'display' => 'off' });
-    $self->modify_configs(['gencode'], { 'display' => 'transcript_label' });
+    $self->modify_configs(['gencode_primary'], { 'display' => 'transcript_label' });
 
     # overwriting Genes comprehensive track description to not be the big concatenation of many description (only gencode gene track)
     $self->modify_configs(['transcript_core_ensembl'],{ description => 'The <a class="popup" href="/Help/Glossary?id=487">GENCODE Comprehensive</a> set is the gene set for human and mouse' });

--- a/modules/EnsEMBL/Web/Query/GlyphSet/Transcript.pm
+++ b/modules/EnsEMBL/Web/Query/GlyphSet/Transcript.pm
@@ -56,7 +56,7 @@ sub precache {
         shortlabels => '',
       }
     },
-    gencode => {
+    gencode_basic => {
       loop => ['species','genome'],
       args => {
         logic_names => [qw(
@@ -72,6 +72,23 @@ sub precache {
         only_attrib => "gencode_basic",
         shortlabels => '',
       }
+    },
+    gencode_primary => {
+      loop => ['species','genome'],
+      args => {
+        logic_names => [qw(
+          assembly_patch_ensembl    ensembl      ensembl_havana_gene
+          ensembl_havana_ig_gene    ensembl_havana_lincrna
+          ensembl_lincrna           havana       havana_ig_gene
+          mt_genbank_import         ncrna        proj_ensembl
+          proj_ensembl_havana_gene  proj_ensembl_havana_ig_gene
+          proj_ensembl_havana_lincrna   proj_havana
+          proj_havana_ig_gene       proj_ncrna
+        )],
+        label_key => "[biotype]",
+        only_attrib => "gencode_primary",
+        shortlabels => '', 
+      }   
     },
     MANE_Select => {
       loop => ['species','genome'],
@@ -230,9 +247,10 @@ sub _get_prediction_transcripts {
   my $db_alias = $args->{'db'};
   my @out;
   my $is_gencode_basic = ($args->{'only_attrib'} && $args->{'only_attrib'} eq 'gencode_basic') ? 1 : 0;
+  my $is_gencode_primary = ($args->{'only_attrib'} && $args->{'only_attrib'} eq 'gencode_primary') ? 1 : 0;
 
   foreach my $logic_name (@{$args->{'logic_names'}}) {
-    my $logic_name_with_species = $is_gencode_basic ?  $logic_name.'_'.$args->{'species'} : $logic_name;
+    my $logic_name_with_species = ( $is_gencode_basic || $is_gencode_primary) ?  $logic_name.'_'.$args->{'species'} : $logic_name;
 
     my @t = @{$slice->get_all_PredictionTranscripts($logic_name_with_species,$db_alias)};
     my @g = map { $self->_fake_gene($_) } @t;
@@ -251,7 +269,7 @@ sub _get_genes {
 
   my $analyses_postfix = '';
 
-  if( $only_attrib eq 'gencode_basic' || $only_attrib eq 'MANE_Select' || $only_attrib eq 'MANE_Plus_Clinical'){
+  if( $only_attrib eq 'gencode_primary' || $only_attrib eq 'gencode_basic' || $only_attrib eq 'MANE_Select' || $only_attrib eq 'MANE_Plus_Clinical'){
     $analyses_postfix = '_'. $species; 
   }
 


### PR DESCRIPTION
## Description

This PR adds the Gencode Primary gene track. It will be enabled by default, while the Gencode basic primary track will be disabled. However, users should be able to switch between them using the track configuration modal. I used #1040 as reference when working on this PR.

There is another related PR that I created in `public-plugins` to enable Gencode Primary track in Region in Detail: https://github.com/Ensembl/public-plugins/pull/852

## Release version

114

## Views affected

Location ([sandbox link](http://wp-np2-1e.ebi.ac.uk:8310/Homo_sapiens/Location/View?db=core;g=ENSG00000139618;r=13:32315086-32400268))
Gene ([sandbox link](http://wp-np2-1e.ebi.ac.uk:8310/Homo_sapiens/Gene/Summary?g=ENSG00000139618;r=13:32315086-32400268))

## Related JIRA Issues (EBI developers only)

[ENSWEB-6947](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6947)
