### PR TITLE
Remove highlighting of GOC score zero

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -224,8 +224,8 @@ sub content {
       my $goc_score  = (defined $orthologue->{'goc_score'} && $orthologue->{'goc_score'} >= 0) ? $orthologue->{'goc_score'} : 'n/a';
       my $wgac       = (defined $orthologue->{'wgac'} && $orthologue->{'wgac'} >= 0) ? $orthologue->{'wgac'} : 'n/a';
       my $confidence = $orthologue->{'highconfidence'} eq '1' ? 'Yes' : $orthologue->{'highconfidence'} eq '0' ? 'No' : 'n/a';
-      my $goc_class  = ($goc_score ne "n/a" && $goc_score >= $orthologue->{goc_threshold}) ? "box-highlight" : "";
-      my $wga_class  = ($wgac ne "n/a" && $wgac >= $orthologue->{wga_threshold}) ? "box-highlight" : "";
+      my $goc_class  = ($goc_score ne "n/a" && defined $orthologue->{goc_threshold} && $goc_score >= $orthologue->{goc_threshold}) ? "box-highlight" : "";
+      my $wga_class  = ($wgac ne "n/a" && defined $orthologue->{wga_threshold} && $wgac >= $orthologue->{wga_threshold}) ? "box-highlight" : "";
 
       my $base_url;
 


### PR DESCRIPTION
## Description

In cases where a GOC score threshold is undefined, a GOC score of zero may be adorned with the green highlighting intended for high GOC scores.

This PR would remove such highlighting of zero-value GOC scores.

## Views affected

This change would affect the Compara orthologues view.

An up-to-date example is given in the comments of the related ticket.

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- ENSWEB-6354
