### PR TITLE
Web MaveDB plug-in to display 1 additional column: `MaveDB_doi` as hyperlink

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -370,6 +370,7 @@ DBSNPSS                     = http://www.ncbi.nlm.nih.gov/SNP/snp_ss.cgi?subsnp_
 DBSNPSSID                   = http://www.ncbi.nlm.nih.gov/projects/SNP/snp_viewTable.cgi?handle=###ID###
 DBVAR                       = https://www.ncbi.nlm.nih.gov/dbvar
 DDG2P                       = https://www.ebi.ac.uk/gene2phenotype/
+DOI                         = https://doi.org/###ID###
 G2P                         = https://www.ebi.ac.uk/gene2phenotype/
 DECIPHER                    = https://www.deciphergenomics.org/patient/###ID###
 DECIPHER_BROWSER            = https://www.deciphergenomics.org/browser#q/###ID###


### PR DESCRIPTION
Adds constant `DOI` which is doi.org - by concatenating a doi after the URL like doi.org/<my_doi>, this can resolve any doi. 

Linked to [public-plugins PR #877 ](https://github.com/Ensembl/public-plugins/pull/877), linked to [VEP_plugins PR #794](https://github.com/Ensembl/VEP_plugins/pull/794) and [ticket 6760](https://embl.atlassian.net/browse/ENSVAR-6760).