### PR TITLE
Check for DATABASE_VARIATION when accessing TranscriptVariationAdaptor

### DIFF
--- a/modules/EnsEMBL/Web/Object/Transcript.pm
+++ b/modules/EnsEMBL/Web/Object/Transcript.pm
@@ -1554,6 +1554,7 @@ sub get_genetic_variations {
 sub get_transcript_variations {
   my ($self,$vf_cache) = @_;
 
+  return [] unless $self->hub->species_defs->databases->{'DATABASE_VARIATION'};
   my $tvs = $self->__data->{'tv_cache'} ||= $self->get_adaptor('get_TranscriptVariationAdaptor', 'variation')->fetch_all_by_Transcripts_with_constraint([ $self->Obj ], undef, 1);
 
   # Most VFs will be in slice for transcript, so cache them.

--- a/modules/EnsEMBL/Web/ViewConfig/Transcript/ExonsSpreadsheet.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Transcript/ExonsSpreadsheet.pm
@@ -30,13 +30,17 @@ sub init_cacheable {
 
   $self->SUPER::init_cacheable;
 
+  my $default_snp_display_option = $self->hub->species_defs->databases->{'DATABASE_VARIATION'}
+                                 ? 'exon'
+                                 : 'off';
+
   $self->set_default_options({
     'sscon'           => 25,
     'flanking'        => 50,
     'fullseq'         => 'off',
     'exons_only'      => 'off',
     'line_numbering'  => 'off',
-    'snp_display'     => 'exon',
+    'snp_display'     => $default_snp_display_option,
   });
 
   $self->title('Exons');
@@ -45,7 +49,9 @@ sub init_cacheable {
 sub field_order {
   ## Abstract method implementation
   my @out = (qw(flanking display_width sscon fullseq exons_only line_numbering), $_[0]->variation_fields);
-  unless(grep { $_ eq 'consequence_filter' } @out) {
+
+  if ($_[0]->hub->species_defs->databases->{'DATABASE_VARIATION'}
+      && !(grep { $_ eq 'consequence_filter' } @out)) {
     push @out,'consequence_filter';
   }
   return @out;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

This PR aims to mitigate an intermittent error affecting some views, by adding defensive code in places where a `TranscriptVariationAdaptor` may be accessed for a genome without a variation database.

To see an example of this issue, go to the [staging-site page for Plasmodium falciparum gene PF3D7_0221300](https://staging-protists.ensembl.org/Plasmodium_falciparum/Transcript/Summary?db=core;g=PF3D7_0221300;r=Pf3D7_02_v3:857567-858675;t=PF3D7_0221300.1) and try clicking on any of the links in the "Frameshift introns" row of the transcript summary.

Here is a screenshot of an error:
<img width="866" height="200" alt="p_falciparum_dbexception" src="https://github.com/user-attachments/assets/c8457f55-30cf-472c-9000-137631a3e87b" />

In addition to mitigating this error, the PR would remove the "Filter variants by consequence type" config option from the `ExonsSpreadsheet` view of a genome lacking a variation database.

## Views affected

This PR is expected to affect the `ExonsSpreadsheet` view of a genome lacking a variation database, most obviously with the removal of the unneeded "Filter variants by consequence type" config option.

Example:
- Plasmodium falciparum gene PF3D7_0221300 on [sandbox](http://wp-np2-35.ebi.ac.uk:5099/Plasmodium_falciparum/Transcript/Exons?db=core;g=PF3D7_0221300;r=Pf3D7_02_v3:857567-858675;t=PF3D7_0221300.1) and [staging](https://staging-protists.ensembl.org/Plasmodium_falciparum/Transcript/Exons?db=core;g=PF3D7_0221300;r=Pf3D7_02_v3:857567-858675;t=PF3D7_0221300.1)

## Possible complications

No complications are expected. This PR takes a similar approach to some existing code (e.g. [line 134 of EnsEMBL/Web/Object/Transcript.pm](https://github.com/twalsh-ebi/ensembl-webcode/blob/f985e7030183ff53953b5215d3c9f648747d2f80/modules/EnsEMBL/Web/Object/Transcript.pm#L134)).

## Merge conflicts

None detected

## Related JIRA Issues (EBI developers only)

N/A