### PR TITLE
Add gnomAD SV url for external link

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -387,7 +387,7 @@ GEM_J_POP                   = https://togovar.biosciencedbc.jp/doc/datasets/gem_
 GEM_J_POP_USE               = https://togovar.biosciencedbc.jp/doc/datasets/gem_j_wga#terms
 GENE3D                      = https://www.ebi.ac.uk/interpro/entry/cathgene3d/###ID###
 GIANT                       = http://www.broadinstitute.org/collaboration/giant/index.php/Main_Page
-GNOMAD_SV                   = https://gnomad.broadinstitute.org/variant/###ID###?dataset=gnomad_sv_r4?
+GNOMAD_SV                   = https://gnomad.broadinstitute.org/variant/###ID###?dataset=gnomad_sv_r4
 HAPMAP                      = http://www.hapmap.org/cgi-perl/secure/gbrowse/snp_details/hapmap?class=SNP;name=###ID###
 HBVAR                       = http://globin.bx.psu.edu/cgi-bin/hbvar/query_vars3?mode=output&display_format=page&i=###ID### 
 HGMD-PUBLIC                 = http://www.hgmd.cf.ac.uk/ac/index.php

--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -387,6 +387,7 @@ GEM_J_POP                   = https://togovar.biosciencedbc.jp/doc/datasets/gem_
 GEM_J_POP_USE               = https://togovar.biosciencedbc.jp/doc/datasets/gem_j_wga#terms
 GENE3D                      = https://www.ebi.ac.uk/interpro/entry/cathgene3d/###ID###
 GIANT                       = http://www.broadinstitute.org/collaboration/giant/index.php/Main_Page
+GNOMAD_SV                   = https://gnomad.broadinstitute.org/variant/###ID###?dataset=gnomad_sv_r4?
 HAPMAP                      = http://www.hapmap.org/cgi-perl/secure/gbrowse/snp_details/hapmap?class=SNP;name=###ID###
 HBVAR                       = http://globin.bx.psu.edu/cgi-bin/hbvar/query_vars3?mode=output&display_format=page&i=###ID### 
 HGMD-PUBLIC                 = http://www.hgmd.cf.ac.uk/ac/index.php


### PR DESCRIPTION
## Description

Adding gnomAD url to provide external link for gnomAD SV variants.

## Views affected

Ensembl VEP result page.
Example in sandbox - http://wp-np2-35.ebi.ac.uk:7070/Homo_sapiens/Tools/VEP/Results?tl=ATsnWN4TdEdf5cVy-149
see "gnomAD SV" column.

## Possible complications

N/A

## Merge conflicts

N/A

## Related JIRA Issues (EBI developers only)

N/A
