### PR TITLE
Update Compara track description links

### DIFF
--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -946,7 +946,7 @@ sub add_synteny {
       species     => $species_2,
       species_hr  => $species_readable,
       caption     => $caption,
-      description => qq{<a href="/info/genome/compara/analyses.html#synteny" class="cp-external">Synteny regions</a> between $self_label and $label},
+      description => qq{<a href="/info/genome/compara/synteny.html" class="cp-external">Synteny regions</a> between $self_label and $label},
       colours     => $colours,
       display     => 'off',
       renderers   => [qw(off Off normal On)],
@@ -970,12 +970,12 @@ sub add_alignments {
   my ($static, $wga_page);
   my $division = $species_defs->EG_DIVISION;
   if ($division) {
-    $wga_page = $static = 'whole_genome_alignment.html';
+    $static = 'whole_genome_alignment.html';
   }
   else {
     $static = 'analyses.html';
-    $wga_page = $static.'#conservation';
   }
+  $wga_page = 'multiple_genome_alignments.html';
 
   foreach my $row (values %{$hashref->{'ALIGNMENTS'}}) {
     next unless $row->{'species'}{$prod_name};
@@ -1007,7 +1007,7 @@ sub add_alignments {
         $description = 'Pairwise alignments';
       }
 
-      $description  = qq{<a href="$static" class="cp-external">$description</a> between $self_label and $other_label};
+      $description  = qq{<a href="/info/genome/compara/$static" class="cp-external">$description</a> between $self_label and $other_label};
       $description .= " $1" if $row->{'name'} =~ /\((on.+)\)/;
 
       $alignments->{$menu_key}{$row->{'id'}} = {
@@ -1043,13 +1043,12 @@ sub add_alignments {
       if ($row->{'conservation_score'}) {
         my ($program) = $hashref->{'CONSERVATION_SCORES'}{$row->{'conservation_score'}}{'type'} =~ /(.+)_CONSERVATION_SCORE/;
 
-        $options{'description'} = sprintf '<a href="/info/genome/compara/%s">%s conservation scores</a> based on the %s', $wga_page, $program, $row->{'name'};
-
         $alignments->{'conservation'}{"$row->{'id'}_scores"} = {
           %options,
           conservation_score => $row->{'conservation_score'},
           name               => "Conservation score for $row->{'name'}",
           caption            => "$n_species way $program scores",
+          description        => sprintf('<a href="/info/genome/compara/conservation_and_constrained.html">%s conservation scores</a> based on the %s', $program, $row->{'name'}),
           order              => sprintf('%12d::%s::%s', 1e12-$n_species*10, $row->{'type'}, $row->{'name'}),
           display            => 'off',
           renderers          => [ 'off', 'Off', 'tiling', 'Tiling array' ],
@@ -1060,6 +1059,7 @@ sub add_alignments {
           constrained_element => $row->{'constrained_element'},
           name                => "Constrained elements for $row->{'name'}",
           caption             => "$n_species way $program elements",
+          description         => sprintf('<a href="/info/genome/compara/conservation_and_constrained.html">%s constrained elements</a> based on the %s', $program, $row->{'name'}),
           order               => sprintf('%12d::%s::%s', 1e12-$n_species*10+1, $row->{'type'}, $row->{'name'}),
           display             => 'off',
           renderers           => [ 'off', 'Off', 'compact', 'On' ],


### PR DESCRIPTION
## Description

This PR updates links in comparative track descriptions to point to the most appropriate comparative web documentation page available, taking advantage where possible of recent updates to Compara docs. 

## Views affected

This primarily affects the "Region overview" and "Region in detail" views.

### Region overview

Taking the region overview for Oryza sativa region 5:20683551-20684336 ([sandbox](http://wp-np2-35.ebi.ac.uk:5098/Oryza_sativa/Location/Overview?r=5:20683551-20684336) vs [live site](https://plants.ensembl.org/Oryza_sativa/Location/Overview?r=5:20683551-20684336)), click on the button to "Configure this page" and select the "Synteny" tab. Click on any of the info icons (&#9432;) to the right of the modal window, and click the link in the description.

Example links:
- "Synteny regions": [sandbox](http://wp-np2-35.ebi.ac.uk:5098/info/genome/compara/synteny.html) vs [live site](https://plants.ensembl.org/info/genome/compara/analyses.html#synteny)

### Region in detail

Taking the region-in-detail view for Oryza sativa region 5:20683551-20684336 ([sandbox](http://wp-np2-35.ebi.ac.uk:5098/Oryza_sativa/Location/View?r=5:20683551-20684336) vs [live site](https://plants.ensembl.org/Oryza_sativa/Location/View?r=5:20683551-20684336)), click on the button to "Configure this page" and select the "Comparative genomics" tab. Click on any of the info icons (&#9432;) to the right of the modal window, and click the link in the description.

Example links:
- "26 way whole-genome multiple alignments": [sandbox](http://wp-np2-35.ebi.ac.uk:5098/info/genome/compara/multiple_genome_alignments.html) vs [live site](https://plants.ensembl.org/info/genome/compara/whole_genome_alignment.html)
- "GERP conservation scores": [sandbox](http://wp-np2-35.ebi.ac.uk:5098/info/genome/compara/conservation_and_constrained.html) vs [live site](https://plants.ensembl.org/info/genome/compara/whole_genome_alignment.html)
- "LASTz net pairwise alignments": [sandbox](http://wp-np2-35.ebi.ac.uk:5098/info/genome/compara/whole_genome_alignment.html) vs [live site](https://plants.ensembl.org/Oryza_sativa/Location/whole_genome_alignment.html)

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- N/A