### PR TITLE
Set z-index of synteny highlights, sort Zmenu areas in reverse of rendering order

### DIFF
--- a/htdocs/components/15_ImageMap.js
+++ b/htdocs/components/15_ImageMap.js
@@ -289,7 +289,11 @@ Ensembl.Panel.ImageMap = Ensembl.Panel.Content.extend({
         $.each(this.coords, function (i) { c[rect[i]] = parseInt(this, 10); });
       }
       
-      panel.areas.unshift(c);
+      if (this.klass.drag || this.klass.vdrag) {
+        panel.areas.push(c);
+      } else {
+        panel.areas.unshift(c);
+      }
       
       if (this.klass.drag || this.klass.vdrag) {
         // r = [ '#drag', image number, species number, species name, region, start, end, strand ]

--- a/htdocs/components/15_ImageMap.js
+++ b/htdocs/components/15_ImageMap.js
@@ -289,7 +289,7 @@ Ensembl.Panel.ImageMap = Ensembl.Panel.Content.extend({
         $.each(this.coords, function (i) { c[rect[i]] = parseInt(this, 10); });
       }
       
-      panel.areas.push(c);
+      panel.areas.unshift(c);
       
       if (this.klass.drag || this.klass.vdrag) {
         // r = [ '#drag', image number, species number, species name, region, start, end, strand ]

--- a/htdocs/components/15_ImageMap.js
+++ b/htdocs/components/15_ImageMap.js
@@ -289,10 +289,10 @@ Ensembl.Panel.ImageMap = Ensembl.Panel.Content.extend({
         $.each(this.coords, function (i) { c[rect[i]] = parseInt(this, 10); });
       }
       
-      if (this.klass.drag || this.klass.vdrag) {
-        panel.areas.push(c);
-      } else {
+      if (panel.id == 'SyntenyImage' && !(this.klass.drag || this.klass.vdrag)) {
         panel.areas.unshift(c);
+      } else {
+        panel.areas.push(c);
       }
       
       if (this.klass.drag || this.klass.vdrag) {

--- a/modules/EnsEMBL/Draw/GlyphSet/Vsynteny.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/Vsynteny.pm
@@ -607,6 +607,7 @@ sub draw_chromosome {
   
   my %coords;
   
+  my $highlight_z_index = 1;
   foreach my $box (@$highlights) {
     my $vc_start  = $box->{'start'} * $scale + $v_offset;
     my $vc_end    = $box->{'end'}   * $scale + $v_offset;
@@ -622,6 +623,7 @@ sub draw_chromosome {
     $self->push($self->Rect({
       'x'             => $vc_start,
       'y'             => $h_offset + $box->{'side'} * ($wid+4),
+      'z'             => $highlight_z_index,
       'width'         => $vc_end - $vc_start,
       'height'        => $wid,
       'colour'        => $box->{'col'},
@@ -632,6 +634,7 @@ sub draw_chromosome {
       'href'          => $box->{'href'},
       'zmenu'         => $box->{'zmenu'}
     }));
+    $highlight_z_index += 1;
     
     if ($box->{'marked'}==1 || $box->{'marked'}==-1) {
       $self->push($self->Rect({


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

This draft PR would assign z-index values to synteny highlights, and would sort non-draggable image-map areas in reverse of rendering order.

The benefit of this would be more intuitive behaviour of image-map ZMenus in views that have overlapping clickable elements, such as the synteny view.

## Views affected

### Synteny view

- Tongue sole synteny view: [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Cynoglossus_semilaevis/Location/Synteny?otherspecies=Oryzias_latipes&r=19%3A1-1000) vs [staging site](https://staging.ensembl.org/Cynoglossus_semilaevis/Location/Synteny?otherspecies=Oryzias_latipes&r=19%3A1-1000)

The following example images show the tongue sole synteny view, with red arrows linking Zmenus to the synteny regions for which they are generated.

On the staging site, clicking on a visible synteny region may bring up a Zmenu that is not for that synteny region, but rather for another synteny region obscured by it:
<img width="565" height="315" alt="e116_staging_synteny" src="https://github.com/user-attachments/assets/ddf25c2d-d0df-4c5c-90a9-ce5d68202c5a" />

On the sandbox, clicking on a visible synteny region brings up the ZMenu for that region:
<img width="530" height="351" alt="e116_sandbox_synteny" src="https://github.com/user-attachments/assets/c93cedee-da66-4ae0-901a-517a5f1b7bbb" />

## Possible complications

This could potentially affect any Ensembl view with an image map.

The following table lists image-map views that have been tested for possible issues.

During initial checks, an issue was identified with how this update deals with views containing draggable areas, and the pull request has since been updated to revert to the previous behaviour in the case of draggable areas.

| view_name | sandbox_view | staging_view | tested |
|-----------|--------------|--------------|--------|
| Chromosome summary | [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Chromosome?r=15:75516662-101991189) | [staging](https://staging.ensembl.org/Homo_sapiens/Location/Chromosome?r=15:75516662-101991189) | headings; chromosome bands; histogram |
| Gene summary | [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Gene/Summary?g=ENSG00000139618;r=13:32315086-32400268) | [staging](https://staging.ensembl.org/Homo_sapiens/Gene/Summary?g=ENSG00000139618;r=13:32315086-32400268) | gene tracks; contig tracks; regulatory features |
| Gene tree | [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Gene/Compara_Tree?db=core;g=ENSG00000139618;r=13:32384663-32386641) | [staging](https://staging.ensembl.org/Homo_sapiens/Gene/Compara_Tree?db=core;g=ENSG00000139618;r=13:32384663-32386641) | gene-tree nodes; leaf labels |
| Gene Variant Image | [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Mus_musculus/Gene/Variation_Gene/Image?g=ENSMUSG00000017167;r=11:101061349-101082747) | [staging](https://staging.ensembl.org/Mus_musculus/Gene/Variation_Gene/Image?g=ENSMUSG00000017167;r=11:101061349-101082747) | variant tracks; gene tracks; domain tracks |
| Image alignment | [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Compara_Alignments/Image?r=15:75516662-75536662;db=core) | [staging](https://staging.ensembl.org/Homo_sapiens/Location/Compara_Alignments/Image?r=15:75516662-75536662;db=core) | gene tracks; contig tracks; alignment bands |
| LD view | [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/LD/ajax?db=core;r=15%3A75516662-75536662;pop1=373508) | [staging](https://staging.ensembl.org/Homo_sapiens/Location/LD/ajax?db=core;r=15%3A75516662-75536662;pop1=373508) | chromosome bands; gene tracks; variant track; LD plots |
| Protein summary | [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Transcript/ProteinSummary?db=core;g=ENSG00000139618;r=13:32384663-32386641;t=ENST00000380152) | [staging](https://staging.ensembl.org/Homo_sapiens/Transcript/ProteinSummary?db=core;g=ENSG00000139618;r=13:32384663-32386641;t=ENST00000380152) | exon track; protein domain tracks; protein feature tracks; variant tracks; mutation tracks |
| Region comparison | [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Multi?db=core;r=15:75516662-75536662;r1=15:56501537-56521537:1;s1=Pan_troglodytes) | [staging](https://staging.ensembl.org/Homo_sapiens/Location/Multi?db=core;r=15:75516662-75536662;r1=15:56501537-56521537:1;s1=Pan_troglodytes) | chromosome bands; contig tracks; gene tracks; alignment bands; regulatory features |
| Region in detail | [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/View?r=15:75516662-75536662;db=core) | [staging](https://staging.ensembl.org/Homo_sapiens/Location/View?r=15:75516662-75536662;db=core) | chromosome bands; constrained elements; gene tracks; gnomAD short variants; phenotype-associated short variants; gnomAD structural variants; regulatory features; Age of Base |
| Region overview | [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Overview?r=15:75516662-101991189) | [staging](https://staging.ensembl.org/Homo_sapiens/Location/Overview?r=15:75516662-101991189) | chromosome bands; tile path; gene tracks |
| Splice variants | [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Gene/Splice?g=ENSG00000139618;r=13:32315086-32400268) | [staging](https://staging.ensembl.org/Homo_sapiens/Gene/Splice?g=ENSG00000139618;r=13:32315086-32400268) | transcript tracks; domain tracks |
| Structural variants | [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Mus_musculus/Gene/StructuralVariation_Gene?db=core;g=ENSMUSG00000017167) | [staging](https://staging.ensembl.org/Mus_musculus/Gene/StructuralVariation_Gene?db=core;g=ENSMUSG00000017167) | gene tracks; contig tracks; structural variant tracks; regulatory features |
| Transcript Variant Image | [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Mus_musculus/Transcript/Variation_Transcript/Image?db=core;g=ENSMUSG00000017167;r=11:101061349-101082747;t=ENSMUST00000103109) | [staging](https://staging.ensembl.org/Mus_musculus/Transcript/Variation_Transcript/Image?db=core;g=ENSMUSG00000017167;r=11:101061349-101082747;t=ENSMUST00000103109) | variant tracks; gene tracks; domain tracks |
| Whole genome | [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Genome?r=15:75516662-101991189) | [staging](https://staging.ensembl.org/Homo_sapiens/Location/Genome?r=15:75516662-101991189) | chromosome bands

### Update

To minimise the potential impact on other image map views, I've updated the `15_ImageMap.js` code so that it only calls `unshift` on non-draggable areas in a `SyntenyImage` panel.

To test the updated code, I've accessed an example of each of the listed views, and counted the number of pushed and unshifted areas, summarised in the following table.

With areas only observed being unshifted in the `SyntenyImage` example, this indicates that the change in this PR should affect only synteny views.

| example_pages | view_name | panel_name | num_pushed_areas | num_unshifted_areas
|---------------|-----------|------------|------------------|-
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Chromosome?r=15:75516662-101991189) vs [staging](https://staging.ensembl.org/Homo_sapiens/Location/Chromosome?r=15:75516662-101991189) | Chromosome summary | Summary | 2 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Chromosome?r=15:75516662-101991189) vs [staging](https://staging.ensembl.org/Homo_sapiens/Location/Chromosome?r=15:75516662-101991189) | Chromosome summary | ChromosomeImage | 85 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Gene/Summary?g=ENSG00000139618;r=13:32315086-32400268) vs [staging](https://staging.ensembl.org/Homo_sapiens/Gene/Summary?g=ENSG00000139618;r=13:32315086-32400268) | Gene summary | TranscriptsImage | 47 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Gene/Compara_Tree?db=core;g=ENSG00000139618;r=13:32384663-32386641) vs [staging](https://staging.ensembl.org/Homo_sapiens/Gene/Compara_Tree?db=core;g=ENSG00000139618;r=13:32384663-32386641) | Gene tree | ComparaTree | 74 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Mus_musculus/Gene/Variation_Gene/Image?g=ENSMUSG00000017167;r=11:101061349-101082747) vs [staging](https://staging.ensembl.org/Mus_musculus/Gene/Variation_Gene/Image?g=ENSMUSG00000017167;r=11:101061349-101082747) | Gene Variant Image | VariationImage | 3354 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Compara_Alignments/Image?r=15:75516662-75536662;db=core) vs [staging](https://staging.ensembl.org/Homo_sapiens/Location/Compara_Alignments/Image?r=15:75516662-75536662;db=core) | Image alignment | Summary | 2 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Compara_Alignments/Image?r=15:75516662-75536662;db=core) vs [staging](https://staging.ensembl.org/Homo_sapiens/Location/Compara_Alignments/Image?r=15:75516662-75536662;db=core) | Image alignment | Compara_AlignSliceBottom | 246 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/LD/ajax?db=core;r=15%3A75516662-75536662;pop1=373508) vs [staging](https://staging.ensembl.org/Homo_sapiens/Location/LD/ajax?db=core;r=15%3A75516662-75536662;pop1=373508) | LD view | Summary | 2 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/LD/ajax?db=core;r=15%3A75516662-75536662;pop1=373508) vs [staging](https://staging.ensembl.org/Homo_sapiens/Location/LD/ajax?db=core;r=15%3A75516662-75536662;pop1=373508) | LD view | LDImage | 20316 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Transcript/ProteinSummary?db=core;g=ENSG00000139618;r=13:32384663-32386641;t=ENST00000380152) vs [staging](https://staging.ensembl.org/Homo_sapiens/Transcript/ProteinSummary?db=core;g=ENSG00000139618;r=13:32384663-32386641;t=ENST00000380152) | Protein summary  | TranslationImage | 30457 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Multi?db=core;r=15:75516662-75536662;r1=15:56501537-56521537:1;s1=Pan_troglodytes) vs [staging](https://staging.ensembl.org/Homo_sapiens/Location/Multi?db=core;r=15:75516662-75536662;r1=15:56501537-56521537:1;s1=Pan_troglodytes) | Region comparison | MultiIdeogram | 4 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Multi?db=core;r=15:75516662-75536662;r1=15:56501537-56521537:1;s1=Pan_troglodytes) vs [staging](https://staging.ensembl.org/Homo_sapiens/Location/Multi?db=core;r=15:75516662-75536662;r1=15:56501537-56521537:1;s1=Pan_troglodytes) | Region comparison | MultiBottom | 65 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/View?r=15:75516662-75536662;db=core) vs [staging](https://staging.ensembl.org/Homo_sapiens/Location/View?r=15:75516662-75536662;db=core) | Region in detail | Summary | 2 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/View?r=15:75516662-75536662;db=core) vs [staging](https://staging.ensembl.org/Homo_sapiens/Location/View?r=15:75516662-75536662;db=core) | Region in detail | ViewBottom | 5025 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Overview?r=15:75516662-85516662) vs [staging](https://staging.ensembl.org/Homo_sapiens/Location/Overview?r=15:75516662-85516662) | Region overview | Summary | 2 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Overview?r=15:75516662-85516662) vs [staging](https://staging.ensembl.org/Homo_sapiens/Location/Overview?r=15:75516662-85516662) | Region overview | Region | 1270 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Gene/Splice?g=ENSG00000139618;r=13:32315086-32400268) vs [staging](https://staging.ensembl.org/Homo_sapiens/Gene/Splice?g=ENSG00000139618;r=13:32315086-32400268) | Splice variants | SpliceImage | 768 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Mus_musculus/Gene/StructuralVariation_Gene?db=core;g=ENSMUSG00000017167) vs [staging](https://staging.ensembl.org/Mus_musculus/Gene/StructuralVariation_Gene?db=core;g=ENSMUSG00000017167) | Structural variants | SVImage | 135 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Cynoglossus_semilaevis/Location/Synteny?otherspecies=Oryzias_latipes&r=19%3A1-1000) vs [staging site](https://staging.ensembl.org/Cynoglossus_semilaevis/Location/Synteny?otherspecies=Oryzias_latipes&r=19%3A1-1000) | Synteny | Summary | 2 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Cynoglossus_semilaevis/Location/Synteny?otherspecies=Oryzias_latipes&r=19%3A1-1000) vs [staging site](https://staging.ensembl.org/Cynoglossus_semilaevis/Location/Synteny?otherspecies=Oryzias_latipes&r=19%3A1-1000) | Synteny | SyntenyImage | 0 | 110
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Mus_musculus/Transcript/Variation_Transcript/Image?db=core;g=ENSMUSG00000017167;r=11:101061349-101082747;t=ENSMUST00000103109) vs [staging](https://staging.ensembl.org/Mus_musculus/Transcript/Variation_Transcript/Image?db=core;g=ENSMUSG00000017167;r=11:101061349-101082747;t=ENSMUST00000103109) | Transcript Variant Image | VariationImage | 2730 | 0
| [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Genome?r=15:75516662-101991189) vs [staging](https://staging.ensembl.org/Homo_sapiens/Location/Genome?r=15:75516662-101991189) | Whole genome | Genome | 75 | 0

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- N/A
