### PR TITLE
Match highlighted orthologue by gene and species

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
@@ -208,10 +208,10 @@ sub _init {
     }
 
     if ( $f->{label} ) {
-      if( $other_gene && $f->{_genes}->{$other_gene} ){
+      if( $other_gene && $other_genome_db_id && $f->{_leaves}->{$other_genome_db_id . '|' . $other_gene} ){
         $bold = 1;
         $label_colour = "ff6666";
-      } elsif( $f->{_genes}->{$current_gene} ){
+      } elsif( $f->{_leaves}->{$current_genome_db_id . '|' . $current_gene} ){
         $label_colour     = 'red';
         $collapsed_colour = 'red';
         $node_colour = 'navyblue';
@@ -731,7 +731,7 @@ sub features {
       $sum_dist += $dist || 0;
       $genome_dbs{$leaf->genome_db->dbID}++;
       $genes{$leaf->gene_member->stable_id}++;
-      $leaves{$leaf->node_id}++;
+      $leaves{$leaf->genome_db->dbID . '|' . $leaf->gene_member->stable_id}++;
     }
     
     $f->{'_collapsed'}          = 1,
@@ -826,6 +826,7 @@ sub features {
       $f->{'_gene'} = $stable_id;
       $f->{'_genes'} ||= {};
       $f->{'_genes'}->{$stable_id}++;
+      $f->{'_leaves'}->{$member->genome_db_id . '|' . $stable_id}++;
       
       my $treefam_link = "http://www.treefam.org/cgi-bin/TFseq.pl?id=$stable_id";
       

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -318,7 +318,8 @@ sub content {
         anc_node_ids => $anc_node_ids, # the anc_node_ids parameter only becomes relevant in the Metazoa plugin
         cdb => $cdb,
         stable_id => $stable_id,
-        orthologue => $orthologue
+        orthologue => $orthologue,
+        s1 => $species,
       });
 
       my @homology_type_parts = (glossary_helptip($hub, ucfirst $orthologue_desc, ucfirst "$orthologue_desc orthologues"));
@@ -405,6 +406,7 @@ sub create_gene_tree_links {
 
   my $cdb = $params->{cdb};
   my $stable_id = $params->{stable_id};
+  my $s1 = $params->{s1};
   my $orthologue = $params->{orthologue};
 
   my $hub          = $self->hub;
@@ -414,6 +416,7 @@ sub create_gene_tree_links {
     type   => 'Gene',
     action => $strain_url . ($cdb =~ /pan/ ? 'PanComparaTree' : 'Compara_Tree'),
     g1     => $stable_id,
+    s1     => $s1,
     anc    => $orthologue->{'gene_tree_node_id'},
     r      => undef
   });

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -113,6 +113,7 @@ sub content {
   my $leaves               = $tree->get_all_leaves;
   my $tree_stable_id       = $tree->tree->stable_id;
   my $highlight_gene       = $hub->param('g1');
+  my $highlight_species_url = $hub->param('s1');
   my $highlight_status     = $hub->get_cookie_value('gene_tree_highlighting') || 'on'; # get the the highlight switch status from the cookie
 
   # Set $highlight_gene to undefined if the highlight status is off. This is due to the module relying heavily on $highlight_gene to do the rendering based on the highlight status.
@@ -192,7 +193,9 @@ sub content {
      
   my $lookup = $hub->species_defs->prodnames_to_urls_lookup; 
   foreach my $this_leaf (@$leaves) {
-    if ($gene_to_highlight && $this_leaf->gene_member->stable_id eq $gene_to_highlight) {
+    if ($gene_to_highlight
+        && $this_leaf->gene_member->stable_id eq $gene_to_highlight
+        && $lookup->{$this_leaf->gene_member->genome_db->name} eq $highlight_species_url) {
       $highlight_species            = $lookup->{$this_leaf->gene_member->genome_db->name};
       $highlight_species_name       = $this_leaf->gene_member->genome_db->display_name;
       $highlight_genome_db_id       = $this_leaf->gene_member->genome_db_id;
@@ -256,8 +259,7 @@ sub content {
     foreach my $this_leaf (@$leaves) {
       my $genome_db_id = $this_leaf->genome_db_id;
       
-      next if $highlight_genome_db_id && $genome_db_id eq $highlight_genome_db_id;
-      next if $highlight_gene && $this_leaf->gene_member->stable_id eq $highlight_gene;
+      next if $highlight_genome_db_id && $genome_db_id eq $highlight_genome_db_id;  # this should also skip $highlight_gene
       next if $member && $genome_db_id == $member->genome_db_id;
       
       if ($hidden_genome_db_ids{$genome_db_id}) {
@@ -359,7 +361,7 @@ sub content {
 
   ## Parameters to pass into export form
   $image->{'export_params'} = [['gene_name', $gene_name],['align', 'tree']];
-  my @extra_params = qw(g1 anc collapse exons);
+  my @extra_params = qw(g1 s1 anc collapse exons);
   foreach (@extra_params) {
     push @{$image->{'export_params'}}, [$_, $self->param($_)];
   }
@@ -372,21 +374,21 @@ sub content {
   $image->{'remove_reset'}  = 1;
 
   $image->set_button('drag', 'title' => 'Drag to select region');
-  my $default_view_url = $hub->url({ collapse => $collapsed_to_gene, g1 => $highlight_gene });
+  my $default_view_url = $hub->url({ collapse => $collapsed_to_gene, g1 => $highlight_gene, s1 => $highlight_species_url });
   if ($gene) {
     push @view_links, sprintf '<li><a href="%s">%s</a> (Default) </li>', $default_view_url, $highlight_gene ? 'View current genes only' : 'View current gene only';
-    push @view_links, sprintf $li_tmpl, $hub->url({ collapse => $collapsed_to_para, g1 => $highlight_gene }), $highlight_gene ? 'View paralogs of current genes' : 'View paralogs of current gene';
+    push @view_links, sprintf $li_tmpl, $hub->url({ collapse => $collapsed_to_para, g1 => $highlight_gene, s1 => $highlight_species_url }), $highlight_gene ? 'View paralogs of current genes' : 'View paralogs of current gene';
   }
   
-  push @view_links, sprintf $li_tmpl, $hub->url({ collapse => $collapsed_to_dups, g1 => $highlight_gene }), 'View all duplication nodes';
-  push @view_links, sprintf $li_tmpl, $hub->url({ collapse => 'none', g1 => $highlight_gene }), 'View fully expanded tree';
+  push @view_links, sprintf $li_tmpl, $hub->url({ collapse => $collapsed_to_dups, g1 => $highlight_gene, s1 => $highlight_species_url }), 'View all duplication nodes';
+  push @view_links, sprintf $li_tmpl, $hub->url({ collapse => 'none', g1 => $highlight_gene, s1 => $highlight_species_url }), 'View fully expanded tree';
 
   {
     my @rank_options = ( q{<option value="#">-- Select a rank--</option>} );
     my $selected_rank = $self->param('gtr') || '';
     foreach my $rank (qw(species genus family order class phylum kingdom)) {
       my $collapsed_to_rank = $self->collapsed_nodes($tree, $node, "rank_$rank", $highlight_genome_db_id, $highlight_gene);
-      push @rank_options, sprintf qq{<option value="%s" %s>%s</option>\n}, $hub->url({ collapse => $collapsed_to_rank, g1 => $highlight_gene, gtr => $rank }), $rank eq $selected_rank ? 'selected' : '', ucfirst $rank;
+      push @rank_options, sprintf qq{<option value="%s" %s>%s</option>\n}, $hub->url({ collapse => $collapsed_to_rank, g1 => $highlight_gene, s1 => $highlight_species_url, gtr => $rank }), $rank eq $selected_rank ? 'selected' : '', ucfirst $rank;
     }
     push @view_links, sprintf qq{<li>Collapse all the nodes at the taxonomic rank <select onchange="Ensembl.redirect(this.value)">%s</select></li>}, join("\n", @rank_options) if(!$self->is_strain);
   }
@@ -432,7 +434,7 @@ sub collapsed_nodes {
       foreach my $leaf (@{$tree->get_all_leaves}) {
         $collapsed_nodes{$_->node_id} = $_ for @{$leaf->get_all_adjacent_subtrees};
         
-        if ($leaf->gene_member->stable_id eq $highlight_gene) {
+        if ($leaf->gene_member->stable_id eq $highlight_gene && $leaf->genome_db_id == $highlight_genome_db_id) {
           $expanded_nodes{$_->node_id} = $_ for @{$leaf->get_all_ancestors};
           last;
         }


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

This PR would:
- pass an `s1` parameter with the gene-tree links in an orthologue table, whose value is the URL of the species containing the given orthologue;
- add an `s1` parameter to gene-tree views, which is expected to contain the species URL of the genome containing the gene specified by `g1`;
- use the species indicated by `s1` to help unambiguously identify the gene specified by `g1` for highlighting in a given gene-tree view; and
- repurpose the `'_leaves'` item of node features in the `genetree` GlyphSet to identify leaves by their concatenated `genome_db_id` and gene stable ID, making it possible for a highlighted orthologue to be identified even if in a collapsed branch of the gene tree.

## Views affected

This is expected to affect gene-tree views in which an orthologue is highlighted, such as those linked from the `ComparaOrthologs` view.

## Possible complications

Complications are not expected, as the `s1` parameter has not (as far as I know) been used in a `ComparaTree` component, and the `'_leaves'` item of node features should be safe to repurpose as they are not (as far as I know) currently used.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- TBD
