### PR TITLE
Facilitate config of contributing gene trees

### DIFF
--- a/modules/EnsEMBL/Web/Command/DataExport/Output.pm
+++ b/modules/EnsEMBL/Web/Command/DataExport/Output.pm
@@ -157,7 +157,7 @@ sub process {
     $url_params->{'__clear'}        = 1;
     ## Pass parameters needed for Back button to work
     my @core_params = keys %{$hub->core_object('parameters')};
-    push @core_params, qw(export_action data_type data_action component align g1 node strain hom_id);
+    push @core_params, qw(export_action data_type data_action component align align_type clusterset_id g1 hom_id node strain);
     push @core_params, $self->config_params; 
     foreach (@core_params) {
       my @values = $component->param($_);

--- a/modules/EnsEMBL/Web/Component/DataExport/GeneTree.pm
+++ b/modules/EnsEMBL/Web/Component/DataExport/GeneTree.pm
@@ -41,7 +41,7 @@ sub content {
   my $view_config  = $self->view_config;
 
   my $settings = $view_config->form_fields('export');
-  $settings->{'Hidden'} = [qw(align align_type node strain)];
+  $settings->{'Hidden'} = [qw(align align_type clusterset_id node strain)];
 
   ## Add export-specific settings
   my $fields_by_format;
@@ -87,9 +87,9 @@ sub content {
 
     ## Options per format
     $fields_by_format = [{'Tree formats' => {
-                                    'Newick'    => [qw(newick_mode clusterset_id)],
-                                    'NHX'       => [qw(nhx_mode clusterset_id)],
-                                    'Text'      => [qw(scale clusterset_id)],
+                                    'Newick'    => [qw(newick_mode)],
+                                    'NHX'       => [qw(nhx_mode)],
+                                    'Text'      => [qw(scale)],
                                     'OrthoXML'  => [],
                                     'PhyloXML'  => $self->phyloxml_fields, 
                             }}];

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -164,12 +164,22 @@ sub content {
   }
 
   if ($hub->type eq 'Gene') {
-    if ($tree->tree->clusterset_id ne $clusterset_id) {
-      $html .= $self->_info('Phylogenetic model selection',
-        sprintf(
-          'The phylogenetic model <i>%s</i> is not available for this tree. Showing the <i>%s</i> tree instead.', $clusterset_id, $tree->tree->clusterset_id,
-          )
-      );
+    my $tree_clusterset_id = $tree->tree->clusterset_id;
+    if ($tree_clusterset_id ne $clusterset_id) {
+      my $strain_clusterset_id = $hub->species_defs->get_config($self->hub->species, 'RELATED_TAXON');
+      # When switching between the respective consensus trees of the default and strain gene-tree view
+      # (e.g. 'default' to 'murinae'), each clusterset_id represents the consensus clusterset for its
+      # respective view, so we skip the model selection info box in such cases.
+      unless ( $strain_clusterset_id
+               && (($clusterset_id eq 'default') && ($tree_clusterset_id eq $strain_clusterset_id) || ($clusterset_id eq $strain_clusterset_id) && ($tree_clusterset_id eq 'default')) ) {
+        $html .= $self->_info('Phylogenetic model selection',
+          sprintf(
+            'The phylogenetic model <i>%s</i> is not available for this tree. Showing the <i>%s</i> tree instead.',
+            $clusterset_id,
+            $tree_clusterset_id,
+            )
+        );
+      }
     } elsif ($tree->tree->ref_root_id) {
 
       my $text = sprintf(

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -171,7 +171,13 @@ sub content {
       # (e.g. 'default' to 'murinae'), each clusterset_id represents the consensus clusterset for its
       # respective view, so we skip the model selection info box in such cases.
       unless ( $strain_clusterset_id
-               && (($clusterset_id eq 'default') && ($tree_clusterset_id eq $strain_clusterset_id) || ($clusterset_id eq $strain_clusterset_id) && ($tree_clusterset_id eq 'default')) ) {
+               &&
+               (
+                 ($clusterset_id eq 'default' && $tree_clusterset_id eq $strain_clusterset_id)
+                 ||
+                 ($clusterset_id eq $strain_clusterset_id && $tree_clusterset_id eq 'default')
+               )
+             ) {
         $html .= $self->_info('Phylogenetic model selection',
           sprintf(
             'The phylogenetic model <i>%s</i> is not available for this tree. Showing the <i>%s</i> tree instead.',

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -187,7 +187,7 @@ sub content {
       );
       my $rank = $tree->tree->get_tagvalue('k_score_rank');
       my $score = $tree->tree->get_tagvalue('k_score');
-      $text .= sprintf('<br/>This tree is the <b>n&deg;%d</b> closest to the final tree, with a K-distance of <b>%f</b>, as computed by <a href="http://molevol.cmima.csic.es/castresana/Ktreedist.html">Ktreedist</a>.', $rank, $score) if $rank;
+      $text .= sprintf('<br/>This tree is the <b>n&deg;%d</b> closest to the final tree, with a K-distance of <b>%f</b>, as computed by <a href="https://www.biologiaevolutiva.org/jcastresana/Ktreedist.html">Ktreedist</a>.', $rank, $score) if $rank;
       $html .= $self->_info('Phylogenetic model selection', $text);
     }
   }

--- a/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
@@ -193,7 +193,7 @@ sub _replace_default_clusterset_id_option {
   my $default_option = $cset_id_dropdown->get_elements_by_attribute({'value' => 'default'})->[0];
   my $cset_id_option = $cset_id_dropdown->dom->create_element('option', {'value' => $clusterset_id, 'inner_HTML' => 'Final (merged) tree'});
   $default_option->after($cset_id_option);
-  $cset_id_dropdown->remove_option('default');
+  $default_option->remove();
 }
 
 1;


### PR DESCRIPTION
## Description

In conjunction with [eg-web-metazoa PR 48](https://github.com/EnsemblGenomes/eg-web-metazoa/pull/48), this pull request would facilitate handling of gene tree configuration.

This PR would:
- add method `EnsEMBL::Web::Object::Gene::_resolve_clusterset_ids`, which resolves the appropriate consensus and alternative `clusterset_id` values;
- update `EnsEMBL::Web::Object::Gene::get_GeneTree` to prioritise an explicit `clusterset_id` parameter over a consensus clusterset (e.g. `"pig_breeds"`) where that `clusterset_id` represents an alternative clusterset appropriate to the given gene-tree view, facilitating display of contributing clustersets of a strain gene tree (e.g. `"pig_breeds_raxml_parsimony"`);
- change `EnsEMBL::Web::Object::Gene::get_GeneTree` to use the consensus clusterset if a given gene or tree is not relevant to the current gene-tree view;
- adjust the `EnsEMBL::Draw::GlyphSet::genetree::features` method to use the `ref_root_id` of a gene tree in order to fetch the reference/consensus gene tree (instead of explicitly requesting the `"default"` gene tree);
- add method `EnsEMBL::Web::ViewConfig::Gene::ComparaTree::_replace_default_clusterset_id_option`, which can be used to replace the `"default"` `clusterset_id` option with an explicit default `clusterset_id` (e.g. strain consensus clusterset `"murinae"`);
- update method `EnsEMBL::Web::ViewConfig::Gene::ComparaTree::init_form_non_cacheable` to facilitate configuration of the contributing clustersets of a strain gene tree, and to replace the default `clusterset_id` with the relevant strain consensus clusterset;
- ensure `align_type` and `clusterset_id` are passed as parameters for data export, while removing the (unused) Newick/NHX/Text `clusterset_id` dropdown from the gene-tree export config modal window;
- fix a link to the Ktreedist webpage.

## Views affected

This PR would affect strain and default gene-tree views, as well as the gene-tree config modal window.

See related ticket ENSCOMPARASW-8520 for an example test case.

## Possible complications

None expected, though the changes to handling of `$clusterset_id` in method `EnsEMBL::Web::Object::Gene::get_GeneTree` merit consideration.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- ENSCOMPARASW-8520