### PR TITLE
Update OLS URLs to OLS4

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -232,9 +232,9 @@ our $ENSEMBL_JAVA         = "java"; # For js/css minification
 
 ## REST services used by e.g. ConfigPacker
 
-our $OLS_REST_API          = 'https://www.ebi.ac.uk/ols/api/';
+our $OLS_REST_API          = 'https://www.ebi.ac.uk/ols4/api/';
 our $ENSEMBL_GLOSSARY_REST = $OLS_REST_API.'ontologies/ensemblglossary';
-our $ENSEMBL_GLOSSARY_URL  = 'https://www.ebi.ac.uk/ols/ontologies/ensemblglossary';
+our $ENSEMBL_GLOSSARY_URL  = 'https://www.ebi.ac.uk/ols4/ontologies/ensemblglossary';
 # Molecular interaction REST API
 our $MOLECULAR_INTERACTIONS_URL = 'https://interactions.rest.ensembl.org';
 


### PR DESCRIPTION
## Description

This PR would update the configuration of OLS URLs to OLS4.

The main effect of this would be on search functionality in the Ensembl Glossary page.

## Views affected

The following table breaks down the expected impact of this pull request.

| variable | module | comments |
|----------|--------|-
| `OLS_REST_API` | `EnsEMBL::Web::Component::Help::Glossary` | Used in glossary search form, where the updated URL helps restore glossary search functionality.
| `OLS_REST_API`  | `SiteDefs` | Used to set prefix of `ENSEMBL_GLOSSARY_REST` variable.
| `ENSEMBL_GLOSSARY_REST` | `EnsEMBL::Web::Component::Help::Glossary Component::Help::Glossary` | Used only to check if Ontology Lookup Service is available.
| `ENSEMBL_GLOSSARY_REST` | `EnsEMBL::Web::ConfigPacker` | Used during packing of `ENSEMBL_GLOSSARY` metadata. When `ENSEMBL_GLOSSARY` metadata was repacked with and without the changes in this PR, the packed `ENSEMBL_GLOSSARY` metadata was identical.
| `ENSEMBL_GLOSSARY_URL` | `EnsEMBL::Web::Apache::Handlers` | Used to support glossary redirect functionality, which is unchanged by this pull request.

Example of changed functionality:
- Glossary search functionality: search the Ensembl Glossary for a term such as 'GENCODE' on [sandbox](http://wp-np2-35.ebi.ac.uk:5092/info/website/glossary.html) and [live](https://www.ensembl.org/info/website/glossary.html) sites

Examples of unchanged functionality:
- Glossary redirect functionality: access the Ensembl Glossary term 'GENCODE' on [sandbox](http://wp-np2-35.ebi.ac.uk:5092/glossary/ENSGLOSSARY_0000210) and [live](https://ensembl.org/glossary/ENSGLOSSARY_0000210) sites, with both redirecting to the [OLS page for the GENCODE term](https://www.ebi.ac.uk/ols4/ontologies/ensemblglossary/classes/http%253A%252F%252Fensembl.org%252Fglossary%252FENSGLOSSARY_0000210).

## Possible complications

None anticipated.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
