### PR TITLE
Get info about Archaeans regardless of NV division

### DIFF
--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -2048,9 +2048,9 @@ sub _summarise_pan_compara {
           and o.name IN $prod_names_str
           and r.ensembl_version = $version"
       );    
-  ## Also get info about Archaea from pan-compara itself, for bacteria
+  ## Also get info about Archaea from pan-compara itself
   my $archaea = {};
-  if ($SiteDefs::DIVISION && $SiteDefs::DIVISION eq 'bacteria') {
+  if ($SiteDefs::DIVISION) {
     my $bref = $dbh->selectall_arrayref(
           "select 
             g.name from ncbi_taxa_node a 


### PR DESCRIPTION
## Description

The Pan Compara orthologue breakdown table breaks down orthologue counts by Ensembl division, with separate rows for Bacteria and Archaea. However, the table currently provides orthologue tallies for Archaea only in Ensembl Bacteria.

This PR would change that, so that Bacterial and Archaean orthologues would be tallied separately in all Non-Vertebrate divisions.

## Views affected

This change affects the orthologue summary table in the Pan Compara orthologue view.

For example, in Ensembl Plants release 115, A. thaliana gene EGY2 (AT5G05740) has 13 orthologues across 12 Archaean genomes.

On the [sandbox](http://wp-np2-35.ebi.ac.uk:5098/Arabidopsis_thaliana/Gene/Compara_Ortholog/pan_compara?db=core;g=AT5G05740), these are tallied in the "Archaea" row of the orthologue summary table, while on the [live site](https://plants.ensembl.org/Arabidopsis_thaliana/Gene/Compara_Ortholog/pan_compara?db=core;g=AT5G0574), they are counted along with Bacteria.

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- ENSCOMPARASW-8607
