### PR TITLE
Take the strain, disentangle clustersets

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaParalogs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaParalogs.pm
@@ -42,7 +42,7 @@ sub content {
   my $cdb            = shift || $hub->param('cdb') || 'compara';
   my $biotype        = $self->object->Obj->get_Biotype;  # We expect a Biotype object, though it could be a biotype name.
   my $is_ncrna       = ( ref $biotype eq 'Bio::EnsEMBL::Biotype' ? $biotype->biotype_group =~ /noncoding$/ : $biotype =~ /RNA/ );
-  my $strain_url     = $hub->is_strain ? 'Strain_' : '';
+  my $strain_url     = $hub->action =~ /^Strain_/ ? 'Strain_' : '';
   my %paralogue_list = %{$self->object->get_homology_matches('ENSEMBL_PARALOGUES', 'paralog|gene_split', undef, $cdb)};
 
   return '<p>No paralogues have been identified for this gene</p>' unless keys %paralogue_list;

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -166,7 +166,7 @@ sub content {
     if ($tree->tree->clusterset_id ne $clusterset_id) {
       $html .= $self->_info('Phylogenetic model selection',
         sprintf(
-          'The phylogenetic model <I>%s</I> is not available for this tree. Showing the <I>%s</I> tree instead.', $clusterset_id, $tree->tree->clusterset_id,
+          'The phylogenetic model <i>%s</i> is not available for this tree. Showing the <i>%s</i> tree instead.', $clusterset_id, $tree->tree->clusterset_id,
           )
       );
     } elsif ($tree->tree->ref_root_id) {

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -163,18 +163,10 @@ sub content {
   }
 
   if ($hub->type eq 'Gene') {
-    my $obs_clusterset_id = $tree->tree->clusterset_id;
-    my $exp_clusterset_id = $is_strain_view && $clusterset_id eq 'default'
-                          ? $hub->species_defs->get_config($hub->species, 'RELATED_TAXON')
-                          : $clusterset_id
-                          ;
-
-    if ($obs_clusterset_id ne $exp_clusterset_id) {
+    if ($tree->tree->clusterset_id ne $clusterset_id) {
       $html .= $self->_info('Phylogenetic model selection',
         sprintf(
-          'The phylogenetic model <I>%s</I> is not available for this tree. Showing the <I>%s</I> tree instead.',
-          $exp_clusterset_id,
-          $obs_clusterset_id,
+          'The phylogenetic model <I>%s</I> is not available for this tree. Showing the <I>%s</I> tree instead.', $clusterset_id, $tree->tree->clusterset_id,
           )
       );
     } elsif ($tree->tree->ref_root_id) {

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -38,7 +38,8 @@ sub get_details {
   my $member = $object->get_compara_Member({'stable_id' => $object->stable_id, 'cdb' => $cdb});
   return (undef, '<strong>Gene is not in the compara database</strong>') unless $member;
 
-  my $strain_tree  = $self->hub->species_defs->get_config($self->hub->species,'RELATED_TAXON') if ($self->hub->is_strain || $self->hub->param('strain') || $self->hub->action =~ /Strain_/);
+  my $strain_tree = $self->hub->species_defs->get_config($self->hub->species,'RELATED_TAXON') if ($self->hub->param('strain') || $self->hub->action =~ /^Strain_/);
+
   my $tree = $object->get_GeneTree($cdb,"", $strain_tree);
   return (undef, '<strong>Gene is not in a compara tree</strong>') unless $tree;
 
@@ -94,7 +95,7 @@ sub content {
   my $hub         = $self->hub;
   my $object      = $self->object || $self->hub->core_object('gene');
   my $is_genetree = $object && $object->isa('EnsEMBL::Web::Object::GeneTree') ? 1 : 0;
-  my $is_strain   = $hub->is_strain || $hub->param('strain') || $hub->action =~ /Strain_/;
+  my $is_strain_view = $hub->param('strain') || $hub->action =~ /^Strain_/;
   my ($gene, $member, $tree, $node);
 
   my $type   = $self->param('data_type') || $hub->type;
@@ -147,7 +148,7 @@ sub content {
   if (defined $parent) {
 
     if ($vc->get('super_tree') eq 'on' || $self->param('super_tree') eq 'on') {
-      my $super_url = $self->ajax_url('sub_supertree',{ cdb => $cdb, update_panel => undef, strain => $is_strain });
+      my $super_url = $self->ajax_url('sub_supertree',{ cdb => $cdb, update_panel => undef, strain => $is_strain_view });
       $html .= qq(<div class="ajax"><input type="hidden" class="ajax_load" value="$super_url" /></div>);
     } else {
       $html .= $self->_info(
@@ -162,10 +163,18 @@ sub content {
   }
 
   if ($hub->type eq 'Gene') {
-    if ($tree->tree->clusterset_id ne $clusterset_id && !$self->is_strain) {
+    my $obs_clusterset_id = $tree->tree->clusterset_id;
+    my $exp_clusterset_id = $is_strain_view && $clusterset_id eq 'default'
+                          ? $hub->species_defs->get_config($hub->species, 'RELATED_TAXON')
+                          : $clusterset_id
+                          ;
+
+    if ($obs_clusterset_id ne $exp_clusterset_id) {
       $html .= $self->_info('Phylogenetic model selection',
         sprintf(
-          'The phylogenetic model <I>%s</I> is not available for this tree. Showing the default (consensus) tree instead.', $clusterset_id
+          'The phylogenetic model <I>%s</I> is not available for this tree. Showing the <I>%s</I> tree instead.',
+          $exp_clusterset_id,
+          $obs_clusterset_id,
           )
       );
     } elsif ($tree->tree->ref_root_id) {
@@ -275,7 +284,7 @@ sub content {
     image_width     => $image_width,
     slice_number    => '1|1',
     cdb             => $cdb,
-    strain          => $is_strain,
+    strain          => $is_strain_view,
   });
   
   # Keep track of collapsed nodes
@@ -388,7 +397,11 @@ sub content {
       my $collapsed_to_rank = $self->collapsed_nodes($tree, $node, "rank_$rank", $highlight_genome_db_id, $highlight_gene);
       push @rank_options, sprintf qq{<option value="%s" %s>%s</option>\n}, $hub->url({ collapse => $collapsed_to_rank, g1 => $highlight_gene, gtr => $rank }), $rank eq $selected_rank ? 'selected' : '', ucfirst $rank;
     }
-    push @view_links, sprintf qq{<li>Collapse all the nodes at the taxonomic rank <select onchange="Ensembl.redirect(this.value)">%s</select></li>}, join("\n", @rank_options) if(!$self->is_strain);
+    # The ability to collapse by taxonomic rank was not seen as
+    # particularly useful in a strain gene-tree view ( ENSWEB-3037 ).
+    if(!$is_strain_view) {
+      push @view_links, sprintf qq{<li>Collapse all the nodes at the taxonomic rank <select onchange="Ensembl.redirect(this.value)">%s</select></li>}, join("\n", @rank_options);
+    }
   }
 
   $html .= $image->render;

--- a/modules/EnsEMBL/Web/Component/Gene/Compara_Portal.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/Compara_Portal.pm
@@ -35,8 +35,9 @@ sub content {
   my $hub           = $self->hub;
   my $availability  = $self->object->availability;
   my $location      = $hub->url({ type => 'Location',  action => 'Compara' });
-  my $strain_url    = ($self->is_strain || $hub->action =~ /^Strain_/) ? "Strain_" : "";
-  my $strain_avail  = ($self->is_strain || $hub->action =~ /^Strain_/) ? "strain_" : "";
+  my $is_strain_view = $hub->action =~ /^Strain_/;
+  my $strain_url    = $is_strain_view ? "Strain_" : "";
+  my $strain_avail  = $is_strain_view ? "strain_" : "";
 
   my $ortho_image = $strain_avail ? 'strain_ortho.gif' : 'compara_ortho.gif';
   my $para_image  = $strain_avail ? 'strain_para.gif' : 'compara_para.gif';
@@ -49,7 +50,7 @@ sub content {
     { title => 'Families',           img => '80/compara_fam.gif',   url => $availability->{'family'}         ? $hub->url({ action => 'Family'             }) : '' },
   ];
   
-  @$buttons  = grep { $_->{title} !~ /^Families$|^Genomic alignments$/ } @$buttons if($self->is_strain); #remove the one we dont show for strains species
+  @$buttons  = grep { $_->{title} !~ /^Families$|^Genomic alignments$/ } @$buttons if($is_strain_view); #remove the one we dont show for strain views
   my $html  = $self->button_portal($buttons, 'portal-small');
      $html .= qq{<p>More views of comparative genomics data, such as multiple alignments and synteny, are available on the <a href="$location">Location</a> page for this gene.</p>};
 

--- a/modules/EnsEMBL/Web/Component/Gene/HomologAlignment.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/HomologAlignment.pm
@@ -85,10 +85,13 @@ sub content {
         my $label             = $external_species ? $pan_lookup->{$prodname}{'display_name'} : $species_defs->species_label($member_species);
         my $location       = sprintf '%s:%d-%d', $gene->dnafrag->name, $gene->dnafrag_start, $gene->dnafrag_end;
        
-        if (!$second_gene && $member_species ne $species && $hub->param('species_' .$prodname) eq 'off') {
-          $flag = 0;
-          $skipped{$label}++;
-          next;
+        if (!$second_gene && $member_species ne $species) {
+          my $species_toggle = $hub->param('species_' .$prodname);
+          if (!defined $species_toggle || $species_toggle eq 'off') {
+            $skipped{$label}++ if defined $species_toggle;
+            $flag = 0;
+            next;
+          }
         }
 
         if ($gene->stable_id eq $gene_id) {

--- a/modules/EnsEMBL/Web/Configuration/Gene.pm
+++ b/modules/EnsEMBL/Web/Configuration/Gene.pm
@@ -80,7 +80,7 @@ sub populate_tree {
 
   my $compara_menu = $self->create_node('Compara', 'Comparative Genomics',
     [qw(strain_button_panel EnsEMBL::Web::Component::Gene::Compara_Portal)],
-    {'availability' => 'gene database:compara core not_strain'}
+    {'availability' => 'gene database:compara core has_default_compara'}
   );
   
   $compara_menu->append($self->create_node('Compara_Alignments', 'Genomic alignments',
@@ -93,34 +93,34 @@ sub populate_tree {
   
   $compara_menu->append($self->create_node('Compara_Tree', 'Gene tree',
     [qw( image EnsEMBL::Web::Component::Gene::ComparaTree )],
-    { 'availability' => 'gene database:compara core has_gene_tree not_strain' }
+    { 'availability' => 'gene database:compara core has_gene_tree' }
   ));
   
   $compara_menu->append($self->create_node('SpeciesTree', 'Gene gain/loss tree',
       [qw( image EnsEMBL::Web::Component::Gene::SpeciesTree )],
-      { 'availability' => 'gene database:compara core has_species_tree not_strain' }
+      { 'availability' => 'gene database:compara core has_species_tree' }
     ));
     
   my $ol_node = $self->create_node('Compara_Ortholog', 'Orthologues',
     [qw( orthologues EnsEMBL::Web::Component::Gene::ComparaOrthologs )],
-    { 'availability' => 'gene database:compara core has_orthologs not_strain', 'concise' => 'Orthologues' }
+    { 'availability' => 'gene database:compara core has_orthologs', 'concise' => 'Orthologues' }
   );
   
   $ol_node->append($self->create_subnode('Compara_Ortholog/Alignment', 'Orthologue alignment',
     [qw( alignment EnsEMBL::Web::Component::Gene::HomologAlignment )],
-    { 'availability'  => 'gene database:compara core has_orthologs not_strain', 'no_menu_entry' => 1 }
+    { 'availability'  => 'gene database:compara core has_orthologs', 'no_menu_entry' => 1 }
   ));
   
   $compara_menu->append($ol_node);
   
   my $pl_node = $self->create_node('Compara_Paralog', 'Paralogues',
     [qw(paralogues EnsEMBL::Web::Component::Gene::ComparaParalogs)],
-    { 'availability' => 'gene database:compara core has_paralogs not_strain', 'concise' => 'Paralogues' }
+    { 'availability' => 'gene database:compara core has_paralogs', 'concise' => 'Paralogues' }
   );
   
   $pl_node->append($self->create_subnode('Compara_Paralog/Alignment', 'Paralogue alignment',
     [qw( alignment EnsEMBL::Web::Component::Gene::HomologAlignment )],
-    { 'availability' => 'gene database:compara core has_paralogs not_strain', 'no_menu_entry' => 1 }
+    { 'availability' => 'gene database:compara core has_paralogs', 'no_menu_entry' => 1 }
   ));
   
   $compara_menu->append($pl_node);
@@ -134,7 +134,7 @@ sub populate_tree {
     my $strain_type_name = ucfirst $strain_type;
     my $strain_compara_menu = $self->create_node('Strain_Compara', $strain_type_name . 's',
       [qw(strain_button_panel EnsEMBL::Web::Component::Gene::Compara_Portal)],
-      {'availability' => 'gene database:compara core', 'closed' => $collapse }
+      {'availability' => 'gene database:compara core has_strain_compara', 'closed' => $collapse }
     );
 
     $strain_compara_menu->append($self->create_node('Strain_Compara_Tree', 'Gene tree',

--- a/modules/EnsEMBL/Web/Form/ViewConfigForm.pm
+++ b/modules/EnsEMBL/Web/Form/ViewConfigForm.pm
@@ -552,7 +552,7 @@ sub add_species_fieldset {
   my $cdb = $function =~ /pan_compara/ ? 'compara_pan_ensembl' : 'compara';
 
   my $page_action = $hub->referer->{'ENSEMBL_ACTION'};
-  my $strain = $hub->param('strain') || $hub->action =~ /^Strain_/ || $page_action =~ /^Strain_/;
+  my $strain = $hub->param('strain') || $page_action =~ /^Strain_/;
 
   my $compara_spp = EnsEMBL::Web::Utils::Compara::orthoset_prod_names($hub, $cdb, $strain);
 

--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -61,7 +61,6 @@ sub availability {
     } elsif ($obj->isa('Bio::EnsEMBL::Compara::Family')) {
       $availability->{'family'} = 1;
     }
-    $availability->{'not_strain'} = $self->hub->is_strain ? 0 : 1; #availability to check if species is a strain or not, it has to be this way round (used in Gene Configuration to disable main compara view on strain species)
     $availability->{"has_interactions"} = $self->interaction_check; # check if interactions data is available for a gene
 
     $self->{'_availability'} = $availability;

--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -61,6 +61,7 @@ sub availability {
     } elsif ($obj->isa('Bio::EnsEMBL::Compara::Family')) {
       $availability->{'family'} = 1;
     }
+    $availability->{'not_strain'} = $self->hub->is_strain ? 0 : 1; #availability to check if species is a strain or not, it has to be this way round (used in Gene Configuration to disable main compara view on strain species)
     $availability->{"has_interactions"} = $self->interaction_check; # check if interactions data is available for a gene
 
     $self->{'_availability'} = $availability;

--- a/modules/EnsEMBL/Web/Query/Availability/Gene.pm
+++ b/modules/EnsEMBL/Web/Query/Availability/Gene.pm
@@ -307,6 +307,25 @@ sub get {
   if($self->variation_db_adaptor($args)) {
     $out->{'has_phenotypes'} = $self->_get_phenotype($args);
   }
+
+  $out->{'has_default_compara'} = $out->{'database:compara'} && (
+    $out->{'has_gene_tree'}
+    || $out->{'has_species_tree'}
+    || $out->{'has_orthologs'}
+    || $out->{'has_paralogs'}
+    || $out->{'has_homoeologs'}
+    || $out->{'has_homologs'}
+    || $out->{'family'}
+    || $out->{'has_alignments'}
+  );
+
+  $out->{'has_strain_compara'} = $out->{'database:compara'} && (
+    $out->{'has_strain_gene_tree'}
+    || $out->{'has_strain_orthologs'}
+    || $out->{'has_strain_paralogs'}
+    || $out->{'has_strain_homoeologs'}
+  );
+
   if($out->{'database:compara_pan_ensembl'} && $self->pancompara_db_adaptor) {
     $out->{'family_pan_ensembl'} = !!$counts->{'families_pan'};
     $out->{'has_gene_tree_pan'} =
@@ -314,6 +333,14 @@ sub get {
     for (qw(alignments_pan paralogs_pan orthologs_pan)) {
       $out->{"has_$_"} = $counts->{$_};
     }
+
+    $out->{'has_pan_compara'} = $out->{'database:compara_pan_ensembl'} && (
+      $out->{'has_gene_tree_pan'}
+      || $out->{'has_orthologs_pan'}
+      || $out->{'has_paralogs_pan'}
+      || $out->{'family_pan_ensembl'}
+      || $out->{'has_alignments_pan'}
+    );
   }
 
   return [$out];

--- a/modules/EnsEMBL/Web/Utils/Compara.pm
+++ b/modules/EnsEMBL/Web/Utils/Compara.pm
@@ -1,0 +1,93 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2025] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::Utils::Compara;
+
+use strict;
+
+
+sub _get_non_strain_orthoset_prod_names {
+  my ($hub, $url_lookup) = @_;
+
+  my $cdb_info = $hub->species_defs->multi_val('DATABASE_COMPARA');
+
+  my $prod_name_set;
+  if (exists $cdb_info->{'CLUSTERSET_PRODNAMES'} && exists $cdb_info->{'CLUSTERSET_PRODNAMES'}{'default'}) {
+    $prod_name_set = $cdb_info->{'CLUSTERSET_PRODNAMES'}{'default'};
+  } else {
+    $prod_name_set = $cdb_info->{'COMPARA_SPECIES'};
+  }
+
+  # Skip species absent from URL lookup (e.g. Human in Ensembl Plants)
+  return [grep { $prod_name_set->{$_} && exists $url_lookup->{$_} } keys %{$prod_name_set}];
+}
+
+
+sub _get_strain_orthoset_prod_names {
+  my ($hub, $url_lookup) = @_;
+
+  my $species_defs = $hub->species_defs;
+  my $cdb_info = $species_defs->multi_val('DATABASE_COMPARA');
+  my $species_url = $hub->species;
+
+  my $orthoset_prod_names = [];
+  if ($species_url && $species_url ne 'Multi') {
+    my $strain_cset_id = $species_defs->get_config($species_url, 'RELATED_TAXON');
+    if (exists $cdb_info->{'CLUSTERSET_PRODNAMES'} && exists $cdb_info->{'CLUSTERSET_PRODNAMES'}{$strain_cset_id}) {
+      $orthoset_prod_names = [keys %{$cdb_info->{'CLUSTERSET_PRODNAMES'}{$strain_cset_id}}];
+    }
+  }
+
+  unless (@{$orthoset_prod_names}) {
+    $orthoset_prod_names = _get_non_strain_orthoset_prod_names($hub, $url_lookup);
+  }
+
+  return $orthoset_prod_names;
+}
+
+
+sub orthoset_prod_names {
+  ## Gets the appropriate set of Compara orthology production
+  ## names for the given hub, Compara and strain status.
+  my ($hub, $compara_db, $strain) = @_;
+
+  $compara_db |= 'compara';
+  $strain |= 0;
+
+  my $species_defs = $hub->species_defs;
+
+  my $url_lookup = $species_defs->prodnames_to_urls_lookup($compara_db);
+  delete $url_lookup->{'ancestral_sequences'};
+
+  my $orthoset_prod_names = [];
+  if ($compara_db eq 'compara_pan_ensembl') {
+    $orthoset_prod_names = [keys %{$url_lookup}];
+  } else {
+    if ($strain) {
+      $orthoset_prod_names = _get_strain_orthoset_prod_names($hub, $url_lookup);
+    } else {
+      $orthoset_prod_names = _get_non_strain_orthoset_prod_names($hub, $url_lookup);
+    }
+  }
+
+  return $orthoset_prod_names;
+}
+
+
+1;

--- a/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
@@ -112,7 +112,7 @@ sub form_fields {
     'value' => 'on',
   };
 
-  my @groups = ($self->hub->param('strain') || $self->hub->is_strain) ? () : $self->_groups; #hide these options for strain view or strain species
+  my @groups = $self->hub->param('strain') ? () : $self->_groups; #hide these options for strain view
 
   if (@groups) {
     my $taxon_labels = $self->hub->species_defs->TAXON_LABEL;

--- a/modules/EnsEMBL/Web/ZMenu/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaOrthologs.pm
@@ -28,7 +28,7 @@ use base qw(EnsEMBL::Web::ZMenu);
 sub content {
   my $self        = shift;
   my $hub         = $self->hub;
-  my $strain_url  = $hub->is_strain || $hub->param('strain') ? "Strain_" : "";
+  my $strain_url  = $hub->param('strain') ? "Strain_" : "";
   
   my $align_url = $hub->url({
     type     => 'Gene',


### PR DESCRIPTION
## Description

Strain-group metadata to represent strain-reference relationships have become increasingly common in recent years, with 75 genomes in about 15 such groups in Ensembl Vertebrates 115.

The same period has seen strain gene-tree collections being used more broadly, to a point where Ensembl Plants release 115 cultivar gene-tree collections are expected to have almost as many genomes (123) as are in the default gene-tree collection (126).

Lines between strain and non-strain comparative data are becoming increasingly blurred. For some time, a proportion of genomes in strain collections have not themselves been strains, and as of release 115, there is at least one strain-tagged genome in a default gene-tree collection.

Finally, gene-tree configuration has become more complex in release 115 with the introduction of "interlocking" strain collections — strain species sets sharing one or more genomes in common with each other — which are challenging to handle in a system which has been built to treat strain and default gene-tree collections as binary.

With the accumulation of data changes, some unexpected hiccups have come to light, including:
- inactive default homology links for a genome tagged as a strain-level genome (ENSCOMPARASW-8481);
- orthologue table of strain collections not showing orthologues from genomes that are in another strain collection (ENSCOMPARASW-8511);
- various strain-related issues (ENSCOMPARASW-8512).

In conjunction with [eg-web-common PR 144](https://github.com/EnsemblGenomes/eg-web-common/pull/144), this PR would decouple strain view status from the strain status of individual genomes, making comparative web views more robust to data changes, and making it possible to disentangle orthology data from different gene-tree clustersets.

### General changes

- Addition of module `EnsEMBL::Web::Utils::Compara` containing one public function `orthoset_prod_names`, which returns a list of the appropriate genome production names for a set of orthologues based on relevant information such as the Compara database (e.g. `compara_pan_ensembl`) or whether the orthologues are in a strain view.
- Inclusion of `CLUSTERSET_PRODNAMES` data in `MULTI.db.packed` for use by `EnsEMBL::Web::Utils::Compara::orthoset_prod_names`, containing production names by clusterset in an Ensembl division that has at least one strain gene-tree collection (e.g. Vertebrates, Plants, Metazoa).
- Use of `EnsEMBL::Web::Utils::Compara::orthoset_prod_names` to get the set of relevant production names as needed in various modules. This ensures the appropriate set of production names is configured in orthologue views. As a side benefit, it's less often necessary to explicitly skip `ancestral_sequences` or species absent from URL lookup (e.g. Human in Ensembl Plants), since such genomes are excluded from `orthoset_prod_names`.
- Instead of checking strain view status with `$hub->is_strain`, one or more of three cues are used: `$hub->action =~ /^Strain_/` (current view is a strain view), `$hub->referer->{'ENSEMBL_ACTION'} =~ /^Strain_/` (referer view is a strain view) or `$hub->param('strain')` (a `strain` parameter has been passed).
- The `not_strain` availability tag is dropped, so that strains can have default gene-tree/homology links.
- Availability tags `has_default_compara` and `has_strain_compara` are used to determine whether default and strain Compara portal links are active.

### EnsEMBL::Web::Component::Gene::ComparaOrthologs

- The question, "Should we be showing this orthologue on this page by default?" is now answered by checking if the given production name is in the list returned by `EnsEMBL::Web::Utils::Compara::orthoset_prod_names`. If the answer is no, the production name is stored in `$species_not_relevant` and used to filter homologies, but not included in the list of species without orthologues, because they were not in any of the gene-tree analyses relevant to the given orthologue view.
- Relevant species and strains lacking orthologues with the current gene are now counted together in `$species_not_shown`, but the breakdown of strain types is stored in `$unshown_strain_types`.
- A single list of "Species without orthologues" (ordered by display name) is shown at the bottom of the orthologue view. If relevant, a strain-type breakdown is placed after the `no_ortho_count` total showing the different strain types (e.g. breeds, cultivars).
- Because the orthologue summary table is generated using `orthoset_prod_names`, it takes account only of genomes in the relevant clusterset(s). The effect of this on the orthologue summary is most clear for genomes in the Drosophila pangenome (e.g. Drosophila elegans), which now has only two rows in its orthologue summary: "Diptera" and "All".

### EnsEMBL::Web::Component::Gene::HomologAlignment

- Homology alignments are not shown if the homologue is in a genome that is not in one of the relevant clustersets.

### EnsEMBL::Web::Component::Gene::ComparaTree

- False alarms affecting the "Phylogenetic model selection" info box are reduced by fetching the strain clusterset_id (e.g. `murinae`) from the `RELATED_TAXON` config.
- The gene-tree option to "Collapse all the nodes at the taxonomic rank" is deactivated in strain views, rather than for gene trees viewed from a non-reference-strain genome.

## Views affected

The various changes in this pull request will affect comparative items in the gene sidebar menu, Compara portal pages, gene-tree views, orthologue/paralogue/homologue table views, orthologue/paralogue/homologue alignment views, and the "Selected species" field set in orthologue table and orthologue alignment view config forms.

Please see related JIRA tickets for more information on the effects of these changes.

## Possible complications

Because of the addition of `CLUSTERSET_PRODNAMES` to the `MULTI.db.packed` file, this PR would require repacking that file for Ensembl Vertebrates and Plants.

The main possible source of complications is the `ViewConfigForm::add_species_fieldset` method, which is used in both `EnsEMBL::Web::ViewConfig::Gene::ComparaOrthologs` and `EnsEMBL::Web::ViewConfig::Gene::Family` modules, and potentially elsewhere.

However, for comparative views that do not contain strain-level genomes, the list of Compara species should remain the same as before, ultimately being taken from the `COMPARA_SPECIES` set.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- ENSCOMPARASW-8481
- ENSCOMPARASW-8511
- ENSCOMPARASW-8512
- ENSCOMPARASW-8516