### PR TITLE
[115] Update Regulatory features links on Z-menu

### DIFF
--- a/modules/EnsEMBL/Web/ZMenu/Regulation.pm
+++ b/modules/EnsEMBL/Web/ZMenu/Regulation.pm
@@ -40,21 +40,25 @@ sub content {
   $self->caption($caption);
   
   my $object         = $self->new_object('Regulation', $reg_feature, $self->object->__data);
+
+  my $species = $hub->species;
+  my $species_defs = $hub->species_defs;
+  my $species_prod_name = $species_defs->get_config($species, 'SPECIES_PRODUCTION_NAME');
+  my $ensembl_version = $species_defs->ENSEMBL_VERSION;
+  my $feature_url = sprintf("https://regulation.ensembl.org/%s/regulatory_features/%s/%s", $ensembl_version, $species_prod_name, $object->stable_id);
   
   $self->add_entry({
     type  => 'ID',
-    label => $object->stable_id,
-    link  => $object->get_summary_page_url
+    label_html => sprintf("<a href=\"%s\" rel=\"external\" >%s</a>", $feature_url, $object->stable_id),
   });
 
   if (!($reg_feature->feature_type->name =~ /^EMAR/)  && !($reg_feature->feature_type->name =~ /^CTCF/)) {
     $self->add_entry({
       type  => 'Activity',
-      label => 'Regulatory activity',
-      link  => $object->get_summary_page_url
+      label_html => sprintf("<a href=\"%s\" rel=\"external\" >Regulatory activity</a>", $feature_url),
     });
   }
-    
+ 
   $self->add_entry({
     type  => 'Type',
     label => $object->feature_type->name


### PR DESCRIPTION
## Description

The regulatory feature page is being replaced by the regulation subsite (regulation.ensembl.org).
Because of that, we're updating the links pointing to that page.

## Views affected

Location view (reg. feature Z-menu).
http://wp-np2-35.ebi.ac.uk:6030/Homo_sapiens/Location/View?r=17:63992802-64038237

![Screenshot 2025-04-15 at 14 19 13](https://github.com/user-attachments/assets/7fcc2f0a-7f8a-499c-b562-ccea6ce34f8e)
