### PR TITLE
Changes to switch from VEP to Ensembl VEP as per requirements

### DIFF
--- a/htdocs/info/website/upload/var.html
+++ b/htdocs/info/website/upload/var.html
@@ -14,7 +14,7 @@
 </ul>
 
 <p>
-The <a href="/info/docs/tools/vep/index.html">Variant Effect Predictor</a>
+The <a href="/info/docs/tools/vep/index.html">Ensembl Variant Effect Predictor (VEP)</a>
 tool which appears as an option when you click on <strong>Manage your
 Data</strong> allows you to upload a set of variation data and predict the
 effect of the variants.</p>
@@ -81,15 +81,15 @@ example, a three base pair deletion of nucleotides 12600, 12601, and
     details. These must be relative to genomic or Ensembl transcript
     coordinates. It is possible, although less reliable, to <a
     href="/info/docs/tools/vep/script/vep_other.html#hgvs">use notations relative
-    to RefSeq transcripts</a> in the VEP script.</li>
+    to RefSeq transcripts</a> in the Ensembl VEP script.</li>
     <li>Variant identifiers - these should be e.g. dbSNP rsIDs, or any synonym
     for a variant present in the Ensembl Variation database. See <a
     href="/info/genome/variation/sources_documentation.html">here</a> for a list
     of identifier sources in Ensembl.</li>
 </ul>
 
-<p> When using the web VEP, ensure that you have the correct file format
-selected from the drop-down menu. The VEP script is able to auto-detect the
+<p> When using the web Ensembl VEP, ensure that you have the correct file format
+selected from the drop-down menu. The Ensembl VEP script is able to auto-detect the
 format of the input file. </p>
 
 <h2 id="output">Output format</h2>
@@ -137,8 +137,8 @@ columns are:</p>
 
 <p>Empty values are denoted by '-'. Further fields in the Extra column can be
 added by <a href="/info/docs/tools/vep/script/index.html#plugins">plugins</a> or using <a
-href="/info/docs/tools/vep/script/index.html#custom">custom annotations</a> in the VEP script. Output
-fields can be configured using the --fields flag when running the VEP script.
+href="/info/docs/tools/vep/script/index.html#custom">custom annotations</a> in the Ensembl VEP script. Output
+fields can be configured using the --fields flag when running the Ensembl VEP script.
 </p>
 
 <pre class="code">
@@ -149,7 +149,7 @@ fields can be configured using the --fields flag when running the VEP script.
 22_16084370_G/A  22:16084370 A  -                ENSR00000615113  RegulatoryFeature  REGULATORY_REGION       -    -    -    -    -        -  -
 </pre>
 
-<p> The VEP script will also add a header to the output file. This contains
+<p> The Ensembl VEP script will also add a header to the output file. This contains
 information about the databases connected to, and also a key describing the
 key/value pairs used in the extra column. </p>
 

--- a/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
@@ -105,7 +105,7 @@ Each directory on <a href="$ftp" rel="external">$ftp_domain</a> contains a
     emf       => 'Alignments of resequencing data from the ensembl_compara database',
     gvf       => 'Variation data in GVF format',
     vcf       => 'Variation data in VCF format',
-    vep       => 'Cache files for use with the VEP script',
+    vep       => 'Cache files for use with the Ensembl VEP script',
     funcgen   => 'Regulation data in GFF format',
     coll      => 'Additional regulation data (not in the database)',
     bed       => 'Constrained elements calculated using GERP',
@@ -141,7 +141,7 @@ Each directory on <a href="$ftp" rel="external">$ftp_domain</a> contains a
     push @$columns, (
     { key => 'var2',    title => 'Variation (GVF)',              align => 'center', width => '10%', sort => 'html' },
     { key => 'var4',    title => 'Variation (VCF)',              align => 'center', width => '10%', sort => 'html' },
-    { key => 'var3',    title => 'Variation (VEP)',              align => 'center', width => '10%', sort => 'html' }
+    { key => 'var3',    title => 'Variation (Ensembl VEP)',      align => 'center', width => '10%', sort => 'html' }
     );
   }
 
@@ -222,7 +222,7 @@ Each directory on <a href="$ftp" rel="external">$ftp_domain</a> contains a
       mysql   => sprintf('<a rel="external" title="%s" href="%s/mysql/">MySQL</a>',          $title{'mysql'},  $ftp_base),
       var2    => $has_vcf ? sprintf('<a rel="external" title="%s" href="%s/variation/gvf/%s/">GVF</a>', $title{'gvf'}, $ftp_base, $sp_dir) : '-',
       var4    => $has_vcf ? sprintf('<a rel="external" title="%s" href="%s/variation/vcf/%s/">VCF</a>', $title{'vcf'}, $ftp_base, $sp_dir) : '-',
-      var3    => sprintf('<a rel="external" title="%s" href="%s/variation/indexed_vep_cache/">VEP</a>',    $title{'vep'}, $ftp_base),
+      var3    => sprintf('<a rel="external" title="%s" href="%s/variation/indexed_vep_cache/">Ensembl VEP</a>',    $title{'vep'}, $ftp_base),
       funcgen => $required_lookup->{'funcgen'}{$sp_dir} ? sprintf('<a rel="external" title="%s" href="%s/regulation/%s/">Regulation</a> (GFF)',      $title{'funcgen'}, $ftp_base, $sp_dir) : '-',
       bam     => $databases->{'DATABASE_RNASEQ'}        ? sprintf('<a rel="external" title="%s" href="%s/bamcov/%s/genebuild/">BAM/BigWig</a>',      $title{'bam'},    $ftp_base, $sp_dir) : '-',
       files   => $required_lookup->{'files'}{$sp_dir}   ? sprintf('<a rel="external" title="%s" href="%s/data_files/%s/">Regulation data files</a>', $title{'files'}, $ftp_base, $sp_dir) : '-',

--- a/modules/EnsEMBL/Web/Document/HTML/ToolsTable.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/ToolsTable.pm
@@ -54,8 +54,8 @@ sub render {
   if ($sd->ENSEMBL_VEP_ENABLED) {
     my $vep_link = $hub->url({'species' => $sp, 'type' => 'Tools', 'action' =>  'VEP'});
     $table->add_row({
-      'name'  => sprintf('<a href="%s" class="nodeco"><b>Variant Effect Predictor</b><br /><img src="%svep_logo_sm.png" alt="[logo]" /></a>', $vep_link, $img_url),
-      'desc'  => 'Analyse your own variants and predict the functional consequences of known and unknown variants via our Variant Effect Predictor (VEP) tool.',
+      'name'  => sprintf('<a href="%s" class="nodeco"><b>Ensembl Variant Effect Predictor</b><br /><img src="%svep_logo_sm.png" alt="[logo]" /></a>', $vep_link, $img_url),
+      'desc'  => 'Analyse your own variants and predict the functional consequences of known and unknown variants via our Ensembl Variant Effect Predictor (VEP) tool.',
       'limit' => $tools_limit.'*',
       'tool'  => sprintf('<a href="%s" class="nodeco"><img src="%s16/tool.png" alt="Tool" title="Go to online tool" /></a>', $vep_link, $img_url),
       'code'  => sprintf('<a href="https://github.com/Ensembl/ensembl-tools/archive/release/%s.zip" rel="external" class="nodeco"><img src="%s16/download.png" alt="Download" title="Download Perl script" /></a>', $sd->ENSEMBL_VERSION, $img_url),
@@ -238,7 +238,7 @@ sub render {
       ## VIRTUAL MACHINE
       $table->add_row({
         'name' => '<b>Ensembl Virtual Machine</b>',
-        'desc' => 'VirtualBox virtual Machine with Ubuntu desktop and pre-configured with the latest Ensembl API plus Variant Effect Predictor (VEP). <b>NB: download is >1 GB</b>',
+        'desc' => 'VirtualBox virtual Machine with Ubuntu desktop and pre-configured with the latest Ensembl API plus Ensembl VEP. <b>NB: download is >1 GB</b>',
         'from' => qq(<a href="$ftp/current_virtual_machine" rel="external">FTP download</a>),
         'docs' => sprintf('<a href="/info/data/virtual_machine.html"><img src="%s16/info.png" alt="Documentation" /></a>', $img_url)
       });


### PR DESCRIPTION
## Description

As per our guidelines the Ensembl Variant Effect Predictor can be referred to either as 

- Ensembl Variant Effect Predictor,
- Ensembl Variant Effect Predictor (VEP)
- Ensembl VEP

No other names are allowed. This follows on from additional work by variation to reduce the number of places we do not conform to guidelines. Additional PRs are being created and will be linked to here.

- Public plugins: public-plugins#880
- EBI plugins: ebi-plugins#192

Specific changes made

- Name usage switched to either Ensembl VEP, Ensembl Variant Effect Predictor (VEP) or just Ensembl Variant Effect Predictor
- FTP table now renders "Ensembl VEP" for column and each download link
- Tools render correctly

## Views affected

- Index home page for www, grch37
- Footer on any site using FatFooter Perl module
- FTP table
- Tools table

## Possible complications

None known.

## Merge conflicts

None found

## Related JIRA Issues (EBI developers only)

None