### PR TITLE
Set Pig breed count from ALL_STRAINS config in genome list

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/GenomeList.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/GenomeList.pm
@@ -277,12 +277,17 @@ sub add_genome_groups {
 }
 
 sub get_featured_genomes {
+  my $self = shift;
+
+  my $pig_breed_urls = $self->hub->species_defs->get_config('Sus_scrofa', 'ALL_STRAINS') // [];
+  my $pig_breed_count = scalar(@{$pig_breed_urls});
+  my $pig_breed_text = $pig_breed_count > 0 ? "$pig_breed_count additional breeds" : 'additional breeds';
   return (
            {
             'url'   => 'Sus_scrofa/Info/Breeds/',
             'img'   => 'Sus_scrofa.png',
             'name'  => 'Pig breeds',
-            'more'  => qq(<a href="/Sus_scrofa/" class="nodeco">Pig reference genome</a> and <a href="Sus_scrofa/Info/Breeds/" class="nodeco">20 additional breeds</a>),
+            'more'  => qq(<a href="/Sus_scrofa/" class="nodeco">Pig reference genome</a> and <a href="Sus_scrofa/Info/Breeds/" class="nodeco">${pig_breed_text}</a>),
            },
           );
 }


### PR DESCRIPTION
## Description

This PR would fetch the `ALL_STRAINS` list from the config of Pig reference genome `Sus_scrofa`, and use that list to set the number of Pig breeds in the genome list on the Ensembl Vertebrates homepage.

## Views affected

The code in this PR should automatically update the Pig breed count in the Ensembl Vertebrates homepage.

The Compara Vertebrates sandbox has been updated for e116, and currently counts 27 Pig breeds/isolates: http://wp-np2-35.ebi.ac.uk:5092/index.html

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- N/A
