### PR TITLE
Tweak/taxonomy

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -488,7 +488,67 @@ sub collapsed_nodes {
     }
   } elsif ($action =~ /rank_(\w+)/) {
     my $asked_rank = $1;
-    my @rank_order = qw(subspecies species subgenus genus subfamily family superfamily parvorder infraorder suborder order superorder infraclass subclass class superclass subphylum phylum superphylum subkingdom kingdom superkingdom);
+
+    # Rank order info as described in
+    # Schoch et al. (2020) NCBI Taxonomy: a comprehensive update on curation, resources and tools.
+    # <https://europepmc.org/article/MED/32761142>,
+    # with some updates based on NCBI Insights (2024-06-04) Upcoming changes to NCBI Taxonomy classifications.
+    # <https://ncbiinsights.ncbi.nlm.nih.gov/2024/06/04/changes-ncbi-taxonomy-classifications/>
+    # and NCBI Insights (2025-04-25) NCBI Taxonomy updates to virus classification.
+    # <https://ncbiinsights.ncbi.nlm.nih.gov/2025/04/25/ncbi-taxonomy-updates-virus-classification-april-2025/>.
+    my @rank_order = (
+      'isolate',
+      'strain',
+      'serotype',
+      'biotype',
+      'genotype',
+      'serogroup',
+      'pathogroup',
+      'forma',
+      'subvariety',
+      'varietas',
+      'form',
+      'morph',
+      'subspecies',
+      'forma specialis',
+      'special form',
+      'species',
+      'species subgroup',
+      'species group',
+      'subseries',
+      'series',
+      'subsection',
+      'section',
+      'subgenus',
+      'genus',
+      'subtribe',
+      'tribe',
+      'subfamily',
+      'family',
+      'superfamily',
+      'parvorder',
+      'infraorder',
+      'suborder',
+      'order',
+      'superorder',
+      'subcohort',
+      'cohort',
+      'infraclass',
+      'subclass',
+      'class',
+      'superclass',
+      'infraphylum',
+      'subphylum',
+      'phylum',
+      'superphylum',
+      'subkingdom',
+      'kingdom',
+      'domain',
+      'realm',
+      'cellular root',
+      'acellular root',
+    );
+
     my %rank_pos = map {$rank_order[$_] => $_} 0..(scalar(@rank_order)-1);
     my @nodes_to_check = ($tree);
     while (@nodes_to_check) {

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -557,10 +557,13 @@ sub collapsed_nodes {
       next unless $internal_node->species_tree_node;
       my $taxon = $internal_node->species_tree_node->taxon;
       my $this_rank = $taxon->rank;
-      if ($this_rank eq 'no rank') {
+      # Rank 'clade' is assigned to recognised groups without a formal rank.
+      # See Schoch et al. (2020) NCBI Taxonomy: a comprehensive update on curation, resources and tools.
+      # <https://europepmc.org/article/MED/32761142>.
+      if ($this_rank eq 'no rank' || $this_rank eq 'clade') {
         # We traverse the taxonomy upwards until we find a rank, and get
         # the rank just below instead
-        while ($this_rank eq 'no rank') {
+        while ($this_rank eq 'no rank' || $this_rank eq 'clade') {
           $taxon = $taxon->parent;
           last unless $taxon;
           $this_rank = $taxon->rank;

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -561,14 +561,13 @@ sub collapsed_nodes {
       # See Schoch et al. (2020) NCBI Taxonomy: a comprehensive update on curation, resources and tools.
       # <https://europepmc.org/article/MED/32761142>.
       if ($this_rank eq 'no rank' || $this_rank eq 'clade') {
-        # We traverse the taxonomy upwards until we find a rank, and get
-        # the rank just below instead
+        # We traverse the taxonomy upwards until we find a rank
         while ($this_rank eq 'no rank' || $this_rank eq 'clade') {
           $taxon = $taxon->parent;
           last unless $taxon;
           $this_rank = $taxon->rank;
         }
-        $this_rank = $rank_pos{$this_rank}-1;
+        $this_rank = $rank_pos{$this_rank};
         #warn sprintf("Mapped 'no rank' %s to %s\n", $internal_node->species_tree_node->taxon->name, $rank_order[$this_rank]);
       } else {
         $this_rank = $rank_pos{$this_rank};

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -560,13 +560,15 @@ sub collapsed_nodes {
       # Rank 'clade' is assigned to recognised groups without a formal rank.
       # See Schoch et al. (2020) NCBI Taxonomy: a comprehensive update on curation, resources and tools.
       # <https://europepmc.org/article/MED/32761142>.
+      my $i = 0;
       if ($this_rank eq 'no rank' || $this_rank eq 'clade') {
         # We traverse the taxonomy upwards until we find a rank
-        while ($this_rank eq 'no rank' || $this_rank eq 'clade') {
+        do {
           $taxon = $taxon->parent;
           last unless $taxon;
           $this_rank = $taxon->rank;
-        }
+          $i += 1;
+        } while (($this_rank eq 'no rank' || $this_rank eq 'clade') && $i < 1729);
         $this_rank = $rank_pos{$this_rank};
         #warn sprintf("Mapped 'no rank' %s to %s\n", $internal_node->species_tree_node->taxon->name, $rank_order[$this_rank]);
       } else {


### PR DESCRIPTION
## Description

This PR would change the `ComparaTree` to:
- update the NCBI Taxonomy `rank_order` with a current list of ranks;
- treat taxa of rank `clade` similarly to taxa of rank `no rank`; and
- borrow the rank of the closest ancestor of hierarchical rank for taxa of rank `no rank` or `clade`.

## Views affected

This affects the Compara gene-tree view.

Example: [sandbox](http://wp-np2-35.ebi.ac.uk:5098/Lactuca_sativa/Gene/Compara_Tree?db=core;g=gene-LSAT_4X12600) vs [live site](https://plants.ensembl.org//Lactuca_sativa/Gene/Compara_Tree?db=core;g=gene-LSAT_4X12600)

In the above example, if you select "Family" from the dropdown to "Collapse all the nodes at the taxonomic rank":
- the ancestor of genes `OE9A017193` and `FRAEX38873_v2_000040480` is linked to a taxon of rank "tribe", which is collapsed only on the sandbox view because this rank is in the updated `rank_order`;
- in the sandbox, the gene tree is collapsed at several nodes associated with the "50kb inversion clade" (a taxon of rank `clade` descending from a taxon of rank `subfamily`), while on the live site these are not collapsed.

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- N/A
