### PR TITLE
Tweak alignment metadata to facilitate human self-alignment view

### DIFF
--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -1503,7 +1503,7 @@ sub _summarise_compara_alignments {
   my $where = '';
   $where = "WHERE ".join(' AND ',@where) if(@where);
   $q = sprintf('
-    select genomic_align_block_id, ga.method_link_species_set_id, ga.dnafrag_start, ga.dnafrag_end, ga.dnafrag_id
+    select distinct genomic_align_block_id, ga.method_link_species_set_id, ga.dnafrag_start, ga.dnafrag_end, ga.dnafrag_id
       from genomic_align ga_ref join dnafrag using (dnafrag_id) join genomic_align ga using (genomic_align_block_id)
       %s
       order by genomic_align_block_id, ga.dnafrag_id',

--- a/modules/EnsEMBL/Web/Factory/MultipleLocation.pm
+++ b/modules/EnsEMBL/Web/Factory/MultipleLocation.pm
@@ -141,7 +141,9 @@ sub createObjects {
   # In within-species region comparison, the secondary
   # region may be provided by the 'align' parameter.
   my $align_param = $self->param('align');
-  if ($align_param && $align_param =~ /^(?<mlss_id>[0-9]+)--(?<species_url>.+)--(?<region>(?<chr>[^:]+).*)$/) {
+  if ($align_param
+      && $align_param =~ /^(?<mlss_id>[0-9]+)--(?<species_url>.+)--(?<region>(?<chr>[^:]+)[0-9]+-[0-9]+)$/
+      && scalar keys %inputs == 1) {
     my $next_input_id = max(keys %inputs) + 1;
     $inputs{$next_input_id} = {
       's'   => $+{'species_url'},

--- a/modules/EnsEMBL/Web/Factory/MultipleLocation.pm
+++ b/modules/EnsEMBL/Web/Factory/MultipleLocation.pm
@@ -142,7 +142,7 @@ sub createObjects {
   # region may be provided by the 'align' parameter.
   my $align_param = $self->param('align');
   if ($align_param
-      && $align_param =~ /^(?<mlss_id>[0-9]+)--(?<species_url>.+)--(?<region>(?<chr>[^:]+)[0-9]+-[0-9]+)$/
+      && $align_param =~ /^(?<mlss_id>[0-9]+)--(?<species_url>.+)--(?<region>(?<chr>[^:]+).*)$/
       && scalar keys %inputs == 1) {
     my $next_input_id = max(keys %inputs) + 1;
     $inputs{$next_input_id} = {


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

This PR would make two adjustments to handling of alignment metadata, both of which facilitate the human self-alignment view.

## Views affected

The main view affected by these changes is the human self-alignment region comparison view. These changes should also benefit other region comparison views.

### Change 1: Extract region from 'align' param only if no secondary region params

[ensembl-webcode PR 1140](https://github.com/Ensembl/ensembl-webcode/pull/1140) added a section of code to extract region metadata from the `align` parameter. This is currently only beneficial when the user accesses region comparison from a text alignment view (as in the following example). In cases where a URL already contains secondary region parameters, extraction of a region from the `align` parameter may result in duplication of a region in the region comparison view.

1. [Text alignment at Human region 17:15332364-15682365](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/View?align=739;r=17:15332364-15682365)
2. [Region comparison against Human region 17:18699947-18824071](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Multi?align=739--Homo_sapiens--17:18699947-18824071;db=core;r=17:15519628-15682365) OR [Region comparison against Human region 3:50718775-50719932](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Multi?align=739--Homo_sapiens--3:50718775-50719932;db=core;r=17:15506910-15507875)

### Change 2: Query distinct regions when packing alignment data

Currently, an alignment region query in `ConfigPacker` may return duplicate region data, resulting in artefactual alignment metadata between a region and itself. This in turn causes within-species Human `LASTZ_NET` and `LASTZ_PATCH` alignments to appear to overlap each other, which may arbitrarily prevent the display of one or the other.

By querying only distinct results, this change would reduce the chances that `LASTZ_NET` and `LASTZ_PATCH` would artefactually appear to overlap each other, facilitating the correct display of these alignments.

Example:
- Human self-alignment in region 17:63992802-64038237: [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Multi?db=core;r=17:63992802-64038237;r1=17:64000475-64045910:1;s1=Homo_sapiens--17) vs [staging](http://staging.ensembl.org/Homo_sapiens/Location/Multi?db=core;r=17:63992802-64038237;r1=17:64000475-64045910:1;s1=Homo_sapiens--17)

## Possible complications

None expected:
- change 1: restricting the extraction of region information from the `align` parameter should reduce the chances of unwanted side effects;
- change 2: querying distinct alignment regions during packing is not expected to result in loss of alignment metadata, because trivial alignments between a region and itself are currently filtered out by the LastZ pipeline.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
