### PR TITLE
Recover sample genotypes help link

### DIFF
--- a/modules/EnsEMBL/Web/Document/Element/Content.pm
+++ b/modules/EnsEMBL/Web/Document/Element/Content.pm
@@ -234,7 +234,7 @@ sub content_panel {
     code        => 'main',
     caption     => $node->data->{'full_caption'} || $node->data->{'concise'} || $node->data->{'caption'},
     omit_header => $controller->page_type eq 'Popup' ? 1 : 0,
-    help        => { $hub->species_defs->multiX('ENSEMBL_HELP') }->{join '/', map $hub->$_ || (), qw(type action function)},
+    help        => { $hub->species_defs->multiX('ENSEMBL_HELP') }->{join '/', map $hub->$_ || (), qw(type action function)} || ($hub->type eq 'Variation' && $hub->action eq 'Sample' ? 172 : undef),
   );
   
   my $panel          = $self->new_panel('Navigation', $controller, %params);


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

The help link is missing from the `Variation/Sample` page because in the `ensembl_website` database, the relevant `help_record_id` ( [172](https://www.ensembl.org/Help/View?id=172) ) does not have a corresponding `page_url`.

This pull request would address the issue by modifying the `content_panel` method of the ` EnsEMBL::Web::Document::Element::Content` module so that if an `ENSEMBL_HELP` entry is not retrieved while on a `Variation/Sample` page, the appropriate `help_record_id` (i.e. `172`) is assigned to the `help` parameter. 

## Views affected

This change represents one way to restore the help link to the Variation / Sample genotypes view.

Example:
- Human variant `rs1333049` on [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Variation/Sample?db=core;r=9:22125003-22126003;v=rs1333049;vdb=variation;vf=605993631) and [live](https://www.ensembl.org/Homo_sapiens/Variation/Sample?db=core;r=9:22125003-22126003;v=rs1333049;vdb=variation;vf=605993631) sites

## Possible complications

This change is not expected to impact noticeably on any other view, as no change is made unless the current page is of type `Variation` and action `Sample`.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- N/A
