### PR TITLE
Populate Vertebrate gene ZMenus on NV sites from Pan Compara

### DIFF
--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -2073,6 +2073,7 @@ sub _summarise_pan_compara {
     if ($division eq 'Bacteria') {
       $subdivision = 'archaea' if $archaea->{$prod_name};
     }
+    $self->db_tree->{'PAN_COMPARA_PRODNAME_LOOKUP'}{$url} = $prod_name;
     $self->db_tree->{'PAN_COMPARA_LOOKUP'}{$prod_name} = {
                 'species_url'     => $url,
                 'display_name'    => $display_name,

--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -1619,8 +1619,22 @@ sub species_label {
       $label = $display;
     }
   }
-  $label = 'Ancestral sequence' unless $label;
-  
+
+  if (!$label) {
+    my $pan_prodname_lookup = $self->multi_val('PAN_COMPARA_PRODNAME_LOOKUP') || {};
+    if (exists $pan_prodname_lookup->{$url} && $pan_prodname_lookup->{$url}) {
+      my $prod_name = $pan_prodname_lookup->{$url};
+      my $pan_lookup = $self->multi_val('PAN_COMPARA_LOOKUP') || {};
+      if (exists $pan_lookup->{$prod_name} && $pan_lookup->{$prod_name}) {
+        $label = $pan_lookup->{$prod_name}{'display_name'};
+      }
+    }
+
+    if (!$label) {
+      $label = 'Ancestral sequence';
+    }
+  }
+
   return $label;
 }
 
@@ -1805,8 +1819,10 @@ sub production_name {
     }
 
 # species name is either has not been registered as an alias, or it comes from a different website, e.g in pan compara
-    my %pan_lookup = $self->multiX('PAN_COMPARA_LOOKUP');
-    my $prod_name  = $pan_lookup{$species} ? $pan_lookup{$species}{'production_name'} : '';
+    my $pan_prodname_lookup = $self->multi_val('PAN_COMPARA_PRODNAME_LOOKUP') || {};
+    if (exists $pan_prodname_lookup->{$species} && $pan_prodname_lookup->{$species}) {
+      return $pan_prodname_lookup->{$species};
+    }
 }
 
 sub verbose_params {

--- a/modules/EnsEMBL/Web/ZMenu/Gene/ComparaTree_pan_compara.pm
+++ b/modules/EnsEMBL/Web/ZMenu/Gene/ComparaTree_pan_compara.pm
@@ -1,0 +1,139 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2024] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::ZMenu::Gene::ComparaTree_pan_compara;
+
+use strict;
+
+use base qw(EnsEMBL::Web::ZMenu::Gene::ComparaTree);
+
+
+sub content {
+  my $self         = shift;
+  my $hub          = $self->hub;
+  my $species_defs = $hub->species_defs;
+  my $cdb          = 'compara_pan_ensembl';
+  my $g            = $hub->param('g');
+  my $s            = $hub->param('s');
+
+  my $dba = $hub->database($cdb) || return;
+  my $gda = $dba->get_adaptor('GenomeDB') || return;
+  my $gma = $dba->get_adaptor('GeneMember') || return;
+
+  my $prod_name = $species_defs->production_name($s);
+  my $genome_db = $gda->fetch_by_name_assembly($prod_name) || return;
+  my $gene_member = $gma->fetch_by_stable_id_GenomeDB($g, $genome_db) || return;
+
+  my $pan_info = $species_defs->multi_val('PAN_COMPARA_LOOKUP');
+  my $division = $pan_info->{$prod_name}{'division'};
+
+  $self->caption('Gene');
+
+  my $zmenu_label = $division eq 'bacteria' && $gene_member->display_label
+                  ? sprintf('%s (%s)', $gene_member->display_label, $gene_member->stable_id)
+                  : $gene_member->stable_id
+                  ;
+
+  $self->add_entry({
+    type       => 'Species',
+    label_html => $species_defs->species_label($s),
+    link       => $hub->species_path($s),
+  });
+
+  $self->add_entry({
+    type  => 'Gene',
+    label => $zmenu_label,
+    link  => $hub->url({ type => 'Gene', action => 'Summary', species => $s }),
+  });
+
+  if ($gene_member->biotype_group eq 'coding') {
+    my $seq_member = $gene_member->get_canonical_SeqMember();
+    my $prot_stable_id = $seq_member->stable_id;
+
+    my ($prot_summary_action, $prot_sequence_action);
+    if ($division eq 'bacteria') {
+      $prot_summary_action = sprintf('ProteinSummary_%s', $prot_stable_id);
+      $prot_sequence_action = sprintf('Sequence_Protein_%s', $prot_stable_id);
+    } else {
+      $prot_summary_action = 'ProteinSummary';
+      $prot_sequence_action = 'Sequence_Protein';
+    }
+
+    $self->add_entry({
+      type  => 'Protein',
+      label => 'Summary',
+      link  => $hub->url({
+        type    => 'Transcript',
+        action  => $prot_summary_action,
+        p       => $prot_stable_id,
+        species => $s,
+      })
+    });
+
+    $self->add_entry({
+      type  => ' ',
+      label => 'Sequence',
+      link  => $hub->url({
+        type    => 'Transcript',
+        action  => $prot_sequence_action,
+        p       => $prot_stable_id,
+        species => $s,
+      })
+    });
+  }
+
+  my $dnafrag = $gene_member->dnafrag;
+  my $dnafrag_name = $dnafrag->name;
+  my $dnafrag_start = $gene_member->dnafrag_start;
+  my $dnafrag_end = $gene_member->dnafrag_end;
+
+  my $region_text = sprintf(
+    '%s: %s-%s',
+    $self->neat_sr_name($dnafrag->coord_system_name, $dnafrag_name),
+    $self->thousandify($dnafrag_start),
+    $self->thousandify($dnafrag_end),
+  );
+
+  my $region_param = sprintf(
+    '%s:%d-%d',
+    $dnafrag_name,
+    $dnafrag_start,
+    $dnafrag_end,
+  );
+
+  $self->add_entry({
+    type  => 'Location',
+    label => $region_text,
+    link  => $hub->url({
+      type    => 'Location',
+      action  => 'View',
+      r       => $region_param,
+      g       => $g,
+      species => $s,
+      __clear => 1,
+    }),
+  });
+
+  $self->add_entry({
+    type  => 'Strand',
+    label => $gene_member->dnafrag_strand < 0 ? 'Reverse' : 'Forward',
+  });
+}
+
+1;


### PR DESCRIPTION
## Description

In Ensembl NV sites, the ZMenu of a Vertebrate gene does not load, but instead shows the _e!_ spinner with the text, "Loading component".

This is because the cross-site requests by which gene ZMenus may be populated in Ensembl NV gene-tree views ([here](https://github.com/EnsemblGenomes/eg-web-common/blob/8c6c5544afc00d8964779ad307f142f9ff279ff8/modules/EnsEMBL/Web/ZMenu.pm#L32-L39)) are JSONP, while those of the Ensembl Vertebrates site ([here](https://github.com/Ensembl/ensembl-webcode/blob/fd68602aad5c30693fbf5a7e6a45ea205784cf6b/modules/EnsEMBL/Web/ZMenu.pm#L240)) are JSON.

This PR would enable population of Vertebrate gene ZMenus from the Pan Compara database (if available) in Ensembl NV sites.

The resulting ZMenus would provide the subset of the regular gene ZMenu functionality that is possible by using Pan Compara data.

## Views affected

This change affects gene-tree views in Ensembl sites with Pan-taxonomic (or Pan-like) data.

Examples:
- Pan Compara gene-tree of A. thaliana gene AT1G07820 : [sandbox](http://wp-np2-35.ebi.ac.uk:5098/Arabidopsis_thaliana/Gene/PanComparaTree?collapse=none;db=core;g=AT1G07820) vs [live site](https://plants.ensembl.org/Arabidopsis_thaliana/Gene/PanComparaTree?collapse=none;db=core;g=AT1G07820)
- Plants gene-tree EPlGT00940000199070 : [sandbox](http://wp-np2-35.ebi.ac.uk:5098/Multi/GeneTree/Image?gt=EPlGT00940000199070) vs [live site](https://plants.ensembl.org/Multi/GeneTree/Image?gt=EPlGT00940000199070)
- Pan gene-tree EGGT00960000281994 : [sandbox](http://wp-np2-35.ebi.ac.uk:5098/Multi/GeneTree/Image?gt=EGGT00960000281994) vs [live site](https://plants.ensembl.org/Multi/GeneTree/Image?gt=EGGT00960000281994)

## Possible complications

No complications are expected.

Changes to the `GlyphSet::genetree` module are restricted to gene members that are in Pan Compara, in division `vertebrates`, and not a valid species in the given Ensembl site.

Changes to `SpeciesDefs` methods `production_name` and `species_label` are placed at the end of each method, and would only return a Pan Compara `production_name` or `species_label` (respectively) if these cannot be obtained by other means.

Addition of a `PAN_COMPARA_PRODNAME_LOOKUP` is expected to cause a modest increase in the size of the `MULTI.db.packed` file, in proportion to the number of Pan Compara genomes.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- N/A


