### PR TITLE
Deactivate scale-dependent track config in Vertebrates

### DIFF
--- a/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
+++ b/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
@@ -80,10 +80,6 @@ sub content {
   my $i               = 1;
   my (@images, $html);
 
-  if ($align_details->{'type'} eq 'CACTUS_DB') {
-    $html .= $self->show_scale_dependent_track_info_box($align_details);
-  }
-  
   my ($caption_height,$caption_img_offset) = (0,-24);
   my $lookup = $species_defs->prodnames_to_urls_lookup;
   foreach (@$slices) {

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -567,48 +567,6 @@ sub add_genes {
     # overwriting Genes comprehensive track description to not be the big concatenation of many description (only gencode gene track)
     $self->modify_configs(['transcript_core_ensembl'],{ description => 'The <a class="popup" href="/Help/Glossary?id=487">GENCODE Comprehensive</a> set is the gene set for human and mouse' });
   }
-
-  # If this is an alignslice track in a large-scale CACTUS_DB alignment
-  # view, disable selected tracks in order to reduce load times.
-  if ($self->type eq 'alignsliceviewbottom') {
-
-    my $align_id = exists $self->hub->referer->{'params'}{'align'}
-                 ? $self->hub->referer->{'params'}{'align'}[0]
-                 : $self->hub->get_alignment_id
-                 ;
-
-    if ($align_id) {
-      my $align_details = $self->species_defs->multi_hash->{'DATABASE_COMPARA'}->{'ALIGNMENTS'}->{$align_id};
-      if ($align_details->{'type'} eq 'CACTUS_DB' && exists $align_details->{'as_track_threshold_data'}) {
-        my $location_param = $self->hub->referer->{'params'}{'r'}[0];
-
-        my $location_length;
-        if ($location_param =~ /^[\w\.\-]+:(\d+)\-(\d+)$/) {  # region pattern from MetaKeyFormat datacheck
-          $location_length = abs($2 - $1) + 1;
-        } else {
-          $location_length = 1;  # This should never happen, but if it does, we revert to default behaviour.
-        }
-
-        my $as_track_thresholds = $align_details->{'as_track_threshold_data'};
-        if (exists $as_track_thresholds->{'transcript'} && $location_length >= $as_track_thresholds->{'transcript'}) {
-
-          my $transcript_node_ids = $self->species_defs->get_config($species, 'GENCODE_VERSION')
-                                  ? ['gencode_primary', 'transcript']
-                                  : ['transcript']
-                                  ;
-
-          # At large scales, disable transcript tracks.
-          $self->modify_configs($transcript_node_ids, { 'display' => 'off' });
-
-          if (exists $as_track_thresholds->{'sequence'} && $location_length >= $as_track_thresholds->{'sequence'}) {
-            # At larger scales still, disable sequence tracks.
-            $self->modify_configs(['sequence'], { 'display' => 'off' });
-          }
-        }
-      }
-    }
-  }
-
 }
 
 sub add_trans_associated {


### PR DESCRIPTION
## Description

In conjunction with an `eg-web-common` PR, this PR would make scale-dependent track config code apply only to Non-Vertebrate `CACTUS_DB` alignments.

It would:
- remove the scale-dependent track config code from the `add_genes` method of the `EnsEMBL::Web::ImageConfigExtension::Tracks` module; and
- remove the invocation of `show_scale_dependent_track_info_box` from the `EnsEMBL::Web::Component::Location::Compara_AlignSliceBottom` module.

This is being proposed due to consistency issues with display of `CACTUS_DB` image alignment views in Vertebrates, which had not been encountered by the staging-site testing done earlier in the release process.

## Views affected

This change would affect the Primates and Rodents `CACTUS_DB` image alignment views.

## Possible complications

The main possible complication is that some regions of the alignment may have excessive load times.

Mitigating factors include:
- more recent testing encountering acceptable load times for tested regions;
- no errors being encountered when loading image alignment views of the tested regions.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

...