### PR TITLE
Update Apache access logs format: print request IP

### DIFF
--- a/conf/httpd.conf
+++ b/conf/httpd.conf
@@ -453,7 +453,7 @@ LogFormat ":%{X-Forwarded-For}i %v %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-
 <IfDefine !ec2>
 # this for live at Hinx
 LogFormat               "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
-LogFormat               "[%P/%{ENSEMBL_CHILD_COUNT}e %{ENSEMBL_SCRIPT_TIME}e %{outstream}n/%{instream}n=%{ratio}n] %h/%{HTTP_X_FORWARDED_FOR}e %l/%{ENSEMBL_SESSION_ID}e %u/%{ENSEMBL_USER_ID}e %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" \"%{HTTP_X_Requested_With}e\" %{ENSEMBL_SCRIPT_START}e/%{ENSEMBL_SCRIPT_END}e" ensembl_extended
+LogFormat               "[%P/%{ENSEMBL_CHILD_COUNT}e %{ENSEMBL_SCRIPT_TIME}e %{outstream}n/%{instream}n=%{ratio}n] %h/%{X-Cluster-Client-Ip}i %l/%{ENSEMBL_SESSION_ID}e %u/%{ENSEMBL_USER_ID}e %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" \"%{HTTP_X_Requested_With}e\" %{ENSEMBL_SCRIPT_START}e/%{ENSEMBL_SCRIPT_END}e" ensembl_extended
 </IfDefine>
 #
 ####


### PR DESCRIPTION
## Description
Our logs currently print the ip of the traffic manager, which isn't useful at all. This PR updates apache log format such that 

**Before:**
No proper information about where requests originated from:

```
[112714/- - -/-=-] 193.62.192.71/- -/- -/- [23/Jan/2024:19:22:29 +0000] "GET /__howsitgoing HTTP/1.0" 200 66 "-" "HTTP-Monitor/1.1" "-" -/-
[112713/- - -/-=-] 193.62.193.70/- -/- -/- [23/Jan/2024:19:22:28 +0000] "GET /index.html HTTP/1.1" 200 197174 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" "-" -/-
[112713/- - -/-=-] 193.62.193.70/- -/- -/- [23/Jan/2024:19:22:30 +0000] "GET /minified/e070e2b9af58bbaac1db99d52f3b9fbd.css HTTP/1.1" 200 41495 "https://test-rapid.ensembl.org/index.html" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" "-" -/-
[112716/- - -/-=-] 193.62.193.70/- -/- -/- [23/Jan/2024:19:22:30 +0000] "GET /minified/2220dc0af50ddba521795a4ae1a0d193.image.css HTTP/1.1" 200 286 "https://test-rapid.ensembl.org/index.html" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" "-" -/-
[112718/- - -/-=-] 193.62.193.70/- -/- -/- [23/Jan/2024:19:22:30 +0000] "GET /i/species/Humans.png HTTP/1.1" 200 7473 "https://test-rapid.ensembl.org/index.html" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" "-" -/-
[112719/- - -/-=-] 193.62.193.70/- -/- -/- [23/Jan/2024:19:22:30 +0000] "GET /i/species/Birds.png HTTP/1.1" 200 5053 "https://test-rapid.ensembl.org/index.html" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" "-" -/-
```

**After:**

Notice the ips separated by the slash: the first is traffic manager, the second is the ip of the originator of the request.

```
[103021/- - -/-=-] 193.62.192.70/- -/- -/- [28/Apr/2025:16:38:30 +0000] "GET /__howsitgoing HTTP/1.0" 200 66 "-" "HTTP-Monitor/1.1" "-" -/-
[102913/- - -/-=-] 193.62.193.70/10.42.16.103 -/- -/- [28/Apr/2025:16:38:31 +0000] "GET / HTTP/1.1" 301 219 "-" "Uptime-Kuma/2.0.0-beta.1" "-" -/-
[102916/- - -/-=-] 193.62.193.70/10.42.16.103 -/- -/- [28/Apr/2025:16:38:31 +0000] "GET /index.html HTTP/1.1" 200 2067219 "-" "Uptime-Kuma/2.0.0-beta.1" "-" -/-
[103076/- - -/-=-] 193.62.193.71/- -/- -/- [28/Apr/2025:16:38:33 +0000] "GET /__howsitgoing HTTP/1.0" 200 65 "-" "HTTP-Monitor/1.1" "-" -/-
```