### PR TITLE
Set pan_compara function in Pan gene tree node ZMenu

### DIFF
--- a/modules/EnsEMBL/Web/Constants.pm
+++ b/modules/EnsEMBL/Web/Constants.pm
@@ -207,14 +207,20 @@ sub GENE_TREE_CONSTANTS {
     compara_pan_ensembl => {
       action => 'PanComparaTree',
       component => 'PanComparaTree',
+      # In Multi gene-tree view, the URL
+      # function signals that the view
+      # is of a Pan Compara gene tree.
+      function => 'pan_compara',
     },
     compara_strain => {
       action => 'Strain_Compara_Tree',
       component => 'ComparaTree',
+      function => undef,
     },
     compara => {
       action => 'Compara_Tree',
       component => 'ComparaTree',
+      function => undef,
     },
   };
 

--- a/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
@@ -187,6 +187,7 @@ sub content {
           species  => 'Multi',
           type     => 'GeneTree',
           action   => 'Image',
+          function => $gene_tree_constants->{function},
           __clear  => 1,
           gt       => $tree_stable_id,
         });


### PR DESCRIPTION
## Description

This PR would set the `pan_compara` function as appropriate in the `ComparaTreeNode` ZMenu entry linking to a subtree of a supertree.

This change would ensure that the resulting `Multi` gene-tree view would be configured to show a Pan Compara tree, so that for example, its Wasabi links would set the Ensembl REST `compara` parameter to `pan_homology`.

## Views affected

To see the effect of this change:
1. Go to a gene tree that is part of a supertree (e.g. Rice gene Os05g0421750 on the [sandbox](http://wp-np2-35.ebi.ac.uk:5098/Oryza_sativa/Gene/PanComparaTree?g=Os05g0421750) and [live site](https://plants.ensembl.org/Oryza_sativa/Gene/PanComparaTree?g=Os05g0421750)).
2. Click on the sidebar menu button to "Configure this page", and in the "Display options" section of the view config modal window, tick the checkbox to "Show super-tree", then click the tick mark in the top-right of the modal window to return to the gene-tree view.
3. In the super tree view, click on any of the subtree nodes to bring up its ZMenu, then click on the link to "Switch to that tree".
4. In the `Multi` gene-tree view, click on any of the internal nodes of the gene tree to bring up its ZMenu, then click on the ZMenu link to access the "Wasabi viewer".

The Wasabi viewer does not work as expected on the live site, because the `compara` parameter is set to the host division (e.g. `plants`).

The Wasabi viewer works as expected on the sandbox because the `pan_compara` function has been set, so the `Multi` gene-tree view is configured to show a Pan Compara tree.

## Possible complications

None expected: the `function` parameter is set only as needed in `Multi/GeneTree/Image` subtree links in the supertree view.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- N/A
