### PR TITLE
Disable dropdown if taxonomy colouring not configured

### DIFF
--- a/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Gene/ComparaTree.pm
@@ -75,6 +75,7 @@ sub field_order {
 sub form_fields {
   ## Abstract method implementation
   my $self      = shift;
+  my $hub       = $self->hub;
   my $fields    = {};
   my $function  = $self->{'function'};
 
@@ -112,22 +113,25 @@ sub form_fields {
     'value' => 'on',
   };
 
-  my @groups = $self->hub->param('strain') ? () : $self->_groups; #hide these options for strain view
+  my @groups = $hub->param('strain') ? () : $self->_groups; #hide these options for strain view
 
   if (@groups) {
-    my $taxon_labels = $self->hub->species_defs->TAXON_LABEL;
+    my $species_defs = $hub->species_defs;
+    my $taxon_labels = $species_defs->TAXON_LABEL;
 
-    $fields->{'colouring'} = {
-      'type'    => 'dropdown',
-      'select'  => 'select',
-      'name'    => 'colouring',
-      'label'   => 'Colour tree according to taxonomy',
-      'values'  => [
-        { 'value' => 'none',       'caption' => 'No colouring'  },
-        { 'value' => 'background', 'caption' => 'Background'    },
-        { 'value' => 'foreground', 'caption' => 'Foreground'    }
-      ],
-    };
+    if (grep { $_ ne '0' } (@{ $species_defs->TAXON_GENETREE_BGCOLOUR }, @{ $species_defs->TAXON_GENETREE_FGCOLOUR })) {
+      $fields->{'colouring'} = {
+        'type'    => 'dropdown',
+        'select'  => 'select',
+        'name'    => 'colouring',
+        'label'   => 'Colour tree according to taxonomy',
+        'values'  => [
+          { 'value' => 'none',       'caption' => 'No colouring'  },
+          { 'value' => 'background', 'caption' => 'Background'    },
+          { 'value' => 'foreground', 'caption' => 'Foreground'    }
+        ],
+      };
+    }
 
     foreach my $group (@groups) {
       $fields->{"group_${group}_display"} = {


### PR DESCRIPTION
## Description

The gene-tree config modal window provides a dropdown menu to "Colour tree according to taxonomy". This is currently shown even in cases where it would have no effect, such as when taxonomy colouring is not configured in the given Ensembl site.

This PR would effectively hide the taxonomy colouring dropdown menu in those Ensembl divisions for which taxonomy colouring has not been configured.

## Views affected

This would affect the gene-tree config window in any Ensembl website without taxonomy colouring (e.g. Non-Vertebrate Ensembl sites).

Taking example Rice gene Os05g0421750 in the [sandbox](http://wp-np2-35.ebi.ac.uk:5098/Oryza_sativa/Gene/Compara_Tree?g=Os05g0421750) or [live site](https://plants.ensembl.org/Oryza_sativa/Gene/Compara_Tree?g=Os05g0421750), if you click on the button to "Configure this page", then click "Display options", the live site will show a dropdown to "Colour tree according to taxonomy", though this dropdown has no effect because taxonomy colouring is not currently configured in Ensembl Plants. This dropdown is not shown in the sandbox.

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- N/A
