### PR TITLE
Tweak phylogenetic context view

### DIFF
--- a/modules/EnsEMBL/Web/Component/Variation/Compara_Alignments.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Compara_Alignments.pm
@@ -105,16 +105,16 @@ sub content {
   my $html;
  
   my $slice = $self->_get_slice($object);   
-  my $align = $hub->get_alignment_id;
-  my $alert = $self->check_for_align_problems({
+  my ($align) = split '--', $hub->get_alignment_id;
+  my ($alert_box, $error) = $self->check_for_align_problems({
                                                 'align'   => $align,
-                                                'species' => $species,
+                                                'species' => $hub->species_defs->SPECIES_PRODUCTION_NAME,
                                                 'slice'   => $slice,
                                                 'ignore'  => 'ancestral_sequences',
                                               });
-  
-  $html .= $alert if $alert;
- 
+  return $alert_box if $error;
+  $html .= $alert_box if $alert_box;
+
   # Get all slices for the gene
   my ($slices, $slice_length) = $self->object->get_slices({
                                     'slice'   => $slice, 
@@ -123,9 +123,11 @@ sub content {
                                 });
   my ($info, @aligned_slices, %non_aligned_slices, %no_variation_slices, $ancestral_seq);
 
+  my $lookup = $species_defs->prodnames_to_urls_lookup;
   foreach my $s (@$slices) {
-    my $other_species_dbs = $species_defs->get_config($s->{'name'}, 'databases');
-    my $name              = $species_defs->species_label($s->{'name'});
+    my $species_url       = $s->{'name'} eq 'ancestral_sequences' ? 'Multi' : $lookup->{$s->{'name'}};
+    my $other_species_dbs = $species_defs->get_config($species_url, 'databases');
+    my $name              = $species_defs->species_label($species_url);
     
     if ($s->{'name'} eq 'ancestral_sequences') {
       $ancestral_seq = $name;


### PR DESCRIPTION
## Description

This PR makes two adjustments to the variant phylogenetic context view:
- the return value of `check_for_align_problems` is handled more consistently with other alignment views;
- handling of species production names and URLs is adjusted to ensure the correct value is passed to methods such as `check_for_align_problems` and `species_label`.

## Views affected

This PR affects the variant phylogenetic context view in the following ways:
- **A**: the stray number `1` is removed;
- **B**: neighbouring variants are now shown;
- **C**: the list of genomes lacking a variation database is fixed.

Example view before changes:
![e114_phylo_context_view_before](https://github.com/user-attachments/assets/db67d727-58b4-4c27-81d7-dc45bb185a9a)

Example view after changes:
![e114_phylo_context_view_after](https://github.com/user-attachments/assets/40626b71-69bc-4abe-8081-fd766bffc398)

## Possible complications

None expected, because changes are made only to `EnsEMBL::Web::Component::Variation::Compara_Alignments`. 

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
