### PR TITLE
Disable Transcript ID NHX export of Pan Compara gene trees

### DIFF
--- a/modules/EnsEMBL/Web/Component/DataExport/GeneTree.pm
+++ b/modules/EnsEMBL/Web/Component/DataExport/GeneTree.pm
@@ -36,6 +36,7 @@ sub _init {
 sub content {
   my $self  = shift;
   my $hub   = $self->hub;
+  my $cdb   = $hub->param('cdb') || 'compara';
 
   ## Get user's current settings
   my $view_config  = $self->view_config;
@@ -53,6 +54,9 @@ sub content {
     my $newick_values = [];
 
     my %nhx = EnsEMBL::Web::Constants::NHX_OPTIONS;
+
+    delete $nhx{'transcript_id'} if ($cdb eq 'compara_pan_ensembl');
+
     foreach my $k (sort {lc($a) cmp lc($b)} keys %nhx) {
       push @$nhx_values, {'value' => $k, 'caption' => $nhx{$k}};
     }  


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

NHX export in "Transcript ID" mode does not work correctly for Pan Compara gene trees containing vertebrate genes.

In NHX gene trees exported in this mode, the leaf nodes representing vertebrate members lack names.

This PR would address the issue by switching off the "Transcript ID" mode of NHX export in Pan Compara gene trees.

## Views affected

This would remove  "Transcript ID" mode from NHX export options of Pan Compara gene trees.

Example:
- Gene tree of Drosophila melanogaster gene FBgn0053839 in the [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/PanComparaTree?collapse=none;db=core;g=FBgn0053839)

## Possible complications

Because the changes in this PR have an effect only if the Compara database (`$cdb`) is `"compara_pan_ensembl"`, it should not affect any views other than the Pan Compara gene tree view.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
