### PR TITLE
Set mus_musculus_nzohlltj strain group in ConfigPacker

### DIFF
--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -1806,6 +1806,13 @@ sub _munge_meta {
       $self->tree($prod_name)->{'STRAIN_TYPE'} = 'strain';
     }
     
+    ## e114 hack to set mus_musculus_nzohlltj STRAIN_GROUP
+    if (!$SiteDefs::EG_DIVISION
+          && $prod_name eq 'mus_musculus_nzohlltj'
+          && $assembly_name eq 'NZO_HlLtJ_v3') {
+      $self->tree($prod_name)->{'STRAIN_GROUP'} = 'mus_musculus';
+    }
+
     ## Munge genebuild info
     my @A = split '-', $meta_hash->{'genebuild.start_date'}[0];
     


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

This pull request would set the `STRAIN_GROUP` of `mus_musculus_nzohlltj` in the `ConfigPacker` module, ensuring consistent handling of this Mouse strain in web views.

This PR has been submitted against the `release/114` branch: this is a proposed solution for release 114 only, in the hope that a more effective solution will be implemented for this Mouse strain from release 115 onwards.

## Views affected

This change would affect the [Mouse strain list view](https://rc.ensembl.org/Mus_musculus/Info/Strains?db=core), [Mouse strain comparative genomics portal](https://rc.ensembl.org/Mus_musculus_NZO_HlLtJ/Gene/Strain_Compara?g=ENSMUSG00225002193), and any view relying on the `STRAIN_GROUP` metadata for correct handling of Mouse strains.

Example Mouse strain list view before change:
![before_strains_list](https://github.com/user-attachments/assets/802c52f6-36e5-4f7f-add0-0690455be1b1)

Example Mouse strain list view after change:
![after_strains_list](https://github.com/user-attachments/assets/56b95f78-d7d9-47c3-9960-a93707b44caa)

Example Mouse strain comparative genomics portal before change:
![before_strains_portal](https://github.com/user-attachments/assets/9191d969-d801-4deb-be70-e8d2cfc886cc)

Example Mouse strain comparative genomics portal after change:
![after_strains_portal](https://github.com/user-attachments/assets/4b08a4b5-c5ab-4fab-9dad-87363eb2b58f)

## Possible complications

For this change to take effect, the Mouse NZO/HlLtJ packed file (`mus_musculus_nzohlltj.db.packed`) would need to be repacked.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
