### PR TITLE
Switch to local policy pages

### DIFF
--- a/htdocs/info/about/legal/policy/ensembl-1000g-browsing.html
+++ b/htdocs/info/about/legal/policy/ensembl-1000g-browsing.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="index" content="NO INDEX" />
+<title>Privacy notice for ensembl-1000g-browsing | EMBL-EBI</title>
+</head>
+
+<body>
+<a href="../privacy.html">Back</a>
+<h1>Privacy notice for ensembl-1000g-browsing</h1>
+<p>This Privacy notice explains what personal data is collected by the specific EMBL-EBI service you are requesting, for what purposes, how it is processed, and how we keep it secure.</p>
+<h3 >Who controls your personal data and how to contact us?</h3>
+<p>The EMBL data controller's contact details are:</p>
+<p >
+Rolf Apweiler and Ewan Birney, EMBL-EBI Directors<br>
+Email:  data-controller@ebi.ac.uk<br>
+EMBL-EBI, Wellcome Genome Campus, CB10 1SD Hinxton, Cambridgeshire, UK.
+</p>
+<p>The EMBL Data Protection Officer's contact details are:</p>
+<p >
+EMBL Data Protection Officer<br>
+Email: dpo@embl.org<br>
+EMBL Heidelberg, Meyerhofstraße 1, 69117 Heidelberg, Germany
+</p>
+<h3 >Which is the lawful basis for processing your personal data?</h3>
+<p>Processing your personal data is necessary for our legitimate interest of allowing the day-to-day management, operation and functioning of EMBL. </p>
+<h3 >What personal data do we collect? How do we use this personal data?</h3>
+<p>We collect the following personal data: </p>
+<ul>
+<li>IP addresses</li>
+<li>Date and time of a visit to the service website</li>
+<li>Operating system</li>
+<li>Amount of data transmitted</li>
+<li>Browser</li>
+</ul>
+
+<p>We will use the personal data: </p>
+
+<ul>
+<li>To better understand the needs of the users and guide future improvements of the service</li>
+<li>To check that the Terms of Use of the service are followed</li>
+<li>To conduct and monitor data protection activities</li>
+<li>To create anonymous usage statistics</li>
+<li>To conduct and monitor security activities</li>
+</ul>
+
+<h3>Who will have access to your personal data?</h3>
+<p>The personal data will be disclosed to: </p>
+<ul>
+<li >Authorised EMBL-EBI staff.</li>
+</ul>
+
+<h3 >Will your personal data be transferred to third countries (i.e. countries not part of EU/EAA) and/or international organisations?</h3>
+<p>There are no personal data transfers to third countries or to international organisations.</p>
+<h3 >How long do we keep your personal data?</h3>
+<p>Any personal data directly obtained from you will be retained as long as the service is live, even if you stop using the service. We will keep the personal data for the minimum amount of time possible to ensure legal compliance and to facilitate internal and external audits if they arise. </p>
+<h3 >Your rights regarding your personal data</h3>
+<p>You have the right to:</p>
+<ol >
+<li >Not be subject to decisions based solely on an automated processing of data (i.e. without human intervention) without you having your views taken into consideration.</li>
+<li >Request at reasonable intervals and without excessive delay or expense, information about the personal data processed about you. Under your request we will inform you in writing about, for example, the origin of the personal data or the preservation period.</li>
+<li >Request information to understand data processing activities when the results of these activities are applied to you.</li>
+<li >Object at any time to the processing of your personal data unless we can demonstrate that we have legitimate reasons to process your personal data.</li>
+<li >Request free of charge and without excessive delay rectification or erasure of your personal data if we have not been processing it respecting the EMBL Internal Policy for Data Protection.</li>
+</ol>
+<p>It must be clarified that rights 4 and 5 are only available whenever the processing of your personal data is not necessary to:</p>
+<ol >
+<li >Comply with a legal obligation.</li>
+<li >Perform a task carried out in the public interest.</li>
+<li >Exercise authority as a data controller.</li>
+<li >Archive for purposes in the public interest, or for historical research purposes, or for statistical purposes.</li>
+<li >Establish, exercise or defend legal claims.</li>
+</ol>
+</body>
+</html>

--- a/htdocs/info/about/legal/policy/ensembl-1000g-contact.html
+++ b/htdocs/info/about/legal/policy/ensembl-1000g-contact.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="index" content="NO INDEX" />
+<title>Privacy notice for ensembl-1000g-contact | EMBL-EBI</title>
+</head>
+
+<body>
+<a href="../privacy.html">Back</a>
+<h1>Privacy notice for ensembl-1000g-contact</h1>
+<p>This Privacy notice explains what personal data is collected by the specific EMBL-EBI service you are requesting, for what purposes, how it is processed, and how we keep it secure.</p>
+<h3 >Who controls your personal data and how to contact us?</h3>
+<p>The EMBL data controller's contact details are:</p>
+<p>
+Rolf Apweiler and Ewan Birney, EMBL-EBI Directors<br>
+Email:  data-controller@ebi.ac.uk<br>
+EMBL-EBI, Wellcome Genome Campus, CB10 1SD Hinxton, Cambridgeshire, UK.
+</p>
+<p>The EMBL Data Protection Officer's contact details are:</p>
+<p >
+EMBL Data Protection Officer<br>
+Email: dpo@embl.org<br>
+EMBL Heidelberg, Meyerhofstraße 1, 69117 Heidelberg, Germany
+</p>
+<h3 >Which is the lawful basis for processing your personal data?</h3>
+<p>Processing your personal data is necessary for our legitimate interest of delivering a service that provides broader societal benefits. </p>
+<h3 >What personal data do we collect? How do we use this personal data?</h3>
+<p>We collect the following personal data: </p>
+<ul>
+<li>Name</li>
+<li>Email address</li>
+<li>IP addresses</li>
+<li>Date and time when the support request was sent</li>
+</ul>
+
+<p>We will use the personal data: </p>
+
+<ul>
+<li>To provide the user access to the service</li>
+<li>To check that the Terms of Use of the service are followed</li>
+<li>To conduct and monitor data protection activities</li>
+<li>To create anonymous usage statistics</li>
+<li>To conduct and monitor security activities</li>
+</ul>
+
+<h3 >Who will have access to your personal data?</h3>
+<p>The personal data will be disclosed to: </p>
+<ul >
+<li >Authorised EMBL-EBI staff.</li>
+</ul>
+<h3 >Will your personal data be transferred to third countries (i.e. countries not part of EU/EAA) and/or international organisations?</h3>
+<p>There are no personal data transfers to third countries or to international organisations.</p>
+<h3 >How long do we keep your personal data?</h3>
+<p>Any personal data directly obtained from you will be retained even if the service is withdrawn. We will keep the personal data for the minimum amount of time possible to ensure legal compliance and to facilitate internal and external audits if they arise. </p>
+<h3 >Your rights regarding your personal data</h3>
+<p>You have the right to:</p>
+<ol>
+<li>Not be subject to decisions based solely on an automated processing of data (i.e. without human intervention) without you having your views taken into consideration.</li>
+<li>Request at reasonable intervals and without excessive delay or expense, information about the personal data processed about you. Under your request we will inform you in writing about, for example, the origin of the personal data or the preservation period.</li>
+<li>Request information to understand data processing activities when the results of these activities are applied to you.</li>
+<li>Object at any time to the processing of your personal data unless we can demonstrate that we have legitimate reasons to process your personal data.</li>
+<li>Request free of charge and without excessive delay rectification or erasure of your personal data if we have not been processing it respecting the EMBL Internal Policy for Data Protection.</li>
+</ol>
+
+<p>It must be clarified that rights 4 and 5 are only available whenever the processing of your personal data is not necessary to:</p>
+<ol >
+<li >Comply with a legal obligation.</li>
+<li >Perform a task carried out in the public interest.</li>
+<li >Exercise authority as a data controller.</li>
+<li >Archive for purposes in the public interest, or for historical research purposes, or for statistical purposes.</li>
+<li >Establish, exercise or defend legal claims.</li>
+</ol>
+</body>
+</html>

--- a/htdocs/info/about/legal/policy/ensembl-contact-signup.html
+++ b/htdocs/info/about/legal/policy/ensembl-contact-signup.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="index" content="NO INDEX" />
+<title>Privacy notice for ensembl-contact-signup | EMBL-EBI</title>
+</head>
+
+<body>
+<a href="../privacy.html">Back</a>
+<h1>Privacy notice for ensembl-contact-signup</h2>
+<p>This Privacy notice explains what personal data is collected by the specific EMBL-EBI service you are requesting, for what purposes, how it is processed, and how we keep it secure.</p>
+<h3 >Who controls your personal data and how to contact us?</h3>
+<p>The EMBL data controller's contact details are:</p>
+<p>
+Rolf Apweiler and Ewan Birney, EMBL-EBI Directors<br>
+Email:  data-controller@ebi.ac.uk<br>
+EMBL-EBI, Wellcome Genome Campus, CB10 1SD Hinxton, Cambridgeshire, UK.
+</p>
+<p>The EMBL Data Protection Officer's contact details are:</p>
+<p >
+EMBL Data Protection Officer<br>
+Email: dpo@embl.org<br>
+EMBL Heidelberg, Meyerhofstraße 1, 69117 Heidelberg, Germany
+</p>
+<h3>Which is the lawful basis for processing your personal data?</h3>
+<p>We need your consent to process your personal data. If you do not consent to us processing your personal data, we will not be able to provide you access to the service or we will only provide you a subset of functionalities available within the service.</p>
+<h3>What personal data do we collect? How do we use this personal data?</h3>
+<p>We collect the following personal data: </p>
+
+<ul>
+<li>Name</li>
+<li>Email address</li>
+</ul>
+
+<p>We will use the personal data: </p>
+<ul>
+<li>To provide the user access to the service</li>
+<li>To better understand the needs of the users and guide future improvements of the service</li>
+</ul>
+
+<h3 >Who will have access to your personal data?</h3>
+<p>The personal data will be disclosed to: </p>
+<ul >
+<li >Authorised EMBL-EBI staff.</li>
+</ul>
+<h3 >Will your personal data be transferred to third countries (i.e. countries not part of EU/EAA) and/or international organisations?</h3>
+<p>There are no personal data transfers to third countries or to international organisations.</p>
+
+<h3 >How long do we keep your personal data?</h3>
+<p>Any personal data directly obtained from you will be retained as long as the service is live, even if you stop using the service. We will keep the personal data for the minimum amount of time possible to ensure legal compliance and to facilitate internal and external audits if they arise. </p>
+<h3 >Your rights regarding your personal data</h3>
+<p>You have the right to:</p>
+<ol>
+<li >Not be subject to decisions based solely on an automated processing of data (i.e. without human intervention) without you having your views taken into consideration.</li>
+<li >Request at reasonable intervals and without excessive delay or expense, information about the personal data processed about you. Under your request we will inform you in writing about, for example, the origin of the personal data or the preservation period.</li>
+<li >Request information to understand data processing activities when the results of these activities are applied to you.</li>
+<li >Object at any time to the processing of your personal data unless we can demonstrate that we have legitimate reasons to process your personal data.</li>
+<li >Request free of charge and without excessive delay rectification or erasure of your personal data if we have not been processing it respecting the EMBL Internal Policy for Data Protection.</li>
+</ol>
+<p>It must be clarified that rights 4 and 5 are only available whenever the processing of your personal data is not necessary to:</p>
+<ol>
+<li >Comply with a legal obligation.</li>
+<li >Perform a task carried out in the public interest.</li>
+<li >Exercise authority as a data controller.</li>
+<li >Archive for purposes in the public interest, or for historical research purposes, or for statistical purposes.</li>
+<li >Establish, exercise or defend legal claims.</li>
+</ol>
+</body>
+</html>

--- a/htdocs/info/about/legal/policy/ensembl-embassy-accounts.html
+++ b/htdocs/info/about/legal/policy/ensembl-embassy-accounts.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="index" content="NO INDEX" />
+<title>Privacy notice for ensembl-embassy-accounts | EMBL-EBI</title>
+</head>
+
+<body>
+<a href="../privacy.html">Back</a>
+<h1>Privacy notice for ensembl-embassy-accounts</h1>
+<p>This Privacy notice explains what personal data is collected by the specific EMBL-EBI service you are requesting, for what purposes, how it is processed, and how we keep it secure.</p>
+<h3 >Who controls your personal data and how to contact us?</h3>
+<p>The EMBL data controller's contact details are:</p>
+<p >
+Rolf Apweiler and Ewan Birney, EMBL-EBI Directors<br>
+Email:  data-controller@ebi.ac.uk<br>
+EMBL-EBI, Wellcome Genome Campus, CB10 1SD Hinxton, Cambridgeshire, UK.
+</p>
+<p>The EMBL Data Protection Officer's contact details are:</p>
+<p >
+EMBL Data Protection Officer<br>
+Email: dpo@embl.org<br>
+EMBL Heidelberg, Meyerhofstraße 1, 69117 Heidelberg, Germany
+</p>
+<h3 >Which is the lawful basis for processing your personal data?</h3>
+<p>We need your consent to process your personal data. If you do not consent to us processing your personal data, we will not be able to provide you access to the service or we will only provide you a subset of functionalities available within the service.</p>
+<h3 >What personal data do we collect? How do we use this personal data?</h3>
+<p>We collect the following personal data: </p>
+
+<ul>
+<li>Name</li>
+<li>Email address</li>
+<li>Username</li>
+<li>Password</li>
+<li>Organisation</li>
+<li>Date and time of a visit to the service website</li>
+</ul>
+
+<p>We will use the personal data: </p>
+
+<ul>
+<li>To provide the user access to the service</li>
+<li>To authenticate the user</li>
+<li>To create anonymous usage statistics</li>
+</ul>
+
+<h3 >Who will have access to your personal data?</h3>
+<p>The personal data will be disclosed to: </p>
+<ul>
+<li>Authorised EMBL-EBI staff.</li>
+</ul>
+
+<h3 >Will your personal data be transferred to third countries (i.e. countries not part of EU/EAA) and/or international organisations?</h3>
+<p>There are no personal data transfers to third countries or to international organisations.</p>
+
+<h3 >How long do we keep your personal data?</h3>
+<p>Any personal data directly obtained from you will be retained as long as the service is live, even if you stop using the service. We will keep the personal data for the minimum amount of time possible to ensure legal compliance and to facilitate internal and external audits if they arise. </p>
+
+<h3 >Your rights regarding your personal data</h3>
+<p>You have the right to:</p>
+<ol>
+<li>Not be subject to decisions based solely on an automated processing of data (i.e. without human intervention) without you having your views taken into consideration.</li>
+<li>Request at reasonable intervals and without excessive delay or expense, information about the personal data processed about you. Under your request we will inform you in writing about, for example, the origin of the personal data or the preservation period.</li>
+<li>Request information to understand data processing activities when the results of these activities are applied to you.</li>
+<li>Object at any time to the processing of your personal data unless we can demonstrate that we have legitimate reasons to process your personal data.</li>
+<li>Request free of charge and without excessive delay rectification or erasure of your personal data if we have not been processing it respecting the EMBL Internal Policy for Data Protection.</li>
+</ol>
+<p>It must be clarified that rights 4 and 5 are only available whenever the processing of your personal data is not necessary to:</p>
+<ol>
+<li>Comply with a legal obligation.</li>
+<li>Perform a task carried out in the public interest.</li>
+<li>Exercise authority as a data controller.</li>
+<li>Archive for purposes in the public interest, or for historical research purposes, or for statistical purposes.</li>
+<li>Establish, exercise or defend legal claims.</li>
+</ol>
+</body>
+</html>

--- a/htdocs/info/about/legal/policy/ensembl-embassy-browsing.html
+++ b/htdocs/info/about/legal/policy/ensembl-embassy-browsing.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="index" content="NO INDEX" />
+<title>Privacy notice for ensembl-embassy-browsing | EMBL-EBI</title>
+</head>
+
+<body>
+<a href="../privacy.html">Back</a>
+<h1>Privacy notice for ensembl-embassy-browsing</h1>
+<p>This Privacy notice explains what personal data is collected by the specific EMBL-EBI service you are requesting, for what purposes, how it is processed, and how we keep it secure.</p>
+<h3 >Who controls your personal data and how to contact us?</h3>
+<p>The EMBL data controller's contact details are:</p>
+<p>
+Rolf Apweiler and Ewan Birney, EMBL-EBI Directors<br>
+Email:  data-controller@ebi.ac.uk<br>
+EMBL-EBI, Wellcome Genome Campus, CB10 1SD Hinxton, Cambridgeshire, UK.
+</p>
+<p>The EMBL Data Protection Officer's contact details are:</p>
+<p>
+EMBL Data Protection Officer<br>
+Email: dpo@embl.org<br>
+EMBL Heidelberg, Meyerhofstraße 1, 69117 Heidelberg, Germany
+</p>
+<h3 >Which is the lawful basis for processing your personal data?</h3>
+<p>Processing your personal data is necessary for our legitimate interest of allowing the day-to-day management, operation and functioning of EMBL. </p>
+<h3 >What personal data do we collect? How do we use this personal data?</h3>
+<p>We collect the following personal data: </p>
+<ul>
+<li>IP addresses</li>
+<li>Date and time of a visit to the service website</li>
+<li>Operating system</li>
+<li>Browser</li>
+</ul>
+
+<p>We will use the personal data: </p>
+
+<ul>
+<li>To provide the user access to the service</li>
+<li>To check that the Terms of Use of the service are followed</li>
+<li>To conduct and monitor data protection activities</li>
+<li>To create anonymous usage statistics</li>
+<li>To conduct and monitor security activities</li>
+</ul>
+
+<h3>Who will have access to your personal data?</h3>
+<p>The personal data will be disclosed to: </p>
+<ul>
+<li >Authorised EMBL-EBI staff.</li>
+</ul>
+
+<h3 >Will your personal data be transferred to third countries (i.e. countries not part of EU/EAA) and/or international organisations?</h3>
+<p>There are no personal data transfers to third countries or to international organisations.</p>
+
+<h3 >How long do we keep your personal data?</h3>
+<p>Any personal data directly obtained from you will be retained as long as the service is live, even if you stop using the service. We will keep the personal data for the minimum amount of time possible to ensure legal compliance and to facilitate internal and external audits if they arise. </p>
+<p>We will anonymise our web logs by removing the recorded IP address after 30 days. We will retain relevant security logs for 90 days</p>
+<p>Access to the web and security logs containing personal data are restricted to the relevant EMBL-EBI staff</p>
+
+<h3 >Your rights regarding your personal data</h3>
+<p>You have the right to:</p>
+<ol>
+<li >Not be subject to decisions based solely on an automated processing of data (i.e. without human intervention) without you having your views taken into consideration.</li>
+<li >Request at reasonable intervals and without excessive delay or expense, information about the personal data processed about you. Under your request we will inform you in writing about, for example, the origin of the personal data or the preservation period.</li>
+<li >Request information to understand data processing activities when the results of these activities are applied to you.</li>
+<li >Object at any time to the processing of your personal data unless we can demonstrate that we have legitimate reasons to process your personal data.</li>
+<li >Request free of charge and without excessive delay rectification or erasure of your personal data if we have not been processing it respecting the EMBL Internal Policy for Data Protection.</li>
+</ol>
+
+<p>It must be clarified that rights 4 and 5 are only available whenever the processing of your personal data is not necessary to:</p>
+<ol>
+<li>Comply with a legal obligation.</li>
+<li>Perform a task carried out in the public interest.</li>
+<li>Exercise authority as a data controller.</li>
+<li>Archive for purposes in the public interest, or for historical research purposes, or for statistical purposes.</li>
+<li>Establish, exercise or defend legal claims.</li>
+</ol>
+</body>
+</html>

--- a/htdocs/info/about/legal/policy/ensembl-embassy-mart.html
+++ b/htdocs/info/about/legal/policy/ensembl-embassy-mart.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="index" content="NO INDEX" />
+<title>Privacy notice for ensembl-embassy-mart | EMBL-EBI</title>
+</head>
+
+<body>
+<a href="../privacy.html">Back</a>
+<h1>Privacy notice for ensembl-embassy-mart</h1>
+<p>This Privacy notice explains what personal data is collected by the specific EMBL-EBI service you are requesting, for what purposes, how it is processed, and how we keep it secure.</p>
+<h3 >Who controls your personal data and how to contact us?</h3>
+<p>The EMBL data controller's contact details are:</p>
+<p>
+Rolf Apweiler and Ewan Birney, EMBL-EBI Directors<br>
+Email:  data-controller@ebi.ac.uk<br>
+EMBL-EBI, Wellcome Genome Campus, CB10 1SD Hinxton, Cambridgeshire, UK.
+</p>
+<p>The EMBL Data Protection Officer's contact details are:</p>
+<p >
+EMBL Data Protection Officer<br>
+Email: dpo@embl.org<br>
+EMBL Heidelberg, Meyerhofstraße 1, 69117 Heidelberg, Germany
+</p>
+<h3 >Which is the lawful basis for processing your personal data?</h3>
+<p>Processing your personal data is necessary for our legitimate interest of delivering a service that provides broader societal benefits. </p>
+<h3 >What personal data do we collect? How do we use this personal data?</h3>
+<p>We collect the following personal data: </p>
+<ul>
+<li>Email address</li>
+<li>Date and time of a visit to the service website</li>
+</ul>
+
+<p>We will use the personal data: </p>
+
+<ul>
+<li>To provide the user access to the service</li>
+<li>To check that the Terms of Use of the service are followed</li>
+<li>To conduct and monitor data protection activities</li>
+<li>To create anonymous usage statistics</li>
+<li>To conduct and monitor security activities</li>
+</ul>
+
+<h3 >Who will have access to your personal data?</h3>
+<p>The personal data will be disclosed to: </p>
+<ul>
+<li >Authorised EMBL-EBI staff.</li>
+</ul>
+
+<h3 >Will your personal data be transferred to third countries (i.e. countries not part of EU/EAA) and/or international organisations?</h3>
+<p>There are no personal data transfers to third countries or to international organisations.</p>
+
+<h3 >How long do we keep your personal data?</h3>
+<p>Any personal data directly obtained from you will be retained for as long as you make use of the service. </p>
+<p>email addresses and IPs are kept for 12h and then deleted</p>
+
+<h3 >Your rights regarding your personal data</h3>
+<p>You have the right to:</p>
+<ol>
+<li >Not be subject to decisions based solely on an automated processing of data (i.e. without human intervention) without you having your views taken into consideration.</li>
+<li >Request at reasonable intervals and without excessive delay or expense, information about the personal data processed about you. Under your request we will inform you in writing about, for example, the origin of the personal data or the preservation period.</li>
+<li >Request information to understand data processing activities when the results of these activities are applied to you.</li>
+<li >Object at any time to the processing of your personal data unless we can demonstrate that we have legitimate reasons to process your personal data.</li>
+<li >Request free of charge and without excessive delay rectification or erasure of your personal data if we have not been processing it respecting the EMBL Internal Policy for Data Protection.</li>
+</ol>
+<p>It must be clarified that rights 4 and 5 are only available whenever the processing of your personal data is not necessary to:</p>
+<ol>
+<li >Comply with a legal obligation.</li>
+<li >Perform a task carried out in the public interest.</li>
+<li >Exercise authority as a data controller.</li>
+<li >Archive for purposes in the public interest, or for historical research purposes, or for statistical purposes.</li>
+<li >Establish, exercise or defend legal claims.</li>
+</ol>
+</body>
+</html>

--- a/htdocs/info/about/legal/policy/ensembl-mailing-lists.html
+++ b/htdocs/info/about/legal/policy/ensembl-mailing-lists.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="index" content="NO INDEX" />
+<title>Privacy notice for ensembl-mailing-lists | EMBL-EBI</title>
+</head>
+
+<body>
+<a href="../privacy.html">Back</a>
+<h1>Privacy notice for ensembl-mailing-lists</h1>
+<p>This Privacy notice explains what personal data is collected by the specific EMBL-EBI service you are requesting, for what purposes, how it is processed, and how we keep it secure.</p>
+<h3 >Who controls your personal data and how to contact us?</h3>
+<p>The EMBL data controller's contact details are:</p>
+<p >
+Rolf Apweiler and Ewan Birney, EMBL-EBI Directors<br>
+Email:  data-controller@ebi.ac.uk<br>
+EMBL-EBI, Wellcome Genome Campus, CB10 1SD Hinxton, Cambridgeshire, UK.
+</p>
+<p>The EMBL Data Protection Officer's contact details are:</p>
+<p >
+EMBL Data Protection Officer<br>
+Email: dpo@embl.org<br>
+EMBL Heidelberg, Meyerhofstraße 1, 69117 Heidelberg, Germany
+</p>
+<h3 >Which is the lawful basis for processing your personal data?</h3>
+<p>Processing your personal data is necessary for our legitimate interest of delivering a service that provides broader societal benefits. </p>
+<h3 >What personal data do we collect? How do we use this personal data?</h3>
+<p>We collect the following personal data: </p>
+<ul>
+<li>Name</li>
+<li>Email address</li>
+</ul>
+<p>We will use the personal data: </p>
+<ul>
+<li>To provide the user access to the service</li>
+</ul>
+
+<h3 >Who will have access to your personal data?</h3>
+<p>The personal data will be disclosed to: </p>
+<ul >
+<li >The general public. </li>
+<li >Authorised EMBL-EBI staff.</li>
+</ul>
+<h3 >Will your personal data be transferred to third countries (i.e. countries not part of EU/EAA) and/or international organisations?</h3>
+<p>There are no personal data transfers to third countries or to international organisations.</p>
+<h3 >How long do we keep your personal data?</h3>
+<p>Any personal data directly obtained from you will be retained even if the service is withdrawn. We will keep the personal data for the minimum amount of time possible to ensure legal compliance and to facilitate internal and external audits if they arise. </p>
+<h3 >Your rights regarding your personal data</h3>
+<p>You have the right to:</p>
+<ol>
+<li>Not be subject to decisions based solely on an automated processing of data (i.e. without human intervention) without you having your views taken into consideration.</li>
+<li>Request at reasonable intervals and without excessive delay or expense, information about the personal data processed about you. Under your request we will inform you in writing about, for example, the origin of the personal data or the preservation period.</li>
+<li>Request information to understand data processing activities when the results of these activities are applied to you.</li>
+<li>Object at any time to the processing of your personal data unless we can demonstrate that we have legitimate reasons to process your personal data.</li>
+<li>Request free of charge and without excessive delay rectification or erasure of your personal data if we have not been processing it respecting the EMBL Internal Policy for Data Protection.</li>
+</ol>
+<p>It must be clarified that rights 4 and 5 are only available whenever the processing of your personal data is not necessary to:</p>
+<ol>
+<li>Comply with a legal obligation.</li>
+<li>Perform a task carried out in the public interest.</li>
+<li>Exercise authority as a data controller.</li>
+<li>Archive for purposes in the public interest, or for historical research purposes, or for statistical purposes.</li>
+<li>Establish, exercise or defend legal claims.</li>
+</ol>
+</body>
+</html>

--- a/htdocs/info/about/legal/policy/ensembl-mirrors-accounts.html
+++ b/htdocs/info/about/legal/policy/ensembl-mirrors-accounts.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="index" content="NO INDEX" />
+<title>Privacy notice for ensembl-mirrors-accounts | EMBL-EBI</title>
+</head>
+
+<body>
+<a href="../privacy.html">Back</a>
+<h1>Privacy notice for ensembl-mirrors-accounts</h1>
+<p>This Privacy notice explains what personal data is collected by the specific EMBL-EBI service you are requesting, for what purposes, how it is processed, and how we keep it secure.</p>
+<h3 >Who controls your personal data and how to contact us?</h3>
+<p>The EMBL data controller's contact details are:</p>
+<p>
+Rolf Apweiler and Ewan Birney, EMBL-EBI Directors<br>
+Email:  data-controller@ebi.ac.uk<br>
+EMBL-EBI, Wellcome Genome Campus, CB10 1SD Hinxton, Cambridgeshire, UK.
+</p>
+<p>The EMBL Data Protection Officer's contact details are:</p>
+<p>
+EMBL Data Protection Officer<br>
+Email: dpo@embl.org<br>
+EMBL Heidelberg, Meyerhofstraße 1, 69117 Heidelberg, Germany
+</p>
+<h3 >Which is the lawful basis for processing your personal data?</h3>
+<p>We need your consent to process your personal data. If you do not consent to us processing your personal data, we will not be able to provide you access to the service or we will only provide you a subset of functionalities available within the service.</p>
+<h3 >What personal data do we collect? How do we use this personal data?</h3>
+<p>We collect the following personal data: </p>
+
+<ul>
+<li>Name</li>
+<li>Email address</li>
+<li>Username</li>
+<li>Password</li>
+<li>Organisation</li>
+<li>Date and time of a visit to the service website</li>
+</ul>
+
+<p>We will use the personal data: </p>
+<ul>
+<li>To provide the user access to the service</li>
+<li>To authenticate the user</li>
+<li>To create anonymous usage statistics</li>
+</ul>
+
+<h3 >Who will have access to your personal data?</h3>
+<p>The personal data will be disclosed to: </p>
+<ul >
+<li >Authorised EMBL-EBI staff.</li>
+</ul>
+<h3 >Will your personal data be transferred to third countries (i.e. countries not part of EU/EAA) and/or international organisations?</h3>
+<p>There are no personal data transfers to third countries or to international organisations.</p>
+<h3 >How long do we keep your personal data?</h3>
+<p>Any personal data directly obtained from you will be retained as long as the service is live, even if you stop using the service. We will keep the personal data for the minimum amount of time possible to ensure legal compliance and to facilitate internal and external audits if they arise. </p>
+<h3>Your rights regarding your personal data</h3>
+<p>You have the right to:</p>
+<ol>
+<li >Not be subject to decisions based solely on an automated processing of data (i.e. without human intervention) without you having your views taken into consideration.</li>
+<li >Request at reasonable intervals and without excessive delay or expense, information about the personal data processed about you. Under your request we will inform you in writing about, for example, the origin of the personal data or the preservation period.</li>
+<li >Request information to understand data processing activities when the results of these activities are applied to you.</li>
+<li >Object at any time to the processing of your personal data unless we can demonstrate that we have legitimate reasons to process your personal data.</li>
+<li >Request free of charge and without excessive delay rectification or erasure of your personal data if we have not been processing it respecting the EMBL Internal Policy for Data Protection.</li>
+</ol>
+<p>It must be clarified that rights 4 and 5 are only available whenever the processing of your personal data is not necessary to:</p>
+<ol>
+<li >Comply with a legal obligation.</li>
+<li >Perform a task carried out in the public interest.</li>
+<li >Exercise authority as a data controller.</li>
+<li >Archive for purposes in the public interest, or for historical research purposes, or for statistical purposes.</li>
+<li >Establish, exercise or defend legal claims.</li>
+</ol>
+</body>
+</html>

--- a/htdocs/info/about/legal/policy/ensembl-mirrors-browsing.html
+++ b/htdocs/info/about/legal/policy/ensembl-mirrors-browsing.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="index" content="NO INDEX" />
+<title>Privacy notice for ensembl-mirrors-browsing | EMBL-EBI</title>
+</head>
+
+<body>
+<a href="../privacy.html">Back</a>
+<h1>Privacy notice for ensembl-mirrors-browsing</h1>
+<p>This Privacy notice explains what personal data is collected by the specific EMBL-EBI service you are requesting, for what purposes, how it is processed, and how we keep it secure.</p>
+<h3 >Who controls your personal data and how to contact us?</h3>
+<p>The EMBL data controller's contact details are:</p>
+<p>
+Rolf Apweiler and Ewan Birney, EMBL-EBI Directors<br>
+Email:  data-controller@ebi.ac.uk<br>
+EMBL-EBI, Wellcome Genome Campus, CB10 1SD Hinxton, Cambridgeshire, UK.
+</p>
+<p>The EMBL Data Protection Officer's contact details are:</p>
+<p>
+EMBL Data Protection Officer<br>
+Email: dpo@embl.org<br>
+EMBL Heidelberg, Meyerhofstraße 1, 69117 Heidelberg, Germany
+</p>
+<h3 >Which is the lawful basis for processing your personal data?</h3>
+<p>Processing your personal data is necessary for our legitimate interest of allowing the day-to-day management, operation and functioning of EMBL. </p>
+<h3 >What personal data do we collect? How do we use this personal data?</h3>
+<p>We collect the following personal data: </p>
+<ul>
+<li>IP addresses</li>
+<li>Date and time of a visit to the service website</li>
+<li>Operating system</li>
+<li>Browser</li>
+<li>Google analytics identifiers: _ga and _gid </li>
+</ul>
+
+<p>We will use the personal data: </p>
+
+<ul>
+<li>To provide the user access to the service</li>
+<li>To check that the Terms of Use of the service are followed</li>
+<li>To conduct and monitor data protection activities</li>
+<li>To create anonymous usage statistics</li>
+<li>To conduct and monitor security activities</li>
+</ul>
+
+<h3 >Who will have access to your personal data?</h3>
+<p>The personal data will be disclosed to: </p>
+<ol>
+<li >Authorised EMBL-EBI staff.</li>
+</ol>
+
+<h3 >Will your personal data be transferred to third countries (i.e. countries not part of EU/EAA) and/or international organisations?</h3>
+<p>There are no personal data transfers to third countries or to international organisations.</p>
+
+<h3 >How long do we keep your personal data?</h3>
+<p>Any personal data directly obtained from you will be retained as long as the service is live, even if you stop using the service. We will keep the personal data for the minimum amount of time possible to ensure legal compliance and to facilitate internal and external audits if they arise. </p>
+<p>We will anonymise our web logs by removing the recorded IP address after 30 days. We will retain relevant security logs for 90 days</p>
+<p>Access to the web and security logs containing personal data are restricted to the relevant EMBL-EBI staff</p>
+
+<h3>Your rights regarding your personal data</h3>
+<p>You have the right to:</p>
+<ol>
+<li >Not be subject to decisions based solely on an automated processing of data (i.e. without human intervention) without you having your views taken into consideration.</li>
+<li >Request at reasonable intervals and without excessive delay or expense, information about the personal data processed about you. Under your request we will inform you in writing about, for example, the origin of the personal data or the preservation period.</li>
+<li >Request information to understand data processing activities when the results of these activities are applied to you.</li>
+<li >Object at any time to the processing of your personal data unless we can demonstrate that we have legitimate reasons to process your personal data.</li>
+<li >Request free of charge and without excessive delay rectification or erasure of your personal data if we have not been processing it respecting the EMBL Internal Policy for Data Protection.</li>
+</ol>
+<p>It must be clarified that rights 4 and 5 are only available whenever the processing of your personal data is not necessary to:</p>
+<ol>
+<li>Comply with a legal obligation.</li>
+<li >Perform a task carried out in the public interest.</li>
+<li >Exercise authority as a data controller.</li>
+<li >Archive for purposes in the public interest, or for historical research purposes, or for statistical purposes.</li>
+<li >Establish, exercise or defend legal claims.</li>
+</ol>
+</body>
+</html>

--- a/htdocs/info/about/legal/policy/ensembl-mirrors-mart.html
+++ b/htdocs/info/about/legal/policy/ensembl-mirrors-mart.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="index" content="NO INDEX" />
+<title>Privacy notice for ensembl-mirrors-mart | EMBL-EBI</title>
+</head>
+
+<body>
+<a href="../privacy.html">Back</a>
+<h1>Privacy notice for ensembl-mirrors-mart</h1>
+<p>This Privacy notice explains what personal data is collected by the specific EMBL-EBI service you are requesting, for what purposes, how it is processed, and how we keep it secure.</p>
+<h3 >Who controls your personal data and how to contact us?</h3>
+<p>The EMBL data controller's contact details are:</p>
+<p >
+Rolf Apweiler and Ewan Birney, EMBL-EBI Directors<br>
+Email:  data-controller@ebi.ac.uk<br>
+EMBL-EBI, Wellcome Genome Campus, CB10 1SD Hinxton, Cambridgeshire, UK.
+</p>
+<p>The EMBL Data Protection Officer's contact details are:</p>
+<p >
+EMBL Data Protection Officer<br>
+Email: dpo@embl.org<br>
+EMBL Heidelberg, Meyerhofstraße 1, 69117 Heidelberg, Germany
+</p>
+<h3 >Which is the lawful basis for processing your personal data?</h3>
+<p>Processing your personal data is necessary for our legitimate interest of delivering a service that provides broader societal benefits. </p>
+<h3 >What personal data do we collect? How do we use this personal data?</h3>
+<p>We collect the following personal data: </p>
+
+<ul>
+<li>Email address</li>
+<li>IP addresses</li>
+<li>Date and time of a visit to the service website</li>
+</ul>
+
+<p>We will use the personal data: </p>
+<ul>
+<li>To provide the user access to the service</li>
+<li>To check that the Terms of Use of the service are followed</li>
+<li>To conduct and monitor data protection activities</li>
+<li>To create anonymous usage statistics</li>
+<li>To conduct and monitor security activities</li>
+</ul>
+
+<h3 >Who will have access to your personal data?</h3>
+<p>The personal data will be disclosed to: </p>
+<ul>
+<li >Authorised EMBL-EBI staff.</li>
+</ul>
+
+<h3 >Will your personal data be transferred to third countries (i.e. countries not part of EU/EAA) and/or international organisations?</h3>
+<p>There are no personal data transfers to third countries or to international organisations.</p>
+<h3 >How long do we keep your personal data?</h3>
+<p>Any personal data directly obtained from you will be retained for as long as you make use of the service. </p>
+<p>email addresses and IPs are kept for 12h and then deleted</p>
+<h3 >Your rights regarding your personal data</h3>
+<p>You have the right to:</p>
+<ol>
+<li >Not be subject to decisions based solely on an automated processing of data (i.e. without human intervention) without you having your views taken into consideration.</li>
+<li >Request at reasonable intervals and without excessive delay or expense, information about the personal data processed about you. Under your request we will inform you in writing about, for example, the origin of the personal data or the preservation period.</li>
+<li >Request information to understand data processing activities when the results of these activities are applied to you.</li>
+<li >Object at any time to the processing of your personal data unless we can demonstrate that we have legitimate reasons to process your personal data.</li>
+<li >Request free of charge and without excessive delay rectification or erasure of your personal data if we have not been processing it respecting the EMBL Internal Policy for Data Protection.</li>
+</ol>
+<p>It must be clarified that rights 4 and 5 are only available whenever the processing of your personal data is not necessary to:</p>
+<ol>
+<li>Comply with a legal obligation.</li>
+<li>Perform a task carried out in the public interest.</li>
+<li>Exercise authority as a data controller.</li>
+<li>Archive for purposes in the public interest, or for historical research purposes, or for statistical purposes.</li>
+<li>Establish, exercise or defend legal claims.</li>
+</ol>
+</body>
+</html>

--- a/htdocs/info/about/legal/policy/ensembl-website-accounts.html
+++ b/htdocs/info/about/legal/policy/ensembl-website-accounts.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="index" content="NO INDEX" />
+<title>Privacy notice for ensembl-website-accounts | EMBL-EBI</title>
+</head>
+
+<body>
+<a href="../privacy.html">Back</a>
+<h1>Privacy notice for ensembl-website-accounts</h1>
+<p>This Privacy notice explains what personal data is collected by the specific EMBL-EBI service you are requesting, for what purposes, how it is processed, and how we keep it secure.</p>
+<h3 >Who controls your personal data and how to contact us?</h3>
+<p>The EMBL data controller's contact details are:</p>
+<p >
+Rolf Apweiler and Ewan Birney, EMBL-EBI Directors<br>
+Email:  data-controller@ebi.ac.uk<br>
+EMBL-EBI, Wellcome Genome Campus, CB10 1SD Hinxton, Cambridgeshire, UK.
+</p>
+<p>The EMBL Data Protection Officer's contact details are:</p>
+<p >
+EMBL Data Protection Officer<br>
+Email: dpo@embl.org<br>
+EMBL Heidelberg, Meyerhofstraße 1, 69117 Heidelberg, Germany
+</p>
+<h3 >Which is the lawful basis for processing your personal data?</h3>
+<p>We need your consent to process your personal data. If you do not consent to us processing your personal data, we will not be able to provide you access to the service or we will only provide you a subset of functionalities available within the service.</p>
+<h3 >What personal data do we collect? How do we use this personal data?</h3>
+<p>We collect the following personal data: </p>
+
+<div >Name</div>
+<div >Email address</div>
+<div >Username</div>
+<div >Password</div>
+<div >Organisation</div>
+<div >Date and time of a visit to the service website</div>
+
+<p>We will use the personal data: </p>
+<div >To provide the user access to the service</div>
+<div >To authenticate the user</div>
+<div >To create anonymous usage statistics</div>
+
+<h3 >Who will have access to your personal data?</h3>
+<p>The personal data will be disclosed to: </p>
+<ul ><li >Authorised EMBL-EBI staff.</li>
+</ul><h3 >Will your personal data be transferred to third countries (i.e. countries not part of EU/EAA) and/or international organisations?</h3>
+<p>There are no personal data transfers to third countries or to international organisations.</p>
+<h3 >How long do we keep your personal data?</h3>
+<p>Any personal data directly obtained from you will be retained as long as the service is live, even if you stop using the service. We will keep the personal data for the minimum amount of time possible to ensure legal compliance and to facilitate internal and external audits if they arise. </p>
+<h3 >Your rights regarding your personal data</h3>
+<p>You have the right to:</p>
+<ul ><li >Not be subject to decisions based solely on an automated processing of data (i.e. without human intervention) without you having your views taken into consideration.</li>
+<li >Request at reasonable intervals and without excessive delay or expense, information about the personal data processed about you. Under your request we will inform you in writing about, for example, the origin of the personal data or the preservation period.</li>
+<li >Request information to understand data processing activities when the results of these activities are applied to you.</li>
+<li >Object at any time to the processing of your personal data unless we can demonstrate that we have legitimate reasons to process your personal data.</li>
+<li >Request free of charge and without excessive delay rectification or erasure of your personal data if we have not been processing it respecting the EMBL Internal Policy for Data Protection.</li>
+</ul><p>It must be clarified that rights 4 and 5 are only available whenever the processing of your personal data is not necessary to:</p>
+<ul ><li >Comply with a legal obligation.</li>
+<li >Perform a task carried out in the public interest.</li>
+<li >Exercise authority as a data controller.</li>
+<li >Archive for purposes in the public interest, or for historical research purposes, or for statistical purposes.</li>
+<li >Establish, exercise or defend legal claims.</li>
+
+</body>
+</html>

--- a/htdocs/info/about/legal/policy/ensembl-website-browsing.html
+++ b/htdocs/info/about/legal/policy/ensembl-website-browsing.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="index" content="NO INDEX" />
+<title>Privacy notice for ensembl-website-browsing | EMBL-EBI</title>
+</head>
+
+<body>
+<a href="../privacy.html">Back</a>
+<h1>Privacy notice for ensembl-website-browsing</h1>
+<p>This Privacy notice explains what personal data is collected by the specific EMBL-EBI service you are requesting, for what purposes, how it is processed, and how we keep it secure.</p>
+<h3>Who controls your personal data and how to contact us?</h3>
+<p>The EMBL data controller's contact details are:</p>
+<p>
+Rolf Apweiler and Ewan Birney, EMBL-EBI Directors<br>
+Email:  data-controller@ebi.ac.uk<br>
+EMBL-EBI, Wellcome Genome Campus, CB10 1SD Hinxton, Cambridgeshire, UK.
+</p>
+<p>The EMBL Data Protection Officer's contact details are:</p>
+<p>
+EMBL Data Protection Officer<br>
+Email: dpo@embl.org<br>
+EMBL Heidelberg, Meyerhofstraße 1, 69117 Heidelberg, Germany
+</p>
+<h3 >Which is the lawful basis for processing your personal data?</h3>
+<p>Processing your personal data is necessary for our legitimate interest of allowing the day-to-day management, operation and functioning of EMBL. </p>
+<h3 >What personal data do we collect? How do we use this personal data?</h3>
+<p>We collect the following personal data: </p>
+<ul>
+<li>IP addresses</li>
+<li>Date and time of a visit to the service website</li>
+<li>Operating system</li>
+<li>Amount of data transmitted</li>
+<li>Browser</li>
+<li>Google analytics identifiers: _ga and _gid </li>
+</ul>
+<p>We will use the personal data: </p>
+<ul>
+<li>To provide the user access to the service</li>
+<li>To better understand the needs of the users and guide future improvements of the service</li>
+<li>To check that the Terms of Use of the service are followed</li>
+<li>To conduct and monitor data protection activities</li>
+<li>To create anonymous usage statistics</li>
+<li>To conduct and monitor security activities</li>
+</ul>
+
+<h3 >Who will have access to your personal data?</h3>
+<p>The personal data will be disclosed to: </p>
+<ul ><li >Authorised EMBL-EBI staff.</li>
+</ul><h3 >Will your personal data be transferred to third countries (i.e. countries not part of EU/EAA) and/or international organisations?</h3>
+<div >
+<p>Personal data is transferred to the following organisation based in a third country and that together with EMBL-EBI provide the service: </p>
+
+<div >Google Analytics</div>
+<div >EMBL European Bioinformatics Institute</div>
+<div >Welcome Genome Campus</div>
+<div >Cambridge</div>
+<div >Cambs.</div>
+<div >CB10 1SD</div>
+
+<p><span >United Kingdom</span></p></div>
+
+<p>There are no personal data transfers to international organisations.</p>
+<h3 >How long do we keep your personal data?</h3>
+<p>Any personal data directly obtained from you will be retained as long as the service is live, even if you stop using the service. We will keep the personal data for the minimum amount of time possible to ensure legal compliance and to facilitate internal and external audits if they arise. </p>
+<p>We will anonymise our web logs by removing the recorded IP address after 30 days. We will retain relevant security logs for 90 days</p>
+<p>Access to the web and security logs containing personal data are restricted to the relevant EMBL-EBI staff</p>
+<h3 >Your rights regarding your personal data</h3>
+<p>You have the right to:</p>
+<ol >
+<li >Not be subject to decisions based solely on an automated processing of data (i.e. without human intervention) without you having your views taken into consideration.</li>
+<li >Request at reasonable intervals and without excessive delay or expense, information about the personal data processed about you. Under your request we will inform you in writing about, for example, the origin of the personal data or the preservation period.</li>
+<li >Request information to understand data processing activities when the results of these activities are applied to you.</li>
+<li >Object at any time to the processing of your personal data unless we can demonstrate that we have legitimate reasons to process your personal data.</li>
+<li >Request free of charge and without excessive delay rectification or erasure of your personal data if we have not been processing it respecting the EMBL Internal Policy for Data Protection.</li>
+</ol><p>It must be clarified that rights 4 and 5 are only available whenever the processing of your personal data is not necessary to:</p>
+<ol ><li >Comply with a legal obligation.</li>
+<li >Perform a task carried out in the public interest.</li>
+<li >Exercise authority as a data controller.</li>
+<li >Archive for purposes in the public interest, or for historical research purposes, or for statistical purposes.</li>
+<li >Establish, exercise or defend legal claims.</li>
+</ol>
+</body>
+</html>

--- a/htdocs/info/about/legal/policy/ensembl-website-contact.html
+++ b/htdocs/info/about/legal/policy/ensembl-website-contact.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="index" content="NO INDEX" />
+<title>Privacy notice for ensembl-website-contact | EMBL-EBI</title>
+</head>
+
+<body>
+<a href="../privacy.html">Back</a>
+<h1>Privacy notice for ensembl-website-contact</h1>
+<p>This Privacy notice explains what personal data is collected by the specific EMBL-EBI service you are requesting, for what purposes, how it is processed, and how we keep it secure.</p>
+<h3 >Who controls your personal data and how to contact us?</h3>
+<p>The EMBL data controller's contact details are:</p>
+<p >
+Rolf Apweiler and Ewan Birney, EMBL-EBI Directors<br>
+Email:  data-controller@ebi.ac.uk<br>
+EMBL-EBI, Wellcome Genome Campus, CB10 1SD Hinxton, Cambridgeshire, UK.
+</p>
+<p>The EMBL Data Protection Officer's contact details are:</p>
+<p>
+EMBL Data Protection Officer<br>
+Email: dpo@embl.org<br>
+EMBL Heidelberg, Meyerhofstraße 1, 69117 Heidelberg, Germany
+</p>
+<h3 >Which is the lawful basis for processing your personal data?</h3>
+<p>Processing your personal data is necessary for our legitimate interest of delivering a service that provides broader societal benefits. </p>
+<h3 >What personal data do we collect? How do we use this personal data?</h3>
+<p>We collect the following personal data: </p>
+<ul>
+<li>Name</li>
+<li>Email address</li>
+<li>IP addresses</li>
+<li>Date and time when the support request was sent</li>
+</ul>
+
+<p>We will use the personal data: </p>
+<ul>
+<li>To provide the user access to the service</li>
+<li>To better understand the needs of the users and guide future improvements of the service</li>
+<li>To check that the Terms of Use of the service are followed</li>
+<li>To conduct and monitor data protection activities</li>
+<li>To create anonymous usage statistics</li>
+<li>To conduct and monitor security activities</li>
+</ul>
+
+<h3 >Who will have access to your personal data?</h3>
+<p>The personal data will be disclosed to: </p>
+<ul ><li >Authorised EMBL-EBI staff.</li>
+</ul><h3 >Will your personal data be transferred to third countries (i.e. countries not part of EU/EAA) and/or international organisations?</h3>
+<p>There are no personal data transfers to third countries or to international organisations.</p>
+<h3 >How long do we keep your personal data?</h3>
+<p>Any personal data directly obtained from you will be retained even if the service is withdrawn. We will keep the personal data for the minimum amount of time possible to ensure legal compliance and to facilitate internal and external audits if they arise. </p>
+<h3 >Your rights regarding your personal data</h3>
+<p>You have the right to:</p>
+<ol ><li >Not be subject to decisions based solely on an automated processing of data (i.e. without human intervention) without you having your views taken into consideration.</li>
+<li >Request at reasonable intervals and without excessive delay or expense, information about the personal data processed about you. Under your request we will inform you in writing about, for example, the origin of the personal data or the preservation period.</li>
+<li >Request information to understand data processing activities when the results of these activities are applied to you.</li>
+<li >Object at any time to the processing of your personal data unless we can demonstrate that we have legitimate reasons to process your personal data.</li>
+<li >Request free of charge and without excessive delay rectification or erasure of your personal data if we have not been processing it respecting the EMBL Internal Policy for Data Protection.</li>
+</ol><p>It must be clarified that rights 4 and 5 are only available whenever the processing of your personal data is not necessary to:</p>
+<ol ><li >Comply with a legal obligation.</li>
+<li >Perform a task carried out in the public interest.</li>
+<li >Exercise authority as a data controller.</li>
+<li >Archive for purposes in the public interest, or for historical research purposes, or for statistical purposes.</li>
+<li >Establish, exercise or defend legal claims.</li>
+</ol>
+</body>
+</html>

--- a/htdocs/info/about/legal/policy/ensembl-website-mart.html
+++ b/htdocs/info/about/legal/policy/ensembl-website-mart.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="index" content="NO INDEX" />
+<title>Privacy notice for ensembl-website-mart | EMBL-EBI</title>
+</head>
+
+<body>
+<a href="../privacy.html">Back</a>
+<h1>Privacy notice for ensembl-website-mart</h1>
+<p>This Privacy notice explains what personal data is collected by the specific EMBL-EBI service you are requesting, for what purposes, how it is processed, and how we keep it secure.</p>
+<h3 >Who controls your personal data and how to contact us?</h3>
+<p>The EMBL data controller's contact details are:</p>
+<p>
+Rolf Apweiler and Ewan Birney, EMBL-EBI Directors<br>
+Email:  data-controller@ebi.ac.uk<br>
+EMBL-EBI, Wellcome Genome Campus, CB10 1SD Hinxton, Cambridgeshire, UK.
+</p>
+<p>The EMBL Data Protection Officer's contact details are:</p>
+<p >
+EMBL Data Protection Officer<br>
+Email: dpo@embl.org<br>
+EMBL Heidelberg, Meyerhofstraße 1, 69117 Heidelberg, Germany
+</p>
+<h3 >Which is the lawful basis for processing your personal data?</h3>
+<p>Processing your personal data is necessary for our legitimate interest of delivering a service that provides broader societal benefits. </p>
+<h3 >What personal data do we collect? How do we use this personal data?</h3>
+<p>We collect the following personal data: </p>
+<ul>
+<li>Email address</li>
+<li>Date and time of a visit to the service website</li>
+</ul>
+<p>We will use the personal data: </p>
+<ul>
+<li>To provide the user access to the service</li>
+<li>To check that the Terms of Use of the service are followed</li>
+<li>To conduct and monitor data protection activities</li>
+<li>To conduct and monitor security activities</li>
+</ul>
+<h3 >Who will have access to your personal data?</h3>
+<p>The personal data will be disclosed to: </p>
+<ul ><li >Authorised EMBL-EBI staff.</li>
+</ul><h3 >Will your personal data be transferred to third countries (i.e. countries not part of EU/EAA) and/or international organisations?</h3>
+<p>There are no personal data transfers to third countries or to international organisations.</p>
+<h3 >How long do we keep your personal data?</h3>
+<p>Any personal data directly obtained from you will be retained for as long as you make use of the service. </p>
+<p>email addresses and IPs are kept for 12h and then deleted</p>
+<h3 >Your rights regarding your personal data</h3>
+<p>You have the right to:</p>
+<ol ><li >Not be subject to decisions based solely on an automated processing of data (i.e. without human intervention) without you having your views taken into consideration.</li>
+<li >Request at reasonable intervals and without excessive delay or expense, information about the personal data processed about you. Under your request we will inform you in writing about, for example, the origin of the personal data or the preservation period.</li>
+<li >Request information to understand data processing activities when the results of these activities are applied to you.</li>
+<li >Object at any time to the processing of your personal data unless we can demonstrate that we have legitimate reasons to process your personal data.</li>
+<li >Request free of charge and without excessive delay rectification or erasure of your personal data if we have not been processing it respecting the EMBL Internal Policy for Data Protection.</li>
+</ol><p>It must be clarified that rights 4 and 5 are only available whenever the processing of your personal data is not necessary to:</p>
+<ol ><li >Comply with a legal obligation.</li>
+<li >Perform a task carried out in the public interest.</li>
+<li >Exercise authority as a data controller.</li>
+<li >Archive for purposes in the public interest, or for historical research purposes, or for statistical purposes.</li>
+<li >Establish, exercise or defend legal claims.</li>
+</ol>
+</body>
+</html>

--- a/htdocs/info/about/legal/policy/ensemblgenomes-apollo.html
+++ b/htdocs/info/about/legal/policy/ensemblgenomes-apollo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="index" content="NO INDEX" />
+<title>Privacy notice for ensemblgenomes-apollo | EMBL-EBI</title>
+</head>
+
+<body>
+<a href="../privacy.html">Back</a>
+<h1>Privacy notice for ensemblgenomes-apollo</h1>
+<p>This Privacy notice explains what personal data is collected by the specific EMBL-EBI service you are requesting, for what purposes, how it is processed, and how we keep it secure.</p>
+<h3 >Who controls your personal data and how to contact us?</h3>
+<p>The EMBL data controller's contact details are:</p>
+<p >
+Rolf Apweiler and Ewan Birney, EMBL-EBI Directors<br>
+Email:  data-controller@ebi.ac.uk<br>
+EMBL-EBI, Wellcome Genome Campus, CB10 1SD Hinxton, Cambridgeshire, UK.
+</p>
+<p>The EMBL Data Protection Officer's contact details are:</p>
+<p >
+EMBL Data Protection Officer<br>
+Email: dpo@embl.org<br>
+EMBL Heidelberg, Meyerhofstraße 1, 69117 Heidelberg, Germany
+</p>
+<h3 >Which is the lawful basis for processing your personal data?</h3>
+<p>Processing your personal data is necessary for our legitimate interest of delivering a service that provides broader societal benefits. </p>
+<h3 >What personal data do we collect? How do we use this personal data?</h3>
+<p>We collect the following personal data: </p>
+
+<ul>
+<li>Name</li>
+<li>Email address</li>
+<li>IP addresses</li>
+<li>Date and time of a visit to the service website</li>
+<li>Operating system</li>
+<li>Browser</li>
+</ul>
+
+<p>We will use the personal data: </p>
+
+<ul>
+<li>To provide the user access to the service</li>
+<li>To better understand the needs of the users and guide future improvements of the service</li>
+<li>To create anonymous usage statistics</li>
+</ul>
+
+<h3>Who will have access to your personal data?</h3>
+<p>The personal data will be disclosed to: </p>
+<ul>
+<li >Authorised EMBL-EBI staff.</li>
+</ul>
+
+<h3 >Will your personal data be transferred to third countries (i.e. countries not part of EU/EAA) and/or international organisations?</h3>
+<p>There are no personal data transfers to third countries or to international organisations.</p>
+
+<h3 >How long do we keep your personal data?</h3>
+<p>Any personal data directly obtained from you will be retained as long as the service is live, even if you stop using the service. We will keep the personal data for the minimum amount of time possible to ensure legal compliance and to facilitate internal and external audits if they arise. </p>
+<h3 >Your rights regarding your personal data</h3>
+<p>You have the right to:</p>
+<ol>
+<li >Not be subject to decisions based solely on an automated processing of data (i.e. without human intervention) without you having your views taken into consideration.</li>
+<li >Request at reasonable intervals and without excessive delay or expense, information about the personal data processed about you. Under your request we will inform you in writing about, for example, the origin of the personal data or the preservation period.</li>
+<li >Request information to understand data processing activities when the results of these activities are applied to you.</li>
+<li >Object at any time to the processing of your personal data unless we can demonstrate that we have legitimate reasons to process your personal data.</li>
+<li >Request free of charge and without excessive delay rectification or erasure of your personal data if we have not been processing it respecting the EMBL Internal Policy for Data Protection.</li>
+</ol>
+<p>It must be clarified that rights 4 and 5 are only available whenever the processing of your personal data is not necessary to:</p>
+<ol>
+<li>Comply with a legal obligation.</li>
+<li>Perform a task carried out in the public interest.</li>
+<li>Exercise authority as a data controller.</li>
+<li>Archive for purposes in the public interest, or for historical research purposes, or for statistical purposes.</li>
+<li>Establish, exercise or defend legal claims.</li>
+</ol>
+</body>
+</html>

--- a/htdocs/info/about/legal/privacy.html
+++ b/htdocs/info/about/legal/privacy.html
@@ -155,39 +155,39 @@
   <ul>
     <li>Ensembl.org including www, plants, metazoa, fungi, bacteria, protists, FTP, REST, MySQL, blog</li>
     <ul>
-      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-website-accounts">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-website-accounts</a></li>
-      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-website-browsing">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-website-browsing</a></li>
-      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-website-contact">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-website-contact</a></li>
-      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-website-mart">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-website-mart</a></li>
+      <li><a href="policy/ensembl-website-accounts.html">Ensembl Accounts</a></li>
+      <li><a href="policy/ensembl-website-browsing.html">Ensembl website browsing</a></li>
+      <li><a href="policy/ensembl-website-contact.html">Ensembl website contact</a></li>
+      <li><a href="policy/ensembl-website-mart.html">Ensembl website Mart</a></li>
     </ul>
     <li>AWS Mirrors</li>
     <ul>
-      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-mirrors-accounts">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-mirrors-accounts</a></li>
-      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-mirrors-browsing">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-mirrors-browsing</a></li>
-      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-mirrors-mart">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-mirrors-mart</a></li>
+      <li><a href="policy/ensembl-mirrors-accounts.html">Ensembl mirrors accounts</a></li>
+      <li><a href="policy/ensembl-mirrors-browsing.html">Ensembl mirrors browsing</a></li>
+      <li><a href="policy/ensembl-mirrors-mart.html">Ensembl mirrors mart</a></li>
     </ul>
     <li>Ensembl Archives Release 87 and older</li>
     <ul>
-      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-embassy-accounts">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-embassy-accounts</a></li>
-      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-embassy-browsing">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-embassy-browsing</a></li>
-      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-embassy-mart">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-embassy-mart</a></li>
+      <li><a href="policy/ensembl-embassy-accounts.html">Ensembl embassy accounts</a></li>
+      <li><a href="policy/ensembl-embassy-browsing.html">Ensembl embassy browsing</a></li>
+      <li><a href="policy/ensembl-embassy-mart.html">Ensembl embassy mart</a></li>
     </ul>
     <li>Ensembl Genomes Apollo</li>
     <ul>
-      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensemblgenomes-apollo">https://www.ebi.ac.uk/data-protection/privacy-notice/ensemblgenomes-apollo</a></li>
+      <li><a href="policy/ensemblgenomes-apollo.html">Ensembl Genomes Apollo</a></li>
     </ul>
     <li>Mailing Lists</li>
     <ul>
-      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-mailing-lists">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-mailing-lists</a></li>
+      <li><a href="policy/ensembl-mailing-lists.html">Ensembl mailing lists</a></li>
     </ul>
     <li>Targeted Emails</li>
     <ul>
-      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-contact-signup">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-contact-signup</a></li>
+      <li><a href="policy/ensembl-contact-signup.html">Ensembl contact signup</a></li>
     </ul>
     <li>IGSR/1000 Genomes Browsers</li>
     <ul>
-      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-1000g-browsing">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-1000g-browsing</a></li>
-      <li><a href="https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-1000g-contact">https://www.ebi.ac.uk/data-protection/privacy-notice/ensembl-1000g-contact</a></li>
+      <li><a href="policy/ensembl-1000g-browsing.html">Ensembl 1000g browsing</a></li>
+      <li><a href="policy/ensembl-1000g-contact.html">Ensembl 1000g contact</a></li>
     </ul>
   </ul>
 </body>


### PR DESCRIPTION
## Description

The EBI service that hosts Ensembl's privacy policy pages has been deactivated.  This PR creates static copies of the policy pages and updates the privacy policy main page to link to them.

The policy pages where generated based on offline copies of the EBI pages saved here https://ensembl.github.io/privacy_notices/

## Views affected

The only change is to  [Privacy policy](https://www.ensembl.org/info/about/legal/privacy.html)
The changes can be viewed here http://wp-np2-33.ebi.ac.uk:10000/info/about/legal/privacy.html

## Possible complications

I may not have created the policy html pages in the correct way


