### PR TITLE
Facilitate CACTUS_DB alignment views in all divisions

### DIFF
--- a/modules/EnsEMBL/Web/Component/Compara_Alignments.pm
+++ b/modules/EnsEMBL/Web/Component/Compara_Alignments.pm
@@ -68,6 +68,15 @@ sub content {
   my ($align, $target_species, $target_slice_name_range) = split '--', $align_param;
   my $target_slice = $object->get_target_slice;
 
+  ## Check for wrong component in per-component polyploid alignments.
+  my $warning_box = $self->check_for_wrong_genome_component({
+    'cdb'   => $cdb,
+    'align' => $align,
+    'slice' => $slice,
+  });
+  return $warning_box if $warning_box;
+  ##
+
   my ($alert_box, $error) = $self->check_for_align_problems({
                     'align' => $align,
                     'species' => $hub->species_defs->SPECIES_PRODUCTION_NAME,
@@ -338,6 +347,9 @@ sub check_for_missing_species {
   $title .= ' species' if $title;
   return $warnings ? ({'severity' => 'info', 'title' => $title, 'message' => $warnings}) : ();
 }
+
+# Stub for use in divisions with polyploid genomes (e.g. Plants)
+sub check_for_wrong_genome_component {}
 
 sub show_warnings {
   my ($self, $messages) = @_;

--- a/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
+++ b/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
@@ -153,9 +153,11 @@ sub show_scale_dependent_track_info_box {
   if (exists $align_details->{'as_track_threshold_data'}) {
     my $r = $self->param('r');
 
-    my $location_length = 1;  # This should never happen, but if it does, we revert to default behaviour.
+    my $location_length;
     if ($r =~ /^[\w\.\-]+:(\d+)\-(\d+)$/) {  # region pattern from MetaKeyFormat datacheck
       $location_length = abs($2 - $1) + 1;
+    } else {
+      $location_length = 1;  # This should never happen, but if it does, we revert to default behaviour.
     }
 
     my $as_track_thresholds = $align_details->{'as_track_threshold_data'};

--- a/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
+++ b/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
@@ -147,6 +147,7 @@ sub content {
 
 sub show_scale_dependent_track_info_box {
   my ($self, $align_details) = @_;
+  my $species_defs = $self->hub->species_defs;
 
   my $html;
   if (exists $align_details->{'as_track_threshold_data'}) {
@@ -177,11 +178,13 @@ sub show_scale_dependent_track_info_box {
         );
       }
 
+      my $help_id = { $species_defs->multiX('ENSEMBL_HELP') }->{'Location/Compara_Alignments/Image'};
       $html .= $self->_info('Scale-dependent alignment track configuration',
           '<p>Some tracks in this Cactus image alignment are disabled by default at larger scales, with '
           . join(', and ', @range_vis_info_parts)
           . '. Tracks hidden in this way can be revealed by zooming in, or by enabling them directly'
           . ' via "<strong>Configure this page</strong>" or "<strong>Add/remove tracks</strong>".'
+          . sprintf(' For more information, see the <a href="/Help/View?id=%d" class="popup">Alignments (image) help page</a>.', $help_id)
       );
     }
   }

--- a/modules/EnsEMBL/Web/ImageConfig/alignsliceviewbottom.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/alignsliceviewbottom.pm
@@ -101,28 +101,6 @@ sub init_cacheable {
     [ 'variation_legend' ],
     { accumulate => 'yes' }
   );
-
-  my $align_id = $self->hub->get_alignment_id;
-  if ($align_id) {
-    my $align_details = $self->species_defs->multi_hash->{'DATABASE_COMPARA'}->{'ALIGNMENTS'}->{$align_id};
-    if ($align_details->{'type'} eq 'CACTUS_DB' && exists $align_details->{'as_track_threshold_data'}) {
-      my $location_param = $self->hub->referer->{'params'}{'r'}[0];
-
-      my $location_length = 1;  # This should never happen, but if it does, we revert to default behaviour.
-      if ($location_param =~ /^[\w\.\-]+:(\d+)\-(\d+)$/) {  # region pattern from MetaKeyFormat datacheck
-        $location_length = abs($2 - $1) + 1;
-      }
-
-      my $as_track_thresholds = $align_details->{'as_track_threshold_data'};
-      if (exists $as_track_thresholds->{'transcript'} && $location_length >= $as_track_thresholds->{'transcript'}) {
-        $self->modify_configs(['transcript'], { 'display' => 'off' });
-
-        if (exists $as_track_thresholds->{'sequence'} && $location_length >= $as_track_thresholds->{'sequence'}) {
-          $self->modify_configs(['sequence'], { 'display' => 'off' });
-        }
-      }
-    }
-  }
 }
 
 sub species_list {

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -469,7 +469,7 @@ sub add_genes {
   }
 
   # Adding gencode basic track, this has been moved from each image config to this generic one
-  if (my $gencode_version = $self->species_defs->GENCODE_VERSION || "") {
+  if (my $gencode_version = $self->species_defs->get_config($species, 'GENCODE_VERSION') || "") {
     $self->add_track('transcript', 'gencode_basic', "Basic Gene Annotations from $gencode_version", '_gencode_basic', {
       labelcaption  => "Genes (Basic set from $gencode_version)",
       display       => 'off',
@@ -492,7 +492,7 @@ sub add_genes {
   }
 
   # Adding gencode primary track
-  if (my $gencode_version = $self->species_defs->GENCODE_VERSION || "") {
+  if (my $gencode_version = $self->species_defs->get_config($species, 'GENCODE_VERSION') || "") {
     $self->add_track('transcript', 'gencode_primary', "Primary Gene Annotations from $gencode_version", '_gencode_primary', {
       labelcaption  => "Genes (Primary set from $gencode_version)",
       display       => 'transcript_label',
@@ -513,9 +513,9 @@ sub add_genes {
       ],   
     });  
   }
-  
+
   # Adding MANE tracks (Only for Humans)
-  if($self->hub->species_defs->SEPARATE_MANE_TRACKS){
+  if($self->species_defs->get_config($species, 'SEPARATE_MANE_TRACKS')){
     
     # Adding MANE Select track
     $self->add_track('transcript', 'mane_select', "MANE Select Transcripts", '_mane_select', {
@@ -557,10 +557,30 @@ sub add_genes {
   # Need to add the gene menu track here
   $self->add_track('information', 'gene_legend', 'Gene Legend', 'gene_legend', { strand => 'r' }) if $flag;
 
-  if($self->species_defs->GENCODE_VERSION) {
+  if($self->species_defs->get_config($species, 'GENCODE_VERSION')) {
     # Disable comprehensive geneset track and enable primary gencode ones
     $self->modify_configs(['transcript_core_ensembl'],{ 'display' => 'off' });
     $self->modify_configs(['gencode_primary'], { 'display' => 'transcript_label' });
+
+    # ... unless this is an alignslice track in a large-scale CACTUS_DB alignment view,
+    # in which case disable the GENCODE Primary track too.
+    my $align_id = $self->hub->get_alignment_id;
+    if ($align_id) {
+      my $align_details = $self->species_defs->multi_hash->{'DATABASE_COMPARA'}->{'ALIGNMENTS'}->{$align_id};
+      if ($align_details->{'type'} eq 'CACTUS_DB' && exists $align_details->{'as_track_threshold_data'}) {
+        my $location_param = $self->hub->referer->{'params'}{'r'}[0];
+
+        my $location_length = 1;  # This should never happen, but if it does, we revert to default behaviour.
+        if ($location_param =~ /^[\w\.\-]+:(\d+)\-(\d+)$/) {  # region pattern from MetaKeyFormat datacheck
+          $location_length = abs($2 - $1) + 1;
+        }
+
+        my $as_track_thresholds = $align_details->{'as_track_threshold_data'};
+        if (exists $as_track_thresholds->{'transcript'} && $location_length >= $as_track_thresholds->{'transcript'}) {
+          $self->modify_configs(['gencode_primary'], { 'display' => 'off' });
+        }
+      }
+    }
 
     # overwriting Genes comprehensive track description to not be the big concatenation of many description (only gencode gene track)
     $self->modify_configs(['transcript_core_ensembl'],{ description => 'The <a class="popup" href="/Help/Glossary?id=487">GENCODE Comprehensive</a> set is the gene set for human and mouse' });

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -580,9 +580,11 @@ sub add_genes {
       if ($align_details->{'type'} eq 'CACTUS_DB' && exists $align_details->{'as_track_threshold_data'}) {
         my $location_param = $self->hub->referer->{'params'}{'r'}[0];
 
-        my $location_length = 1;  # This should never happen, but if it does, we revert to default behaviour.
+        my $location_length;
         if ($location_param =~ /^[\w\.\-]+:(\d+)\-(\d+)$/) {  # region pattern from MetaKeyFormat datacheck
           $location_length = abs($2 - $1) + 1;
+        } else {
+          $location_length = 1;  # This should never happen, but if it does, we revert to default behaviour.
         }
 
         my $as_track_thresholds = $align_details->{'as_track_threshold_data'};


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

In conjunction with [eg-web-common PR 128](https://github.com/EnsemblGenomes/eg-web-common/pull/128) and [eg-web-plants PR 76](https://github.com/EnsemblGenomes/eg-web-plants/pull/76), this PR would facilitate display of `CACTUS_DB` alignments.

It would:
- alter default configuration of `CACTUS_DB` alignslice views to hide gene tracks when the size of the region being accessed exceeds a 'transcript' threshold (e.g. 25 kb), and hide contig tracks when the size of the region exceeds a greater 'sequence' threshold (e.g. 50 kb).
- display a 'scale-dependent track config' info box in image alignment views if any tracks are hidden;
- include `as_track_threshold_data` in packed files, providing easy access to the scale-dependent track threshold region sizes; 
- display a warning box in text genomic alignment views if the user tries to access a per-subgenome alignment from the wrong subgenome, and if possible, recommend the appropriate per-subgenome alignment;
- configure GENCODE tracks according to the genome in the given alignslice row rather than the genome from which the view is being accessed; and
- update genomic alignment stats pages to handle per-subgenome `CACTUS_DB` alignment stats.

## Views affected

Affected views include image and text alignment views, as well as genomic alignment stats views.

## Possible complications

No major complications are expected, though several have been considered.

- The most significant expected complication would be that the changes this PR would make to default track configuration would be a complicating factor when updating general track configuration in future, particularly for GENCODE and related tracks in `modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm`.
- Variation provides a phylogenetic context view (`Variation/Compara_Alignments`) which makes use of Compara text alignments (including `CACTUS_DB`). Scale-dependent track configuration is not relevant to this view, but it is possible for a user to try to access the phylogenetic context of a variant from the wrong polyploid subgenome/component.
An example of this has been tested in the sandbox, and found to be unchanged: before and after the changes in this PR, the info box message is along the lines of "No phylogenetic context available for 16 wheat_component_A Cactus at this location."
- Method `check_for_wrong_genome_component` is a stub in every division except Plants, and in Plants its effect is limited to `CACTUS_DB` alignments with a `genome_component` MLSS tag. As a result, it should only have an effect on the intended genomic alignments.
- Non-Cactus alignment views should be unaffected by scale-dependent track configuration, as this feature is restricted to `CACTUS_DB` image alignment views of regions larger than a configured threshold.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

...
