### PR TITLE
Set example gene-tree action dynamically

### DIFF
--- a/modules/EnsEMBL/Web/Component/Info/HomePage.pm
+++ b/modules/EnsEMBL/Web/Component/Info/HomePage.pm
@@ -23,6 +23,7 @@ use strict;
 
 use Bio::EnsEMBL::Registry;
 use EnsEMBL::Web::Document::HTML::HomeSearch;
+use EnsEMBL::Web::Utils::Compara qw(get_sample_gene_tree_action);
 use EnsEMBL::Web::Utils::FormatText;
 
 use parent qw(EnsEMBL::Web::Component::Info);
@@ -243,6 +244,17 @@ sub compara_text {
   my $sample_data  = $species_defs->SAMPLE_DATA;
   my $ftp          = $self->ftp_url;
 
+  my $gene_tree_action = EnsEMBL::Web::Utils::Compara::get_sample_gene_tree_action($hub, 'compara');
+
+  my $gene_tree_text;
+  if ($gene_tree_action) {
+    $gene_tree_text = sprintf(
+      $self->{'img_link'},
+      $hub->url({ type => 'Gene', action => $gene_tree_action, g => $sample_data->{'GENE_PARAM'}, __clear => 1 }),
+      "Go to gene tree for $sample_data->{'GENE_TEXT'}", 'compara', 'Example gene tree'
+    );
+  }
+
   return sprintf('
     <div class="homepage-icon">
       %s
@@ -252,11 +264,7 @@ sub compara_text {
     <p><a href="/info/genome/compara/" class="nodeco">%sMore about comparative analysis</a></p>
     %s',
     
-    sprintf(
-      $self->{'img_link'},
-      $hub->url({ type => 'Gene', action => 'Compara_Tree', g => $sample_data->{'GENE_PARAM'}, __clear => 1 }),
-      "Go to gene tree for $sample_data->{'GENE_TEXT'}", 'compara', 'Example gene tree'
-    ),
+    $gene_tree_text,
     
     sprintf($self->{'icon'}, 'info'),
     

--- a/modules/EnsEMBL/Web/Utils/Compara.pm
+++ b/modules/EnsEMBL/Web/Utils/Compara.pm
@@ -21,6 +21,36 @@ package EnsEMBL::Web::Utils::Compara;
 
 use strict;
 
+use EnsEMBL::Web::Constants qw(GENE_TREE_CONSTANTS);
+
+
+sub _get_gene_tree_const_param_sets {
+  my ($hub, $compara_db) = @_;
+
+  my @gene_tree_const_param_sets;
+  if ($compara_db eq 'compara_pan_ensembl') {
+    push(@gene_tree_const_param_sets, [$compara_db, 0, 'default']);
+  } else {
+
+    my $species_defs = $hub->species_defs;
+    my $species_prod_name = $species_defs->SPECIES_PRODUCTION_NAME;
+
+    my $cdb_info = $species_defs->multi_val('DATABASE_COMPARA');
+    if (exists $cdb_info->{'CLUSTERSET_PRODNAMES'}
+        && exists $cdb_info->{'CLUSTERSET_PRODNAMES'}{'default'}
+        && exists $cdb_info->{'CLUSTERSET_PRODNAMES'}{'default'}->{$species_prod_name}
+        && $cdb_info->{'CLUSTERSET_PRODNAMES'}{'default'}{$species_prod_name}) {
+      push(@gene_tree_const_param_sets, [$compara_db, 0, 'default']);
+    }
+
+    if ($species_defs->RELATED_TAXON) {
+      push(@gene_tree_const_param_sets, [$compara_db, 1, $species_defs->RELATED_TAXON]);
+    }
+  }
+
+  return \@gene_tree_const_param_sets;
+}
+
 
 sub _get_non_strain_orthoset_prod_names {
   my ($hub, $url_lookup) = @_;
@@ -59,6 +89,56 @@ sub _get_strain_orthoset_prod_names {
   }
 
   return $orthoset_prod_names;
+}
+
+
+sub get_sample_gene_tree_action {
+  ## Get sample gene-tree action.
+  ## Returns undef if no gene tree is found for the sample gene, so
+  ## calling code can avoid creating a broken sample gene-tree link.
+  my ($hub, $compara_db) = @_;
+
+  my $species_defs = $hub->species_defs;
+  return unless $species_defs->SPECIES_PRODUCTION_NAME;
+
+  my $gt_const_param_sets = _get_gene_tree_const_param_sets($hub, $compara_db);
+
+  my $action;
+  if (scalar(@{$gt_const_param_sets}) > 0) {
+    my $db = $hub->database($compara_db);
+
+    if (defined $db) {
+
+      my $genome_db = $db->get_GenomeDBAdaptor->fetch_by_name_assembly(
+        $species_defs->SPECIES_PRODUCTION_NAME,
+        $species_defs->SPECIES_ASSEMBLY_NAME,
+      );
+
+      if (defined $genome_db) {
+        my $gene_stable_id = $species_defs->SAMPLE_DATA->{'GENE_PARAM'};
+
+        if (defined $gene_stable_id) {
+          my $gene_member = $db->get_GeneMemberAdaptor->fetch_by_stable_id_GenomeDB(
+            $gene_stable_id,
+            $genome_db,
+          );
+
+          if (defined $gene_member) {
+            foreach my $gt_const_param_set (@{$gt_const_param_sets}) {
+              my ($cdb, $strain, $cset_id) = @{$gt_const_param_set};
+              if ($gene_member->has_GeneTree($cset_id)) {
+                my $gt_constants = EnsEMBL::Web::Constants::GENE_TREE_CONSTANTS($cdb, $strain, $cset_id);
+                $action = $gt_constants->{'action'};
+                last;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return $action;
 }
 
 


### PR DESCRIPTION
## Description

Example gene tree links in Ensembl species homepages are generated using the [Compara_Tree action](https://github.com/Ensembl/ensembl-webcode/blob/a88f841d346aab3b8e59319ab09b40eb36084cc3/modules/EnsEMBL/Web/Component/Info/HomePage.pm#L257) or [PanComparaTree action](https://github.com/EnsemblGenomes/eg-web-common/blob/8c6c5544afc00d8964779ad307f142f9ff279ff8/modules/EnsEMBL/Web/Component/Info/HomePage.pm#L391).

Genomes that are exclusively in a strain/breed gene-tree collection have broken example gene-tree links, because their gene-tree action is `Strain_Compara_Tree`.

This PR would mend these broken links by adding utility function `EnsEMBL::Web::Utils::Compara::get_sample_gene_tree_action` and calling it in the `EnsEMBL::Web::Component::Info::HomePage` to set the example gene-tree action dynamically.

## Views affected

The changes in this PR would be relevant to all species homepages, but these pages should only be affected for genomes that are exclusively in a strain/breed gene-tree collection.

An example of such a genome is the Mouse NZO/HlLtJ strain: [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Mus_musculus_NZO_HlLtJ/Info/Index) vs [live site](https://www.ensembl.org/Mus_musculus_NZO_HlLtJ/Info/Index).

## Possible complications

The main known risk would be that an error in `get_sample_gene_tree_action` might prevent a species homepage from being displayed.

This function has been written to minimise that risk, checking at each stage if the (Compara) `$db`, `$genome_db`, `$gene_stable_id` and `$gene_member` are defined before fetching the appropriate gene-tree action.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- ENSWEB-6873