### PR TITLE
Set non-ref species to ref in self-alignment

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/Compara/MLSS.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara/MLSS.pm
@@ -650,7 +650,10 @@ sub fetch_pairwise_input {
     my $mlss_id                       = $mlss->dbID;
     my $num_blocks                    = $mlss->get_value_for_tag('num_blocks');
     my $ref_species                   = $mlss->get_value_for_tag('reference_species');
-    my $non_ref_species               = $mlss->get_value_for_tag('non_reference_species');
+    my $non_ref_species               = $mlss->species_set->size == 1  # self-alignment
+                                      ? $ref_species
+                                      : $mlss->get_value_for_tag('non_reference_species')
+                                      ;
     my $pairwise_params               = $mlss->get_value_for_tag('param');
     my $ref_genome_db                 = $genome_db_adaptor->fetch_by_name_assembly($ref_species) || die "Could not find the GenomeDB '$ref_species' for mlss $mlss_id";
     my $non_ref_genome_db             = $genome_db_adaptor->fetch_by_name_assembly($non_ref_species) || die "Could not find the GenomeDB '$non_ref_species' for mlss $mlss_id";


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

This PR would have the effect of always using the reference genome as the non-reference genome in self-alignment statistics views.

Currently the non-reference genome is set from a `non_reference_species` MLSS tag, which is present for the Human self-alignment in Ensembl Vertebrates, but not for the T. aestivum and T. dicoccoides self-alignments in Ensembl Plants.

The PR would have no effect on Human, but would make alignment stats accessible for the other two self-alignments.

An indirect benefit of this is that it would facilitate automated testing of sandbox/staging sites during production, by validating the assumption that when all is going well, all `LASTZ_NET` alignments have an accessible stats page.

## Views affected

Because this change is conditional on the alignment `$mlss` being a self-alignment, it only affects self-alignment statistics views, of which there are currently three:
- Triticum dicoccoides self-alignment: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/info/genome/compara/mlss.html?mlss=9821) vs [staging](http://staging-plants.ensembl.org/info/genome/compara/mlss.html?mlss=9821)
- Triticum aestivum self-alignment: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/info/genome/compara/mlss.html?mlss=9633) vs [staging](http://staging-plants.ensembl.org/info/genome/compara/mlss.html?mlss=9633)
- Homo sapiens self-alignment (unchanged): [sandbox](http://wp-np2-25.ebi.ac.uk:5092//info/genome/compara/mlss.html?mlss=739) vs [staging](https://staging.ensembl.org/info/genome/compara/mlss.html?mlss=739)

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
