### PR TITLE
Prepend Pan Compara base URL to species path

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -227,17 +227,7 @@ sub content {
       my $goc_class  = ($goc_score ne "n/a" && $goc_score >= $orthologue->{goc_threshold}) ? "box-highlight" : "";
       my $wga_class  = ($wgac ne "n/a" && $wgac >= $orthologue->{wga_threshold}) ? "box-highlight" : "";
 
-      my $base_url;
-
-      if ($is_pan) {
-        my $site      = $pan_lookup->{$prodname}{'division'};
-        if ($site ne $hub->species_defs->DIVISION) {
-          $site         = 'www' if $site eq 'vertebrates';
-          $base_url     = "https://$site.ensembl.org";
-        }
-      }
-
-      my $link_url = $base_url.$hub->url({
+      my $link_url = $hub->url({
         species => $species,
         action  => 'Summary',
         g       => $stable_id,

--- a/modules/EnsEMBL/Web/Component/Gene/HomologAlignment.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/HomologAlignment.pm
@@ -100,29 +100,20 @@ sub content {
             $location,
           ]; 
         } else {
-          my $division  = $pan_lookup->{$peptide->genome_db->name}{'division'};
-          my $site      = '';
-          if ($division) {
-            $division = 'www' if $division eq 'vertebrates';
-            $site     =  sprintf('https://%s.ensembl.org', $division);
-          }
           push @$data, [
             $label,
-            sprintf('<a href="%s%s">%s</a>',
-              $site,
+            sprintf('<a href="%s">%s</a>',
               $hub->url({ species => $member_species, type => 'Gene', action => 'Summary', g => $gene->stable_id, r => undef }),
               $gene->stable_id
             ),
-            sprintf('<a href="%s%s">%s</a>',
-              $site,
+            sprintf('<a href="%s">%s</a>',
               $hub->url({ species => $member_species, type => 'Transcript', action => 'ProteinSummary', peptide => $peptide->stable_id, __clear => 1 }),
               $peptide->stable_id
             ),
             sprintf('%d %s', $peptide->seq_length, $unit),
             sprintf('%d %%', $peptide->perc_id),
             sprintf('%d %%', $peptide->perc_cov),
-            sprintf('<a href="%s%s">%s</a>',
-              $site,
+            sprintf('<a href="%s">%s</a>',
               $hub->url({ species => $member_species, type => 'Location', action => 'View', g => $gene->stable_id, r => $location, t => undef }),
               $location
             )

--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -1763,6 +1763,21 @@ sub species_path {
     # as the current species - in that case we don't need the host name bit
     $url =~ s/^http\:\/\/[^\/]+\//\// if $url_hash->{$spsite} =~ /\#\#\#SPECIES\#\#\#/ && substr($spsite, 0, 5) eq substr($cssite, 0, 5);
     $url =~ s/\/$//;
+
+    if (!$url) {
+      my $pan_lookup = $self->multi_val('PAN_COMPARA_LOOKUP') || {};
+      my %rev_lookup = map { $pan_lookup->{$_}{'species_url'} => $_ } keys %{$pan_lookup};
+
+      if (exists $rev_lookup{$species}) {
+        my $prod_name = $rev_lookup{$species};
+        my $site = $pan_lookup->{$prod_name}{'division'};
+        if ($site ne $self->DIVISION) {
+          $site = 'www' if $site eq 'vertebrates';
+          $url = "https://${site}.ensembl.org/${species}";
+        }
+      }
+    }
+
     $url ||= "/$species"; # in case species have not made to the SPECIES_SITE there is a good chance the species name as it is will do  
   }
   


### PR DESCRIPTION
## Description

In Pan Compara `EnsEMBL::Web::Component::Gene::ComparaOrthologs` and `EnsEMBL::Web::Component::Gene::HomologAlignment` views, URLs to features of genomes not in the current host division (e.g. Human in `plants.ensembl.org`) are prefixed with a Pan Compara-specific base URL.

This addition of a Pan-specific base URL is not currently implemented in `EnsEMBL::Web::ZMenu::Gene::ComparaTree`, and as a result, in Pan Compara gene trees, the ZMenu of a gene does not load if that gene is not in the host division.

This pull request would remove the addition of a base URL to Pan Compara URLs in the `ComparaOrthologs` and `HomologAlignment` modules, and would instead add a Pan Compara base URL as a second-to-last resort in the `SpeciesDefs::species_path` method.

This would extend the inclusion of a Pan-specific base URL as needed to gene ZMenus in Pan Compara gene trees.

## Views affected

This is expected to affect the Pan Compara gene-tree view by enabling loading of ZMenus of genes not in the host division.

It is expected to change how URLs are generated for some features in Pan Compara homologue alignment and orthologue views, but neither the URLs nor the views themselves are expected to change.

## Possible complications

No complications are anticipated. The Pan Compara base URL is only prepended if (almost) all other options have been exhausted, and only for genomes that are in Pan-taxonomic Compara.

The base URL is admittedly that of a live Ensembl site, which may result in broken links or inconsistencies when an Ensembl release is archived. However, this is also true of the existing code.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
