### PR TITLE
Load underlying slices iff needed for alignslice view

### DIFF
--- a/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
+++ b/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
@@ -64,6 +64,7 @@ sub content {
     ));
   }
   
+  my $need_underlying_slices = !$self->has_image || $align_details->{'class'} eq 'GenomicAlignTree.ancestral_alignment';
   my $image_width     = $self->image_width;
   my $slice           = $object->slice;
   my %export_params   = $hub->param('data_type') ? ('data_type' => $hub->param('data_type'), 'component' => $hub->param('data_action'))
@@ -71,6 +72,7 @@ sub content {
   my ($slices)        = $object->get_slices({
                                               'slice' => $slice, 
                                               'align' => $align_params, 
+                                              'image' => !$need_underlying_slices,
                                               'species' => $primary_species,
                                               %export_params
                         });
@@ -136,6 +138,7 @@ sub content {
                                 'species' => $prodname, 
                                 'cdb'     => $self->param('cdb') || 'compara',
                                 'ignore'  => 'ancestral_sequences',
+                                'image'   => !$need_underlying_slices,
                                 });
 
   return $alert_box if $error;


### PR DESCRIPTION
## Description

On `line 390 of ensembl-webcode/modules/EnsEMBL/Web/Object.pm` ...
https://github.com/Ensembl/ensembl-webcode/blob/370648c0e9e105faaefd3737e0c6928aed93bfdd/modules/EnsEMBL/Web/Object.pm#L390

...in method `EnsEMBL::Web::Object::get_slices`, the `'image'` parameter is used to control whether `underlying_slices` of a Compara `AlignSlice::Slice` are loaded for a formatted slice.
 
The loaded `underlying_slices` value is used in various places in text alignment views. However, in genomic alignment image (alignslice) views, it appears to be used only to control visibility of ancestral sequences, in line 417 of `ensembl-webcode/modules/EnsEMBL/Web/Object.pm`: https://github.com/Ensembl/ensembl-webcode/blob/370648c0e9e105faaefd3737e0c6928aed93bfdd/modules/EnsEMBL/Web/Object.pm#L417

This PR would set the `get_slices` `'image'` parameter to `0` for genomic alignment image views lacking an ancestral sequence (i.e. not of class `GenomicAlignTree.ancestral_alignment`). In tests done so far on the 91 Mammals EPO-Extended alignment, this has reduced loading times by ~10% on average.

## Views affected

This change would affect image (alignslice) views of all non-ancestral genomic alignments, including EPO-Extended, Cactus and LastZ alignments.

Further details on testing are available in the related Jira ticket.

## Possible complications

This is not expected to adversely affect any views. The change is restricted to non-ancestral image alignments, where the `underlying_slices` value is not currently needed.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- ENSCOMPARASW-8396