### PR TITLE
Add some guards for non-protein-coding MANE transcripts

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/GeneSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GeneSummary.pm
@@ -67,7 +67,7 @@ sub content {
       $has_mane_select = 1 if (@{$t->get_all_Attributes('MANE_Select')});
 
       $mane_select = $t->stable_id if $has_mane_select;
-      $mane_select_translation = $t->translation->stable_id if $has_mane_select;
+      $mane_select_translation = $t->translation->stable_id if ($has_mane_select and $t->translation);
     }
 
     foreach my $t (@{$gene->get_all_Transcripts}) {
@@ -76,7 +76,7 @@ sub content {
       $has_mane_plus_clinical = 1 if (@{$t->get_all_Attributes('MANE_Plus_Clinical')});
 
       $mane_plus_clinical = $t->stable_id if $has_mane_plus_clinical;
-      $mane_plus_clinical_translation = $t->translation->stable_id if $has_mane_plus_clinical;
+      $mane_plus_clinical_translation = $t->translation->stable_id if ($has_mane_plus_clinical and $t->translation);
     }
   }
 
@@ -84,19 +84,27 @@ sub content {
     my $mane_select_url = $hub->url({ type => 'Transcript', action => 'Summary', t => $mane_select });
     my $mane_select_link = sprintf('<a href="%s">%s</a>', $mane_select_url, $mane_select);
 
-    my $mane_select_translation_url = $hub->url({ type => 'Transcript', action => 'ProteinSummary', t => $mane_select_translation });
-    my $mane_select_translation_link = sprintf('<a href="%s">%s</a>', $mane_select_translation_url, $mane_select_translation);
+    my $mane_select_translation_link;
 
-    my $mane_description = sprintf('This gene contains MANE Select %s, %s', $mane_select_link, $mane_select_translation_link);
+    if ($mane_select_translation) {
+      my $mane_select_translation_url = $hub->url({ type => 'Transcript', action => 'ProteinSummary', t => $mane_select_translation });
+      $mane_select_translation_link = sprintf('<a href="%s">%s</a>', $mane_select_translation_url, $mane_select_translation);
+    }
+
+    my $mane_description = sprintf('This gene contains MANE Select %s, %s', $mane_select_link, $mane_select_translation_link // 'no translation');
 
     if ($has_mane_plus_clinical) {
       my $mane_plus_clinical_url = $hub->url({ type => 'Transcript', action => 'Summary', t => $mane_plus_clinical });
       my $mane_plus_clinical_link = sprintf('<a href="%s">%s</a>', $mane_plus_clinical_url, $mane_plus_clinical);
       
-      my $mane_plus_clinical_translation_url = $hub->url({ type => 'Transcript', action => 'ProteinSummary', t => $mane_plus_clinical_translation });
-      my $mane_plus_clinical_translation_link = sprintf('<a href="%s">%s</a>', $mane_plus_clinical_translation_url, $mane_plus_clinical_translation);
+      my $mane_plus_clinical_translation_link;
 
-      $mane_description .= sprintf(' and MANE Plus Clinical %s, %s', $mane_plus_clinical_link, $mane_plus_clinical_translation_link);
+      if ($mane_plus_clinical_translation) {
+        my $mane_plus_clinical_translation_url = $hub->url({ type => 'Transcript', action => 'ProteinSummary', t => $mane_plus_clinical_translation });
+        $mane_plus_clinical_translation_link = sprintf('<a href="%s">%s</a>', $mane_plus_clinical_translation_url, $mane_plus_clinical_translation);
+      }
+
+      $mane_description .= sprintf(' and MANE Plus Clinical %s, %s', $mane_plus_clinical_link, $mane_plus_clinical_translation_link // 'no translation');
     }
 
     $table->add_row('MANE', $mane_description);

--- a/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
@@ -71,18 +71,27 @@ sub content {
     my $transcript_refseq_url = $hub->get_ExtURL('REFSEQ_DNA', { 'ID' => $transcript_refseq_id });
     my $refseq_links = sprintf('<a href="%s">%s</a>', $transcript_refseq_url, $transcript_refseq_id);
 
-    my $mane_transcript_translation_url = $hub->url({ type => 'Transcript', action => 'ProteinSummary', t => $transcript->translation->stable_id });
-    my $mane_transcript_translation_link = sprintf('<a href="%s">%s</a>', $mane_transcript_translation_url, $transcript->translation->stable_id);
+    my $mane_transcript_translation_link = '';
+    if ($transcript->translation) {
+      my $mane_transcript_translation_url = $hub->url({ type => 'Transcript', action => 'ProteinSummary', t => $transcript->translation->stable_id });
+      $mane_transcript_translation_link = sprintf('<a href="%s">%s</a>', $mane_transcript_translation_url, $transcript->translation->stable_id);
 
-    my $translation_refseq_id = $transcript->translation->get_all_Attributes($mane_type)->[0]->value;
+      my $translation_refseq_id = $transcript->translation->get_all_Attributes($mane_type)->[0]->value;
 
-    if ($translation_refseq_id) {
-      my $translation_refseq_url = $hub->get_ExtURL('REFSEQ_RNA', { 'ID' => $translation_refseq_id });
+      if ($translation_refseq_id) {
+        my $translation_refseq_url = $hub->get_ExtURL('REFSEQ_RNA', { 'ID' => $translation_refseq_id });
 
-      $refseq_links .= sprintf(' and <a href="%s">%s</a>', $translation_refseq_url, $translation_refseq_id);
+        $refseq_links .= sprintf(' and <a href="%s">%s</a>', $translation_refseq_url, $translation_refseq_id);
+      }
     }
 
-    $table->add_row('MANE', sprintf('<p>This %s transcript contains %s and matches to %s</p>', $mane_type_str, $mane_transcript_translation_link, $refseq_links));
+    my $mane_description_text = '';
+    if ($mane_transcript_translation_link) {
+      $mane_description_text = sprintf('<p>This %s transcript contains %s and matches to %s</p>', $mane_type_str, $mane_transcript_translation_link, $refseq_links);
+    } else {
+      $mane_description_text = sprintf('<p>This %s transcript has no translation and matches to %s</p>', $mane_type_str, $refseq_links);
+    }
+    $table->add_row('MANE', $mane_description_text);
   }
 
   ## add Uniprot info


### PR DESCRIPTION
## Description
Fix for https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6989

Not all MANE Select transcripts are protein-coding.

## Views affected
- gene with non-coding MANE select transcript: http://wp-np2-33.ebi.ac.uk:8410/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000277027;r=9:35657750-35658019;t=ENST00000363046
- non-coding MANE select transcript: http://wp-np2-33.ebi.ac.uk:8410/Homo_sapiens/Transcript/Summary?db=core;g=ENSG00000277027;r=9:35657750-35658019;t=ENST00000363046
- coding transcript: http://wp-np2-33.ebi.ac.uk:8410/Homo_sapiens/Transcript/Summary?db=core;g=ENSG00000104635;r=8:22367278-22434129;t=ENST00000381237
