### PR TITLE
[115] Hide unneeded ancestral genome sequence

### DIFF
--- a/modules/EnsEMBL/Web/Command/DataExport/Output.pm
+++ b/modules/EnsEMBL/Web/Command/DataExport/Output.pm
@@ -381,7 +381,7 @@ sub write_alignment {
       else {
         $self->object->{'alignments_function'} = 'get_SimpleAlign';
 
-        $alignment = $self->object->get_alignments({
+        ($alignment) = $self->object->get_alignments({
           'slice'     => $data->slice,
           'align'     => $hub->param('align'),
           'species'   => $hub->species,

--- a/modules/EnsEMBL/Web/Object/Export.pm
+++ b/modules/EnsEMBL/Web/Object/Export.pm
@@ -513,7 +513,7 @@ sub alignment {
   
   $self->{'alignments_function'} = 'get_SimpleAlign';
   
-  my $alignments = $self->get_alignments({
+  my ($alignments) = $self->get_alignments({
                               'slice' => $self->slice,
                               'align' => $hub->param('align'), 
                               'species' => $hub->species


### PR DESCRIPTION
## Description

PR [ensembl-webcode PR 155](https://github.com/Ensembl/ensembl-webcode/pull/155) implemented functionality to "Remove the unneeded ancestral species from the sequence view".

The intended behaviour was that in ancestral alignment views (e.g. EPO), hiding all the extant genomes descending from a child of an ancestral sequence would result in that ancestral sequence also being hidden.

The most recent release with this behaviour was Ensembl 104: https://may2021.archive.ensembl.org/Homo_sapiens/Location/Compara_Alignments/Image?align=1944&db=core&r=17%3A63992802-64038237

This pull request would restore that behaviour.

## Views affected

This change would affect EPO alignments in Ensembl Vertebrates.

The following example images show the effect of the change when Mouse lemur is hidden in the Primates EPO alignment views.

Example image alignment view before change (with unneeded ancestral sequence displayed):
![primates_epo_image_alignment_before](https://github.com/user-attachments/assets/b35f4f8a-5c9d-48ec-9f45-1d3e69892413)

Example image alignment view after change:
![primates_epo_image_alignment_after](https://github.com/user-attachments/assets/98342a70-62db-4da0-bcc5-268a5f812e1d)

Example text alignment view before change (with unneeded ancestral sequence displayed):
![primates_epo_text_alignment_before](https://github.com/user-attachments/assets/546a9e40-492b-41b9-b874-445195e5fee0)

Example text alignment view after change:
![primates_epo_text_alignment_after](https://github.com/user-attachments/assets/1cb6143a-a46a-4149-9791-e001b0731488)

## Possible complications

This PR would change the return value of method `EnsEMBL::Web::Object::get_alignments` to include the relevant `$align_slice` object. All known invocations of this method have been adapted in the PR, but it's possible that other invocations of the method would need to be adapted in response to the change in this method's behaviour. 

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A