### PR TITLE
Tweak handling of response to publication metadata request

### DIFF
--- a/modules/EnsEMBL/Web/Utils/Publications.pm
+++ b/modules/EnsEMBL/Web/Utils/Publications.pm
@@ -52,7 +52,7 @@ sub parse_publication_list {
     if ($line =~ m#<li>([A-Z]{3})(/*)(\d+)#) {
       my ($source, $separator, $id) = ($1, $2, $3);
       my $pub_content = get_publication_by_id($rest, $source, $id, $hub);
-      $line =~ s/$source$separator$id/$pub_content/;
+      $line =~ s/$source$separator$id/$pub_content/ if $pub_content;
     }
     $converted .= $line."\n";
   }
@@ -155,7 +155,14 @@ sub _get_publications {
   my ($rest, $endpoint, $hub, $format) = @_;
   my $response = $rest->fetch($endpoint);
   
-  return ($response->{'resultList'}{'result'} || []); 
+  my $publications = [];
+  if (ref($response) eq 'HASH'
+      && exists $response->{'resultList'}
+      && exists $response->{'resultList'}{'result'}) {
+    $publications = $response->{'resultList'}{'result'};
+  }
+
+  return $publications;
 }
 
 1;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

This PR would update handling of the response to a publication metadata request, and handling of publication query strings in species static content.

The aim is to ensure that a species information page can be displayed even if there are issues fetching publication metadata.

## Views affected

This is expected to affect species information pages with publication query strings (e.g. `"MED/33249676"`), helping to make them more robust to issues with fetching publication metadata.

Example:
- Citrullus lanatus species info page on [sandbox](http://wp-np2-35.ebi.ac.uk:5098/Citrullus_lanatus/Info/Annotation/) and [staging](https://staging-plants.ensembl.org/Citrullus_lanatus/Info/Annotation/)

The following screenshot shows an error that may currently be displayed when there are issues fetching publication metadata:
<img width="768" height="256" alt="clan_pubs before error" src="https://github.com/user-attachments/assets/fd8f566b-5d25-4adf-9a43-8757510b2cb4" />

With the changes in this PR, the following screenshots show what the references section of the Citrullus lanatus species info page can look like with successful retrieval of metadata for respectively zero, one or two references.

---

### Zero references retrieved

<img width="480" height="180" alt="clan_pubs after 0" src="https://github.com/user-attachments/assets/18bceed4-08be-4739-8b9b-441f05e20d3b" />

---

### One reference retrieved

<img width="480" height="164" alt="clan_pubs after 1" src="https://github.com/user-attachments/assets/aef1ed1c-987d-47f5-8e17-b62833c26c52" />

---

### Two references retrieved

<img width="480" height="200" alt="clan_pubs after 2" src="https://github.com/user-attachments/assets/84db239e-cdfb-471d-9422-66c89a74d14a" />

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
