### PR TITLE
Remove unused fields from gene gain/loss tree export form

### DIFF
--- a/modules/EnsEMBL/Web/Component/DataExport/SpeciesTree.pm
+++ b/modules/EnsEMBL/Web/Component/DataExport/SpeciesTree.pm
@@ -43,7 +43,7 @@ sub content {
                 };
 
   ## Options per format
-  my $fields_by_format = {'PhyloXML' => $self->phyloxml_fields};
+  my $fields_by_format = {'PhyloXML' => []};
 
   ## Create settings form (comes with some default fields - see parent)
   my $form = $self->create_form($settings, $fields_by_format, 1);


### PR DESCRIPTION
## Description

This PR would remove unused fields from the gene gain/loss tree export form.

The existing checkbox fields — "cDNA rather than protein sequence", "Aligned sequences with gaps" and "Omit sequences" — are relevant to gene-tree export, but not to gene gain/loss (species) tree export.

## Views affected

This would affect the gene gain/loss tree config modal window, but because the removed options are unused, it would not affect the gene gain/loss tree view itself.

Example before:
![cafe_fields_before](https://github.com/user-attachments/assets/ebd54be6-4f74-419f-a080-4e4ba94d81eb)

Example after:
![cafe_fields_after](https://github.com/user-attachments/assets/d87bdddd-2e27-4396-8903-a855ea11daa9)

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
