### PR TITLE
Use node_id in gene-tree node ZMenu root status check

### DIFF
--- a/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
+++ b/modules/EnsEMBL/Web/ZMenu/ComparaTreeNode.pm
@@ -58,7 +58,7 @@ sub content {
   my %collapsed_ids   = map { $_ => 1 } grep /\d/, split ',', $hub->param('collapse');
   my $leaf_count      = scalar @{$node->get_all_leaves};
   my $is_leaf         = $node->is_leaf;
-  my $is_root         = ($node->root eq $node);
+  my $is_root         = ($node->root->node_id == $node->node_id);
   my $is_supertree    = ($node->tree->tree_type eq 'supertree');
   my $parent_distance = $node->distance_to_parent || 0;
 


### PR DESCRIPTION
## Description

For non-default Metazoa gene trees having a stable ID, there is an issue 
with inconsistent display of the gene-tree stable ID in the root node 
ZMenu on Ensembl Metazoa.

For example, if a given gene is in both the Metazoa default and Protostomes collections, the Zmenu of the root of its Protostomes gene tree lacks a stable ID. If that gene is absent from the Metazoa default collection and its Protostomes gene tree has a stable ID, its Protostomes gene-tree root Zmenu displays that gene-tree stable ID.

This PR addresses the issue by comparing `node_id` values instead of nodes in the `ComparaTreeNode` root status check.

## Views affected

This change affects the gene-tree view of Metazoa genomes that are in both a default and non-default gene-tree collection.

For example, if you access the gene tree view of C. elegans example gene `WBGene00009126` ([sandbox](http://wp-np2-35.ebi.ac.uk:5094/Caenorhabditis_elegans/Gene/Compara_Tree?g=WBGene00009126) vs [live site](https://metazoa.ensembl.org//Caenorhabditis_elegans/Gene/Compara_Tree?g=WBGene00009126)), and click on the root node, the ZMenu displays the gene-tree stable ID on the sandbox but not on the live site.

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- [ENSWEB-6877](https://embl.atlassian.net/browse/ENSWEB-6877)
