### PR TITLE
Move/delete regulation menu items

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -98,7 +98,6 @@ our $ENSEMBL_SITETYPE                 = 'Ensembl';
 our $ENSEMBL_HELPDESK_EMAIL           = defer { $ENSEMBL_SERVERADMIN };   # Email address for contact form and help pages
 our $PERL_RLIMIT_AS                   = '2560:4096';                      # linux does not honor RLIMIT_DATA, RLIMIT_AS (address space) will work to limit the size of a process
 our $ENSEMBL_REST_URL                 = 'http://rest.mydomain.org';       # url to your REST service
-our $EQTL_REST_URL                    = 'http://www.ebi.ac.uk/eqtl/api/';       # url to EQTL REST service
 our $CGI_POST_MAX                     = 20 * 1024 * 1024; # 20MB file upload max limit
 our $UPLOAD_SIZELIMIT_WITHOUT_INDEX   = 10 * 1024 * 1024; # 10MB max allowed for url uploads that don't have index files in the same path
 our $TRACKHUB_TIMEOUT                 = 60 * 60 * 24;     # Timeout for outgoing trackhub requests

--- a/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
+++ b/modules/EnsEMBL/Web/Component/Variation/Mappings.pm
@@ -477,54 +477,10 @@ sub render_tables {
   my ($self, $table, $reg_table, $motif_table, $flag) = @_;
 
   my $table_html =  ($table->has_rows && $flag ? '<h2>Gene and Transcript consequences</h2>'.$table->render : '<h3>No Gene or Transcript consequences</h3>').
-                    $self->_render_eqtl_table.
                     ($reg_table->has_rows && $flag ? '<h2>Regulatory feature consequences</h2>'.$reg_table->render : '<h3>No overlap with Ensembl Regulatory features</h3>').
                     ($motif_table->has_rows && $flag ? '<h2>Motif feature consequences</h2>'.$motif_table->render : '<h3>No overlap with Ensembl Motif features</h3>');
                     
   return $table_html;
-}
-
-sub _render_eqtl_table {
-  my $self  = shift;
-  my $hub   = $self->hub;
-
-  my $eqtl_table_html = '';
-
-  if ($hub->species eq 'Homo_sapiens' && (my $rest_url = $hub->species_defs->EQTL_REST_URL)) {
-    # empty table for eQTLs - get populated by JS via REST
-    my @eqtl_columns  = (
-      { key => 'gene_id',    title => 'Gene',                        sort => 'html'    },
-      { key => 'pvalue',     title => 'P-value (-log<sub>10</sub>)', sort => 'numeric',  help => "Nominal p-values of the individual variant-gene pair." },
-      { key => 'beta',       title => 'Effect size',                 sort => 'numeric',  help => "Effect of the alternative allele (ALT) relative to the reference allele (REF) (i.e., the eQTL effect allele is the ALT allele)."},
-      { key => 'qtl_group',  title => 'Tissue',                      sort => 'string'  },
-    );
-
-    # add dummy rows to get pagination working
-    my %dummy_row   = map { $_->{'key'} => 0 } @eqtl_columns;
-    my @dummy_rows  = map {{ %dummy_row }} 0..10;
-
-    # create table
-    my $eqtl_table = $self->new_table(\@eqtl_columns, \@dummy_rows, {
-      data_table => 1, sorting => [ 'pvalue desc' ], data_table_config => {
-        iDisplayLength => 10, 
-        aLengthMenu => [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]]
-      }
-    });
-
-    my $assosiation_url = sprintf('%sassociations/%s?size=1000', $rest_url, $hub->param('v'));
-
-    $eqtl_table_html = sprintf('<div class="hidden _variant_eqtl_table">
-      <input type="hidden" class="panel_type" value="EQTLTable">
-      <input type="hidden" name="eqtl_rest_endpoint" class="js_param" value="%s">
-      <input type="hidden" name="eqtl_gene_url_template" class="js_param" value="%s">
-      <h2>Gene expression correlations</h2>%s<h3 class="_no_data">No Gene expression correlations</h3>
-      </div>',
-      $assosiation_url,
-      $hub->url({'type' => 'Gene', 'action' => 'Regulation', 'g' => '{{geneId}}', 'r' => undef}),
-      $eqtl_table->render
-    );
-  }
-  return $eqtl_table_html;
 }
 
 # Mapping_table

--- a/modules/EnsEMBL/Web/Configuration/Gene.pm
+++ b/modules/EnsEMBL/Web/Configuration/Gene.pm
@@ -225,14 +225,6 @@ sub populate_tree {
     { 'availability'  => 'gene has_gxa' }
   );
 
-  $self->create_node('Regulation', 'Regulation',
-    [qw(
-      regulation EnsEMBL::Web::Component::Gene::RegulationImage
-      features   EnsEMBL::Web::Component::Gene::RegulationTable
-    )],
-    { 'availability' => 'regulation not_patch not_rnaseq' }
-  );
-
   $self->create_node('Matches', 'External references',
     [qw( 
       matches EnsEMBL::Web::Component::Gene::SimilarityMatches 

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -1184,7 +1184,8 @@ sub add_regulation_features {
     my $mfa = $self->hub->get_adaptor('get_MotifFeatureFileAdaptor', 'funcgen');
     my $file = $mfa->fetch_file;
     if ($file) {
-      my $motif_feats = $reg_regions->append_child($self->create_track_node('fg_motif_features', 'Motif features'), {
+      my $motif_feats_menu = $reg_regions->before($self->create_menu_node('motif_features', 'Motif features'));
+      $motif_feats_menu->append_child($self->create_track_node('fg_motif_features', 'Motif features'), {
         db          => $key,
         glyphset    => 'fg_motif_features',
         sources     => 'undef',

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -1184,7 +1184,7 @@ sub add_regulation_features {
     my $mfa = $self->hub->get_adaptor('get_MotifFeatureFileAdaptor', 'funcgen');
     my $file = $mfa->fetch_file;
     if ($file) {
-      my $motif_feats_menu = $reg_regions->before($self->create_menu_node('motif_features', 'Motif features'));
+      my $motif_feats_menu = $menu->first_child->after($self->create_menu_node('motif_features', 'Motif features'));
       $motif_feats_menu->append_child($self->create_track_node('fg_motif_features', 'Motif features'), {
         db          => $key,
         glyphset    => 'fg_motif_features',


### PR DESCRIPTION
## Description
This PR includes the following changes:
- Remove eQTL REST API dependencies
  - Remove `Regulation` menu entry from [gene view](https://www.ensembl.org/Homo_sapiens/Gene/Summary?g=ENSG00000139618;r=13:32315086-32400268)
  - Remove `Gene expression correlation` table from [variant view](https://www.ensembl.org/Homo_sapiens/Variation/Mappings?r=1:230709548-230710548;v=rs699;vdb=variation;vf=11) 
  - Relevant help page updated [separately](https://github.com/Ensembl/public-plugins/commit/4367faffafc1bc95049382fc419f051c50ba3701)
- Move `Motif features` track one level up in the tracks list menu for [location view](https://www.ensembl.org/Homo_sapiens/Location/View?db=core;g=ENSG00000139618;r=13:32315086-32400268)

## JIRA
[ENSWEB-6996](https://embl.atlassian.net/browse/ENSWEB-6996)
[ENSWEB-6961](https://embl.atlassian.net/browse/ENSWEB-6961)

## Sandbox
http://wp-np2-33.ebi.ac.uk:1610
| Before | After |
|----|----|
|<img width="208" height="245" alt="gene_before" src="https://github.com/user-attachments/assets/6e4785f9-1319-4ce5-b1b6-c3257e98084e" />|<img width="208" height="238" alt="gene_after" src="https://github.com/user-attachments/assets/f3f040bc-eee5-46cc-a3b0-863bac6f4a9a" />|
|<img width="208" height="238" alt="variant_before" src="https://github.com/user-attachments/assets/8b59c227-12e2-4869-8ed8-0ffb9200f0d0" />|<img width="207" height="182" alt="variant_after" src="https://github.com/user-attachments/assets/e5ab91e5-eb06-4c0f-9a57-5f15f0dffeb1" />|
|<img width="319" height="332" alt="track_before" src="https://github.com/user-attachments/assets/0dc183d6-09e6-42ee-9dad-dfafa77973c5" />|<img width="319" height="340" alt="track_after" src="https://github.com/user-attachments/assets/bd7c65fd-ccc7-47c3-b682-f68ccb83af09" />|

## Notes

I've made the broken [regulation view](https://www.ensembl.org/Homo_sapiens/Gene/Regulation?g=ENSG00000139618;r=13:32315086-32400268) inaccessible, but left the related code modules untouched, in case we want to migrate to another eQTL data endpoint in the future ([like we did the last time](https://github.com/Ensembl/ensembl-webcode/pull/794)).
