### PR TITLE
Add genome-member gene-tree export modes

### DIFF
--- a/modules/EnsEMBL/Web/Constants.pm
+++ b/modules/EnsEMBL/Web/Constants.pm
@@ -283,6 +283,8 @@ sub NHX_OPTIONS {
     'display_label_composite' => 'Display label composite',
     'simple'                  => 'Simple',
     'phylip'                  => 'PHYLIP',
+    'genome_gene_stable_id'   => 'Genome and gene ID',
+    'genome_product_stable_id' => 'Genome and product ID',
   );
 }
 
@@ -302,6 +304,8 @@ sub NEWICK_OPTIONS {
     'ncbi_taxon'              => 'NCBI taxon',
     'ncbi_name'               => 'NCBI name',
     'phylip'                  => 'PHYLIP',
+    'genome_gene_stable_id'   => 'Genome and gene ID',
+    'genome_product_stable_id' => 'Genome and product ID',
   );
 }
 


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

This PR would add two new gene-tree export modes, listed here with examples.

**"Genome and gene ID"** (`genome_gene_stable_id`): 
```
(((pan_troglodytes|ENSPTRG00000005766:0.000451,
pan_paniscus|ENSPPAG00000002166:0.000791):0.001943,
homo_sapiens|ENSG00000139618:0.001905):0.000218,
gorilla_gorilla|ENSGGOG00000015808:0.001767):0.004755;
```

**"Genome and product ID"** (`genome_product_stable_id`): 
```
(((pan_troglodytes|ENSPTRP00000009812:0.000451,
pan_paniscus|ENSPPAP00000000836:0.000791):0.001943,
homo_sapiens|ENSP00000369497:0.001905):0.000218,
gorilla_gorilla|ENSGGOP00000027226:0.001767):0.004755;
```

These modes would give the option to export an unambiguous Newick/NHX gene tree, even if it contains clashing member stable IDs.

## Views affected

This change would add `Genome and gene ID` and `Genome and product ID` modes to the **"Mode for Newick tree dumping"** dropdown menu available for Newick/NHX formats in the gene-tree export modal window.

An example screenshot:
![proposed_gene_tree_modes](https://github.com/user-attachments/assets/7799376d-8438-4212-a5f9-7a9085e2f6d8)

## Possible complications

None anticipated.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- ENSINT-2411
