### PR TITLE
Match orthologue alignment by gene stable ID and homology ID

### DIFF
--- a/modules/EnsEMBL/Web/Command/DataExport/Output.pm
+++ b/modules/EnsEMBL/Web/Command/DataExport/Output.pm
@@ -157,7 +157,7 @@ sub process {
     $url_params->{'__clear'}        = 1;
     ## Pass parameters needed for Back button to work
     my @core_params = keys %{$hub->core_object('parameters')};
-    push @core_params, qw(export_action data_type data_action component align g1 node strain);
+    push @core_params, qw(export_action data_type data_action component align g1 node strain hom_id);
     push @core_params, $self->config_params; 
     foreach (@core_params) {
       my @values = $component->param($_);


### PR DESCRIPTION
## Description

This PR would:
- require that a homologue alignment have a matching gene stable ID and `homology_id` (if specified), in order to distinguish between aligned genes having the same stable ID;
- remove the unneeded loop in the `get_export_data` method; and
- remove the "Download homology" button in the absence of a `g1` parameter, as the homology alignment export currently depends on this parameter.

## Views affected

The homology ID will be used in all homologue alignments (e.g. orthologue, paralogue, homoeologue), though the difference should only be noticeable in the case of orthologue alignments, as it's only in this case that we would expect two different genes to have the same stable ID.

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- ENSCOMPARASW-8506
