### PR TITLE
Update web code to support EPO_EXTENDED alignments

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/genetree_legend.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/genetree_legend.pm
@@ -33,6 +33,7 @@ sub render_normal {
   my $container          = $self->{'container'};
   my $other_gene         = $self->{'highlights'}[5];
   my $highlight_ancestor = $self->{'highlights'}[6];
+  my $low_coverage_species = $self->{'highlights'}[9] || {};
   my $cafe               = $container->isa('Bio::EnsEMBL::Compara::CAFEGeneFamilyNode');
   my $gat                = $container->isa('Bio::EnsEMBL::Compara::GenomicAlignTree');
   my @nodes;
@@ -94,10 +95,10 @@ sub render_normal {
   }
 
   #Labels for high and low coverage species
-  if ($gat) {
+  if ($gat && scalar keys %{$low_coverage_species} > 0) {
     $self->add_vgroup_to_legend([
-      { legend => 'high quality assembly',  colour => 'black', text => 'SpeciesName' },
-      { legend => 'low quality assembly',   colour => 'brown', text => 'SpeciesName' },
+      { legend => 'EPO aligned assembly',  colour => 'black', text => 'SpeciesName' },
+      { legend => 'EPO-Extended aligned assembly',   colour => 'brown', text => 'SpeciesName' },
      ], 'Species', {
         style => 'text',
      });

--- a/modules/EnsEMBL/Draw/GlyphSet/genetree_legend.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/genetree_legend.pm
@@ -97,8 +97,8 @@ sub render_normal {
   #Labels for high and low coverage species
   if ($gat && scalar keys %{$low_coverage_species} > 0) {
     $self->add_vgroup_to_legend([
-      { legend => 'EPO aligned assembly',  colour => 'black', text => 'SpeciesName' },
-      { legend => 'EPO-Extended aligned assembly',   colour => 'brown', text => 'SpeciesName' },
+      { legend => 'EPO assembly',  colour => 'black', text => 'SpeciesName' },
+      { legend => 'EPO-Extended assembly',   colour => 'brown', text => 'SpeciesName' },
      ], 'Species', {
         style => 'text',
      });

--- a/modules/EnsEMBL/Web/Component/Compara_Alignments.pm
+++ b/modules/EnsEMBL/Web/Component/Compara_Alignments.pm
@@ -107,7 +107,7 @@ sub content {
   my $num_groups = 0;
   my $is_overlap = 0; #whether any of the groups overlaps one another (would need target_slice_table)
   my $groups;
-  my $is_low_coverage_species = 0; #is this species part of the low coverage set in the EPO_LOW_COVERAGE alignments
+  my $is_low_coverage_species = 0; #is this species part of the low coverage set in the EPO_EXTENDED/EPO_LOW_COVERAGE alignments
 
   #method_link_species_set class and type
   my $method_class = $hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'ALIGNMENTS'}{$align}{'class'} if ($align);
@@ -117,8 +117,8 @@ sub content {
   if ($align) {
       $align_blocks = $object->get_align_blocks($slice, $align, $cdb);
 
-      #find out if this species is low_coverage and the alignment is EPO_LOW_COVERAGE
-      if ($method_type =~ /EPO_LOW_COVERAGE/ && @$align_blocks) {
+      #find out if this species is low_coverage and the alignment is EPO_EXTENDED/EPO_LOW_COVERAGE
+      if ($method_type =~ /(EPO_EXTENDED|EPO_LOW_COVERAGE)/ && @$align_blocks) {
           # The species is not low-coverage if it's been used in one of the EPO alignments
           $is_low_coverage_species = !scalar( grep {($_->{type} eq 'EPO') && $_->{species}->{$object->species}}
                                               values %{$hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'ALIGNMENTS'}}
@@ -537,7 +537,7 @@ sub draw_tree {
     }
   }
 
-  #Get low coverage species from the EPO_LOW_COVERAGE species set
+  #Get low coverage species from the EPO_EXTENDED/EPO_LOW_COVERAGE species set
   my $low_coverage_species = {};
   if ($class =~ /GenomicAlignTree.tree_alignment/) {
     $low_coverage_species = _get_low_coverage_genome_db_sets($method_link_species_set);
@@ -653,8 +653,8 @@ sub _get_target_slice_table {
   my $other_species;
   my $lookup = $hub->species_defs->prodnames_to_urls_lookup;
 
-  #Find the mapping reference species for EPO_LOW_COVERAGE alignments to distinguish the overlapping blocks
-  if ($type =~ /EPO_LOW_COVERAGE/ && $is_low_coverage_species) {
+  #Find the mapping reference species for EPO_EXTENDED/EPO_LOW_COVERAGE alignments to distinguish the overlapping blocks
+  if ($type =~ /(EPO_EXTENDED|EPO_LOW_COVERAGE)/ && $is_low_coverage_species) {
     
     my $gdba = $compara_db->get_adaptor('GenomeDB');
     my $main_species = $gdba->fetch_by_name_assembly($ref_species);
@@ -706,7 +706,7 @@ sub _get_target_slice_table {
     my ($ref_start, $ref_end, $non_ref_start, $non_ref_end);
     if ($class =~ /pairwise/) { 
       ($ref_start, $ref_end, $non_ref_start, $non_ref_end, $non_ref_ga) = $self->object->get_start_end_of_slice($gab_group);
-    } elsif ($type =~ /EPO_LOW_COVERAGE/ && $is_low_coverage_species) {
+    } elsif ($type =~ /(EPO_EXTENDED|EPO_LOW_COVERAGE)/ && $is_low_coverage_species) {
       ($ref_start, $ref_end, $non_ref_start, $non_ref_end, $non_ref_ga, $num_species) = $self->object->get_start_end_of_slice($gab_group, $other_species);
     } elsif ($type eq 'CACTUS_DB' && $other_species) {
       ($ref_start, $ref_end, $non_ref_start, $non_ref_end, $non_ref_ga, $num_species) = $self->object->get_start_end_of_slice($gab_group, $other_species);
@@ -745,7 +745,7 @@ sub _get_target_slice_table {
                              r      => $ref_string,
                             });
 
-    #Other species - ref species used for mapping (EPO_LOW_COVERAGE), loading via MAF (CACTUS_DB) or non_ref species (pairwise)
+    #Other species - ref species used for mapping (EPO_EXTENDED/EPO_LOW_COVERAGE), loading via MAF (CACTUS_DB) or non_ref species (pairwise)
     my ($other_string, $other_link);
     if ($other_species) {
       $other_string = $non_ref_ga->dnafrag->name.":".$non_ref_start."-".$non_ref_end;
@@ -784,13 +784,33 @@ sub _get_target_slice_table {
 
 }
 
-#Find the set of low coverage species (genome_dbs) from the EPO_LOW_COVERAGE set (high + low coverage)
-#This could be improved by having a direct link between the EPO_LOW_COVERAGE and the corresponding high coverage EPO set
+#Find the set of low coverage species (genome_dbs) from the EPO_EXTENDED/EPO_LOW_COVERAGE set (high + low coverage)
 sub _get_low_coverage_genome_db_sets {
   my ($mlss) = @_;
   my $found_high_mlss;
   my $low_coverage_species_set;
   my $high_coverage_species_set;
+
+  # If this alignment MLSS has a 'base_mlss_id' tag, we can take the
+  # genome_db_id values in the current MLSS that are not in the base MLSS.
+  my $high_cov_mlss_id = $mlss->get_value_for_tag('base_mlss_id');
+  if ($high_cov_mlss_id) {
+    my $high_cov_mlss = $mlss->adaptor->fetch_by_dbID($high_cov_mlss_id);
+
+    if ($high_cov_mlss) {
+      my %high_cov_gdb_id_set = map { $_->dbID => 1 } @{$high_cov_mlss->species_set->genome_dbs};
+
+      my $low_cov_gdb_id_set;
+      foreach my $mlss_gdb (@{$mlss->species_set->genome_dbs}) {
+        my $mlss_gdb_id = $mlss_gdb->dbID;
+        if (! exists $high_cov_gdb_id_set{$mlss_gdb_id}) {
+          $low_cov_gdb_id_set->{$mlss_gdb_id} = 1;
+        }
+      }
+
+      return $low_cov_gdb_id_set;
+    }
+  }
 
   #Fetch all the high coverage EPO method_link_species_sets
   my $high_coverage_mlsss = $mlss->adaptor->fetch_all_by_method_link_type("EPO");

--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -1261,7 +1261,7 @@ sub _summarise_compara_db {
     } elsif ($class =~ /constrained_element/ || $type =~ /CONSTRAINED_ELEMENT/) {
       $key = 'CONSTRAINED_ELEMENTS';
       $constrained_elements->{$species_set_id} = $id;
-    } elsif ($type !~ /EPO_LOW_COVERAGE/ && ($class =~ /tree_alignment/ || $type  =~ /EPO/)) {
+    } elsif ($type !~ /(EPO_EXTENDED|EPO_LOW_COVERAGE)/ && ($class =~ /tree_alignment/ || $type  =~ /EPO/)) {
       $self->db_tree->{$db_name}{$key}{$id}{'species'}{'ancestral_sequences'} = 1 unless exists $self->db_tree->{$db_name}{$key}{$id};
     } elsif ($type eq 'CACTUS_DB') {
       $cactus_db_found = 1;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

`EPO_LOW_COVERAGE` alignments were renamed to `EPO_EXTENDED` in Ensembl release 101.

This pull request would update web code to support this renamed method type.

## Views affected

These changes would affect Compara genome alignment views.

### EnsEMBL::Web::Component::Compara_Alignments

#### Alignment tables will show the relevant EPO reference genome

Examples: 
- Pig - Ningxiang region 1:101985531-102506489 on [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Sus_scrofa_ningxiang/Location/Compara_Alignments?align=9609&db=core&r=1:101985531-102506489) vs [staging](https://staging.ensembl.org/Sus_scrofa_ningxiang/Location/Compara_Alignments?align=9609&db=core&r=1:101985531-102506489) : see the "Location on Pig" column, visible on sandbox but not on staging.
- Bolivian squirrel monkey region JH378319.1:103833-103839 on [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Saimiri_boliviensis_boliviensis/Location/Compara_Alignments?align=9593;db=core;r=JH378319.1:103833-103839) vs [staging](https://staging.ensembl.org/Saimiri_boliviensis_boliviensis/Location/Compara_Alignments?align=9593;db=core;r=JH378319.1:103833-103839) : see the "Location on Human" column, visible on sandbox but not on staging. To get a sense of the difference this change makes, try clicking on the links to "Block 1" or "Block 2" on the sandbox and staging sites.

#### More accurate EPO-Extended alignment info will be retrieved

EPO-Extended examples:
- Primates EPO-Extended alignment of Human region 17:63992802-64238237 on [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Compara_Alignments?align=2050;db=core;r=17:63992802-64238237) vs [staging](https://staging.ensembl.org/Homo_sapiens/Location/Compara_Alignments?align=2050;db=core;r=17:63992802-64238237)
- EPO-Extended alignment of Ninxiang pig breed region 1:101985531-102006489 on [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Sus_scrofa_ningxiang/Location/Compara_Alignments?align=9609--Sus_scrofa--1:100514760-101044570;db=core;r=1:101985531-102006489) vs [staging](https://staging.ensembl.org/Sus_scrofa_ningxiang/Location/Compara_Alignments?align=9609--Sus_scrofa--1:100514760-101044570;db=core;r=1:101985531-102006489)
- EPO-Extended alignment of Horse region 2:55144620-55829364 on [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Equus_caballus/Location/Compara_Alignments?align=9609&db=core&r=2:55144620-55829364) vs [staging](https://staging.ensembl.org/Equus_caballus/Location/Compara_Alignments?align=9609&db=core&r=2:55144620-55829364)

See the legend and labelling of EPO and EPO-Extended genome assemblies in the alignment tree view.

Other alignment examples:
- Primates EPO alignment of Human region 17:63992802-64238237 on [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Compara_Alignments?align=2006&db=core&r=17%3A63992802-64238237) vs [staging](https://staging.ensembl.org/Homo_sapiens/Location/Compara_Alignments?align=2006&db=core&r=17%3A63992802-64238237)
- Mercator-Pecan alignment of Human region 17:63992802-64238237 on [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Compara_Alignments?align=9586;db=core;r=17:63992802-64038237) vs [staging](https://staging.ensembl.org//Homo_sapiens/Location/Compara_Alignments?align=9586;db=core;r=17:63992802-64038237)

Note removal of EPO-Extended legend entry.

### EnsEMBL::Web::ConfigPacker

Changes in this module will prevent unwanted addition of `ancestral_sequences` to the species set of EPO-Extended alignments.

Example:
- Oryza punctata region 1-2000 on [sandbox](http://wp-np2-35.ebi.ac.uk:5098/Oryza_punctata/Location/Compara_Alignments/Image?r=2:1-2000;align=9911;db=core) vs [staging](https://staging-plants.ensembl.org/Oryza_punctata/Location/Compara_Alignments/Image?r=2:1-2000;align=9911;db=core)

Note the "Hidden and missing species" info box in the staging webpage.

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
