### PR TITLE
Get basal tree when accessing supertree and supertree homologies

### DIFF
--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -778,7 +778,7 @@ sub get_homologies {
     my $hub = $self->hub;
     my $strain_tree = $hub->species_defs->get_config($hub->species,'RELATED_TAXON') if($hub->param('data_action') =~ /strain_/i);
     my $tree = $self->get_GeneTree($compara_db, 1, $strain_tree);
-    $tree = $self->get_basal_gene_tree($compara_db, $tree);
+    $tree = $self->_get_basal_gene_tree($compara_db, $tree);
     $tree->expand_subtrees if $tree->tree_type eq 'supertree';
     my %members_to_keep = map { $_->dbID => 1 } @{$tree->get_all_Members()};
     $tree->release_tree;
@@ -924,7 +924,7 @@ sub get_homologue_alignments {
 
     ## Make sure we use the correct tree
     my $tree = $self->get_GeneTree($compara_db, 1, $strain_tree);
-    $tree = $self->get_basal_gene_tree($compara_db, $tree);
+    $tree = $self->_get_basal_gene_tree($compara_db, $tree);
     $msa = $tree->get_alignment_of_homologues(@params);
     $tree->release_tree;
   }
@@ -959,7 +959,7 @@ sub get_GeneTree {
     if ($parent->tree_type ne 'clusterset') {
 
       # To get the full supertree, we need to get the basal tree.
-      $parent = $self->get_basal_gene_tree($compara_db, $parent);
+      $parent = $self->_get_basal_gene_tree($compara_db, $parent);
 
       my %subtrees;
       my $total_leaves = 0;
@@ -1006,7 +1006,7 @@ sub get_GeneTree {
 
 # Method to fetch the basal gene tree,
 # whose root is linked to the clusterset.
-sub get_basal_gene_tree {
+sub _get_basal_gene_tree {
     my ($self, $compara_db, $next_tree) = @_;
 
     # The basal tree can be a regular tree, a supertree, or even a

--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -778,7 +778,10 @@ sub get_homologies {
     my $hub = $self->hub;
     my $strain_tree = $hub->species_defs->get_config($hub->species,'RELATED_TAXON') if($hub->param('data_action') =~ /strain_/i);
     my $tree = $self->get_GeneTree($compara_db, 1, $strain_tree);
+    $tree = $self->get_basal_gene_tree($compara_db, $tree);
+    $tree->expand_subtrees if $tree->tree_type eq 'supertree';
     my %members_to_keep = map { $_->dbID => 1 } @{$tree->get_all_Members()};
+    $tree->release_tree;
 
     my @gene_tree_homologies;
     foreach my $homology (@$homologies_array) {
@@ -920,16 +923,9 @@ sub get_homologue_alignments {
     push @params, $species if scalar @$species;
 
     ## Make sure we use the correct tree
-    if ($tree->root->is_supertree) {
-      $msa = $tree->get_alignment_of_homologues(@params);
-    } else {
-      my $supertree = $database->get_GeneTreeAdaptor->fetch_parent_tree($tree);
-      if ($supertree and $supertree->tree_type ne 'clusterset') {
-        $msa = $supertree->get_alignment_of_homologues(@params);
-      } else {
-        $msa = $tree->get_alignment_of_homologues(@params);
-      }
-    }
+    my $tree = $self->get_GeneTree($compara_db, 1, $strain_tree);
+    $tree = $self->get_basal_gene_tree($compara_db, $tree);
+    $msa = $tree->get_alignment_of_homologues(@params);
     $tree->release_tree;
   }
   return $msa;
@@ -962,13 +958,8 @@ sub get_GeneTree {
     my $parent      = $adaptor->fetch_parent_tree($tree);
     if ($parent->tree_type ne 'clusterset') {
 
-      # To get the full supertree, we need to keep fetching
-      # the next parent up until we reach the clusterset.
-      my $next_parent = $parent;
-      do {
-        $parent = $next_parent;
-        $next_parent = $adaptor->fetch_parent_tree($parent);
-      } until ($next_parent->tree_type eq 'clusterset');
+      # To get the full supertree, we need to get the basal tree.
+      $parent = $self->get_basal_gene_tree($compara_db, $parent);
 
       my %subtrees;
       my $total_leaves = 0;
@@ -1011,6 +1002,25 @@ sub get_GeneTree {
     }
   }
   return $self->{$cache_key};
+}
+
+# Method to fetch the basal gene tree,
+# whose root is linked to the clusterset.
+sub get_basal_gene_tree {
+    my ($self, $compara_db, $next_tree) = @_;
+
+    # The basal tree can be a regular tree, a supertree, or even a
+    # supertree of a supertree, so in order to make sure we get it,
+    # we fetch successive parent trees until we reach the clusterset.
+    my $gene_tree_adaptor = $self->database($compara_db)->get_GeneTreeAdaptor();
+    my $curr_tree;
+    do {
+      $curr_tree = $next_tree;
+      $next_tree = $gene_tree_adaptor->fetch_parent_tree($curr_tree);
+    } until ($next_tree->tree_type eq 'clusterset');
+    $next_tree->release_tree;
+
+    return $curr_tree;
 }
 
 sub get_gene_slices {


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

This pull request would:
- add internal method `EnsEMBL::Web::Object::Gene::_get_basal_gene_tree` to fetch the basal gene tree, which is a gene tree or supertree linked to the relevant clusterset;
- use this new method to fetch the basal supertree in `EnsEMBL::Web::Object::Gene::get_GeneTree`;
- use the method in `EnsEMBL::Web::Object::Gene::get_homologies` to ensure that exported homology XML files include homologies inferred across a supertree, or across a supertree of a supertree; 
- use method`_get_basal_gene_tree` in `EnsEMBL::Web::Object::Gene::get_homologue_alignments` to ensure that exported homology alignments (e.g. FASTA) include homologies inferred across a supertree of a supertree.

## Views affected

### get_homologue_alignments

Exported homology alignments (e.g. FASTA) now include homologies inferred across a supertree of a supertree.

For example, in the orthologue view of giant panda gene ENSAMEG00000024196, clicking on the "Download whole table" option at top right of the orthologue table downloads a CSV containing 41 orthologues.

On the [staging site](http://staging.ensembl.org/Ailuropoda_melanoleuca/Gene/Compara_Ortholog?g=ENSAMEG00000024196), if you click on the button to "Download orthologues", then set "File format" to "FASTA" and click the button to "Download", the exported FASTA file contains 40 sequences representing 39 orthologies.

Doing the same on the [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Ailuropoda_melanoleuca/Gene/Compara_Ortholog?g=ENSAMEG00000024196) fetches a FASTA file with 42 sequences, representing 41 orthologies.

The two proteins absent from the FASTA file exported from the staging site — Drosophila melanogaster genes FBgn0037931 and FBgn0039329, with respective protein stable IDs FBpp0081919 and FBpp0289911 — are orthologues of giant panda gene ENSAMEG00000024196, and their most recent common ancestor with that gene is a node of a supertree of a supertree.

### get_homologies

Exported homology XML alignments (e.g. OrthoXML) now include homologies inferred across a supertree, or a supertree of a supertree.

For example, in the orthologue view of C. elegans gene WBGene00007709, clicking on the "Download whole table" option at top right of the orthologue table downloads a CSV containing 4409 orthologues.

On the [staging site](http://staging.ensembl.org/Caenorhabditis_elegans/Gene/Compara_Ortholog?db=core;g=WBGene00007709), if you click on the button to "Download orthologues", then set "File format" to "OrthoXML" and click the button to "Download", the exported OrthoXML file is effectively empty, containing neither `gene` elements nor `orthologGroup` elements.

Doing the same on the [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Caenorhabditis_elegans/Gene/Compara_Ortholog?db=core;g=WBGene00007709) fetches an OrthoXML file with the full set of 4410 `gene` elements and 4409 `orthologGroup` elements.

### get_GeneTree

Method `_get_basal_gene_tree` is used in `get_GeneTree` to reduce repetition, and this is not expected to have any effect on the process of getting the basal supertree.

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- ENSCOMPARASW-7590
