### PR TITLE
Show strain Compara portal for all genomes in a strain collection

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/Compara_Portal.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/Compara_Portal.pm
@@ -35,8 +35,8 @@ sub content {
   my $hub           = $self->hub;
   my $availability  = $self->object->availability;
   my $location      = $hub->url({ type => 'Location',  action => 'Compara' });
-  my $strain_url    = ($self->is_strain) ? "Strain_" : "";
-  my $strain_avail  = ($self->is_strain) ? "strain_" : "";
+  my $strain_url    = ($self->is_strain || $hub->action =~ /^Strain_/) ? "Strain_" : "";
+  my $strain_avail  = ($self->is_strain || $hub->action =~ /^Strain_/) ? "strain_" : "";
 
   my $ortho_image = $strain_avail ? 'strain_ortho.gif' : 'compara_ortho.gif';
   my $para_image  = $strain_avail ? 'strain_para.gif' : 'compara_para.gif';


### PR DESCRIPTION
## Description

This PR would ensure that the strain-level Compara portal would be displayed when a user clicks on the strains/breeds/cultivars menu item in a gene view.

## Views affected

This would affect the appearance and behaviour of a Compara portal accessed via the strains/breeds/cultivars menu item of a gene view.

Here is a screenshot illustrating the effect on the cultivar Compara portal of the Rice reference genome:
![rice_cultivar_portal](https://github.com/user-attachments/assets/94fdd36a-bf03-4d0a-9c0d-080bdb590885)

For comparison, here is the corresponding view on the Ensembl Plants live site: https://plants.ensembl.org/Oryza_sativa/Gene/Strain_Compara?g=Os08g0140500

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
