### PR TITLE
Add table to display somatic classifications from ClinVar (release 115)

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Phenotype.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Phenotype.pm
@@ -210,7 +210,7 @@ sub table_data_somatic {
     $classification = qq{$classification};
 
     my $oncogenicity = defined($pf->oncogenicity_classification) ? $pf->oncogenicity_classification : "-";
-    $oncogenicity = qq{<b>$oncogenicity</b>};
+    $oncogenicity = qq{$oncogenicity};
 
     # Review status
     my $stars = "";

--- a/modules/EnsEMBL/Web/Component/Variation/Phenotype.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Phenotype.pm
@@ -207,7 +207,7 @@ sub table_data_somatic {
     }
 
     my $classification = defined($pf->somatic_classification) ? $pf->somatic_classification : "-";
-    $classification = qq{<b>$classification</b>};
+    $classification = qq{$classification};
 
     my $oncogenicity = defined($pf->oncogenicity_classification) ? $pf->oncogenicity_classification : "-";
     $oncogenicity = qq{<b>$oncogenicity</b>};

--- a/modules/EnsEMBL/Web/Object/Variation.pm
+++ b/modules/EnsEMBL/Web/Object/Variation.pm
@@ -861,6 +861,12 @@ sub get_external_data {
   return $self->{'external_data'};
 }
 
+sub get_external_somatic_data {
+  my $self = shift;
+  $self->{'external_somatic_data'} ||= $self->hub->database('variation')->get_PhenotypeFeatureAdaptor->fetch_all_somatic_by_Variation($self->vari);
+  return $self->{'external_somatic_data'};
+}
+
 sub slice {
   my $self = shift;
 


### PR DESCRIPTION
## Description

ClinVar supports a new type of classification (somatic) that we want to display in the current website for release 115.
This change adds a new table to the variant phenotype page to display the new clinvar somatic classification.
To test the new display we have to point the ensembl-variation repo to release/115 - the API changes are already merged.

## Views affected

- EnsEMBL::Web::Component::Variation::Phenotype
- EnsEMBL::Web::Object::Variation

Testing the affected page on the sandbox: http://wp-np2-33.ebi.ac.uk:7040/Homo_sapiens/Variation/Phenotype?db=core;r=13:48459208-48460208;v=rs137853294;vdb=variation;vf=813845583

## Possible complications

This change should only affect the variant phenotype page.

## Merge conflicts

No merge conflicts

## Related JIRA Issues (EBI developers only)

Update ClinVar (main ticket): [ENSVAR-5941](https://embl.atlassian.net/browse/ENSVAR-5941)
Update the web code: [ENSVAR-6659](https://embl.atlassian.net/browse/ENSVAR-6659)
