### PR TITLE
Add logic names for gencode, and dry up the code a little

### DIFF
--- a/modules/EnsEMBL/Web/ImageConfigExtension/Constants.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Constants.pm
@@ -3,7 +3,7 @@ package EnsEMBL::Web::ImageConfigExtension::Constants;
 use Exporter 'import';
 our @EXPORT_OK = qw(logic_names_gencode logic_names_mane);
 
-our $const_logic_names_gencode = [
+my @const_logic_names_gencode = (
   'proj_ensembl',
   'proj_ncrna',
   'proj_havana_ig_gene',
@@ -24,9 +24,9 @@ our $const_logic_names_gencode = [
   'ensembl_havana_tagene_gene',
   'havana_tagene',
   'proj_havana_tagene'
-];
+);
 
-our $const_logic_names_mane = [
+my @const_logic_names_mane = (
   'proj_ensembl',
   'proj_ncrna',
   'proj_havana_ig_gene',
@@ -45,13 +45,13 @@ our $const_logic_names_mane = [
   'proj_ensembl_havana_gene',
   'havana',
   'ensembl_havana_transcript'
-];
+);
 
 sub logic_names_gencode {
   # clone the strings into a new array so the original can't be tampered with
-  return [@$const_logic_names_gencode];
+  return [@const_logic_names_gencode];
 }
 sub logic_names_mane {
   # clone the strings into a new array so the original can't be tampered with
-  return [@$const_logic_names_mane];
+  return [@const_logic_names_mane];
 }

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Constants.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Constants.pm
@@ -1,0 +1,57 @@
+package EnsEMBL::Web::ImageConfigExtension::Constants;
+
+use Exporter 'import';
+our @EXPORT_OK = qw(logic_names_gencode logic_names_mane);
+
+our $const_logic_names_gencode = [
+  'proj_ensembl',
+  'proj_ncrna',
+  'proj_havana_ig_gene',
+  'havana_ig_gene',
+  'ensembl_havana_ig_gene',
+  'proj_ensembl_havana_lincrna',
+  'proj_havana',
+  'ensembl',
+  'mt_genbank_import',
+  'ensembl_havana_lincrna',
+  'proj_ensembl_havana_ig_gene', 
+  'ncrna',
+  'assembly_patch_ensembl',
+  'ensembl_havana_gene',
+  'ensembl_lincrna',
+  'proj_ensembl_havana_gene',
+  'havana',
+  'ensembl_havana_tagene_gene',
+  'havana_tagene',
+  'proj_havana_tagene'
+];
+
+our $const_logic_names_mane = [
+  'proj_ensembl',
+  'proj_ncrna',
+  'proj_havana_ig_gene',
+  'havana_ig_gene',
+  'ensembl_havana_ig_gene',
+  'proj_ensembl_havana_lincrna',
+  'proj_havana',
+  'ensembl',
+  'mt_genbank_import',
+  'ensembl_havana_lincrna',
+  'proj_ensembl_havana_ig_gene',
+  'ncrna',
+  'assembly_patch_ensembl',
+  'ensembl_havana_gene',
+  'ensembl_lincrna',
+  'proj_ensembl_havana_gene',
+  'havana',
+  'ensembl_havana_transcript'
+];
+
+sub logic_names_gencode {
+  # clone the strings into a new array so the original can't be tampered with
+  return [@$const_logic_names_gencode];
+}
+sub logic_names_mane {
+  # clone the strings into a new array so the original can't be tampered with
+  return [@$const_logic_names_mane];
+}

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -31,6 +31,8 @@ use List::MoreUtils qw(firstidx);
 
 use EnsEMBL::Web::Utils::Sanitize qw(clean_id);
 
+use EnsEMBL::Web::ImageConfigExtension::Constants qw(logic_names_gencode logic_names_mane);
+
 sub load_tracks {
   ## Loop through core/compara/funcgen/variation like dbs and loads in various database derived tracks
   ## @params List of arguments to be passed on the individual method to add a specific type of track
@@ -477,7 +479,7 @@ sub add_genes {
       sortable      => 1,
       colours       => $colours,
       label_key     => '[biotype]',
-      logic_names   => ['proj_ensembl',  'proj_ncrna', 'proj_havana_ig_gene', 'havana_ig_gene', 'ensembl_havana_ig_gene', 'proj_ensembl_havana_lincrna', 'proj_havana', 'ensembl', 'mt_genbank_import', 'ensembl_havana_lincrna', 'proj_ensembl_havana_ig_gene', 'ncrna', 'assembly_patch_ensembl', 'ensembl_havana_gene', 'ensembl_lincrna', 'proj_ensembl_havana_gene', 'havana'],
+      logic_names   => logic_names_gencode(),
       renderers     =>  [
         'off',                     'Off',
         'gene_nolabel',            'No exon structure without labels',
@@ -500,7 +502,7 @@ sub add_genes {
       sortable      => 1,
       colours       => $colours,                                                                                                                                                                                                                                                
       label_key     => '[biotype]',
-      logic_names   => ['proj_ensembl',  'proj_ncrna', 'proj_havana_ig_gene', 'havana_ig_gene', 'ensembl_havana_ig_gene', 'proj_ensembl_havana_lincrna', 'proj_havana', 'ensembl', 'mt_genbank_import', 'ensembl_havana_lincrna', 'proj_ensembl_havana_ig_gene', 'ncrna', 'assembly_patch_ensembl', 'ensembl_havana_gene', 'ensembl_lincrna', 'proj_ensembl_havana_gene', 'havana'],
+      logic_names   => logic_names_gencode(),
       renderers     =>  [
         'off',                     'Off',
         'gene_nolabel',            'No exon structure without labels',
@@ -526,7 +528,7 @@ sub add_genes {
       sortable      => 1,
       colours       => $colours,
       label_key     => '[biotype]',
-      logic_names   => ['proj_ensembl',  'proj_ncrna', 'proj_havana_ig_gene', 'havana_ig_gene', 'ensembl_havana_ig_gene', 'proj_ensembl_havana_lincrna', 'proj_havana', 'ensembl', 'mt_genbank_import', 'ensembl_havana_lincrna', 'proj_ensembl_havana_ig_gene', 'ncrna', 'assembly_patch_ensembl', 'ensembl_havana_gene', 'ensembl_lincrna', 'proj_ensembl_havana_gene', 'havana', 'ensembl_havana_transcript'],
+      logic_names   => logic_names_mane(),
       renderers     =>  [
         'off',                     'Off',
         'transcript_nolabel',      'Expanded without labels',
@@ -543,7 +545,7 @@ sub add_genes {
       sortable      => 1,
       colours       => $colours,
       label_key     => '[biotype]',
-      logic_names   => ['proj_ensembl',  'proj_ncrna', 'proj_havana_ig_gene', 'havana_ig_gene', 'ensembl_havana_ig_gene', 'proj_ensembl_havana_lincrna', 'proj_havana', 'ensembl', 'mt_genbank_import', 'ensembl_havana_lincrna', 'proj_ensembl_havana_ig_gene', 'ncrna', 'assembly_patch_ensembl', 'ensembl_havana_gene', 'ensembl_lincrna', 'proj_ensembl_havana_gene', 'havana', 'ensembl_havana_transcript'],
+      logic_names   => logic_names_mane(),
       renderers     =>  [
         'off',                     'Off',
         'transcript_nolabel',      'Expanded without labels',

--- a/modules/EnsEMBL/Web/Query/GlyphSet/Transcript.pm
+++ b/modules/EnsEMBL/Web/Query/GlyphSet/Transcript.pm
@@ -29,6 +29,7 @@ our $VERSION = 13;
 use JSON;
 use List::Util qw(min max);
 use Bio::EnsEMBL::Gene;
+use EnsEMBL::Web::ImageConfigExtension::Constants qw(logic_names_gencode logic_names_mane);
 
 sub precache {
   return {
@@ -59,15 +60,7 @@ sub precache {
     gencode_basic => {
       loop => ['species','genome'],
       args => {
-        logic_names => [qw(
-          assembly_patch_ensembl    ensembl      ensembl_havana_gene
-          ensembl_havana_ig_gene    ensembl_havana_lincrna
-          ensembl_lincrna           havana       havana_ig_gene
-          mt_genbank_import         ncrna        proj_ensembl
-          proj_ensembl_havana_gene  proj_ensembl_havana_ig_gene
-          proj_ensembl_havana_lincrna   proj_havana
-          proj_havana_ig_gene       proj_ncrna
-        )],
+        logic_names => logic_names_gencode(),
         label_key => "[biotype]",
         only_attrib => "gencode_basic",
         shortlabels => '',
@@ -76,15 +69,7 @@ sub precache {
     gencode_primary => {
       loop => ['species','genome'],
       args => {
-        logic_names => [qw(
-          assembly_patch_ensembl    ensembl      ensembl_havana_gene
-          ensembl_havana_ig_gene    ensembl_havana_lincrna
-          ensembl_lincrna           havana       havana_ig_gene
-          mt_genbank_import         ncrna        proj_ensembl
-          proj_ensembl_havana_gene  proj_ensembl_havana_ig_gene
-          proj_ensembl_havana_lincrna   proj_havana
-          proj_havana_ig_gene       proj_ncrna
-        )],
+        logic_names => logic_names_gencode(),
         label_key => "[biotype]",
         only_attrib => "gencode_primary",
         shortlabels => '', 
@@ -94,15 +79,7 @@ sub precache {
       loop => ['species','genome'],
       args => {
         db => "core",
-        logic_names => [qw(
-          assembly_patch_ensembl    ensembl      ensembl_havana_gene
-          ensembl_havana_ig_gene    ensembl_havana_lincrna
-          ensembl_lincrna           havana       havana_ig_gene
-          mt_genbank_import         ncrna        proj_ensembl
-          proj_ensembl_havana_gene  proj_ensembl_havana_ig_gene
-          proj_ensembl_havana_lincrna   proj_havana
-          proj_havana_ig_gene       proj_ncrna    ensembl_havana_transcript
-        )],
+        logic_names => logic_names_mane(),
         label_key => "[display_label]",
         only_attrib => "MANE_Select",
         shortlabels => '',
@@ -112,15 +89,7 @@ sub precache {
       loop => ['species','genome'],
       args => {
         db => "core",
-        logic_names => [qw(
-          assembly_patch_ensembl    ensembl      ensembl_havana_gene
-          ensembl_havana_ig_gene    ensembl_havana_lincrna
-          ensembl_lincrna           havana       havana_ig_gene
-          mt_genbank_import         ncrna        proj_ensembl
-          proj_ensembl_havana_gene  proj_ensembl_havana_ig_gene
-          proj_ensembl_havana_lincrna   proj_havana
-          proj_havana_ig_gene       proj_ncrna    ensembl_havana_transcript
-        )],
+        logic_names => logic_names_mane(),
         label_key => "[display_label]",
         only_attrib => "MANE_Plus_Clinical",
         shortlabels => '',


### PR DESCRIPTION
## Description
This addresses the problem of missing transcripts in gencode primary and gencode basic tracks raised in https://embl.atlassian.net/browse/ENSWEB-6993

As it turned out, the list of 'logic names' that selects transcripts for gencode tracks was missing three members: `ensembl_havana_tagene_gene`, `havana_tagene`, and `proj_havana_tagene`.

While fixing the problem, I've also moved the duplicated lists of strings into a separate file. Note that even now, the list of logic names for gencode and mane tracks is mostly identical — the following members between them are the same:

```
  'proj_ensembl',
  'proj_ncrna',
  'proj_havana_ig_gene',
  'havana_ig_gene',
  'ensembl_havana_ig_gene',
  'proj_ensembl_havana_lincrna',
  'proj_havana',
  'ensembl',
  'mt_genbank_import',
  'ensembl_havana_lincrna',
  'proj_ensembl_havana_ig_gene', 
  'ncrna',
  'assembly_patch_ensembl',
  'ensembl_havana_gene',
  'ensembl_lincrna',
  'proj_ensembl_havana_gene',
  'havana',
```

It isn't yet clear whether `ensembl_havana_transcript ` should only belong to MANE transcripts but not to gencode; and whether the three newly added tagene logic names should belong just to gencode and not to MANE.

## Views affected
**Before the change (current rc site):**
https://rc.ensembl.org/Mus_musculus/Location/View?r=7:103459601-103517491 (enable gencode primary, gencode basic, and gencode comprehensive tracks, and observe in the provided location that only the comprehensive track has certain transcripts

![image](https://github.com/user-attachments/assets/644e86dd-f635-4620-a0e1-d68b4a3a82ac)

**After the change (sandbox):** All three gencode tracks show the same transcripts in this locus:

![image](https://github.com/user-attachments/assets/8802ad4a-65e5-403d-af14-7e3868b9b64c)
 
(http://wp-np2-33.ebi.ac.uk:8410/Mus_musculus/Location/View?r=7:103459601-103517491)
