### PR TITLE
Prevent infinite loop in _get_basal_gene_tree

### DIFF
--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -1014,10 +1014,12 @@ sub _get_basal_gene_tree {
     # we fetch successive parent trees until we reach the clusterset.
     my $gene_tree_adaptor = $self->database($compara_db)->get_GeneTreeAdaptor();
     my $curr_tree;
+    my $i = 0;
     do {
       $curr_tree = $next_tree;
       $next_tree = $gene_tree_adaptor->fetch_parent_tree($curr_tree);
-    } until ($next_tree->tree_type eq 'clusterset');
+      $i += 1;
+    } until ($next_tree->tree_type eq 'clusterset' || $i >= 23);
     $next_tree->release_tree;
 
     return $curr_tree;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

This PR would add a little defensive coding to `EnsEMBL::Web::Object::Gene::_get_basal_gene_tree` in order to prevent an infinite loop when fetching the basal gene tree.

It addresses an issue highlighted by @EbiArnie during review of [ensembl-webcode PR 1098](https://github.com/Ensembl/ensembl-webcode/pull/1098).

## Views affected

The affected views are the same as those in #1098.

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- ENSCOMPARASW-7590
