### PR TITLE
Fix typos in ViewConfig::Gene::HomologAlignment

### DIFF
--- a/modules/EnsEMBL/Web/ViewConfig/Gene/HomologAlignment.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Gene/HomologAlignment.pm
@@ -55,10 +55,10 @@ sub init_form {
   my $form    = $self->SUPER::init_form(@_);
   my %formats = EnsEMBL::Web::Constants::ALIGNMENT_FORMATS;
 
-  $form->get_fieldset('Select species')->remove unless $self->{'is_compara_ortholog'};
+  $form->get_fieldset('Selected species')->remove unless $self->{'is_compara_ortholog'};
 
   $form->add_form_element({
-    'fieldset'  => 'Aligment output',
+    'fieldset'  => 'Alignment output',
     'type'      => 'dropdown',
     'name'      => 'seq',
     'label'     => 'View as cDNA or Protein',
@@ -66,7 +66,7 @@ sub init_form {
   });
 
   $form->add_form_element({
-    'fieldset'  => 'Aligment output',
+    'fieldset'  => 'Alignment output',
     'type'      => 'dropdown',
     'name'      => 'text_format',
     'label'     => 'Output format for sequence alignment',


### PR DESCRIPTION
## Description

This PR would fix some typos in `ViewConfig::Gene::HomologAlignment`:
- a typo in the line of code used to hide the "Selected species" fieldset in the paralogue alignment view, which results in an error when clicking the button to "Configure this page" in the paralogue alignment view ( e.g. [AT1G07820 vs AT5G59690 paralogue alignment page](https://plants.ensembl.org/Arabidopsis_thaliana/Gene/Compara_Paralog/Alignment?db=core;g=AT1G07820;g1=AT5G59690;hom_id=279820) ); and
- a typo in the title of the alignment output config fieldset.

## Views affected

This affects the configuration modal window accessed via the paralogue alignment view.

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
