### PR TITLE
Implement special wiki links for certain species

### DIFF
--- a/modules/EnsEMBL/Web/Component/Info/SpeciesBlurb.pm
+++ b/modules/EnsEMBL/Web/Component/Info/SpeciesBlurb.pm
@@ -128,9 +128,25 @@ sub _wikipedia_link {
   my $self = shift;
   my $species = $self->hub->species_defs->SPECIES_SCIENTIFIC_NAME;
   $species =~ s/ /_/g;;
+
+  # Species with faulty links to be overwritten:
+  my %special_wiki = (
+    'Anas_platyrhynchos_domesticus' => 'https://en.wikipedia.org/wiki/Mallard',
+    'Bos_indicus_x_Bos_taurus'      => 'https://en.wikipedia.org/wiki/Bos',
+    'Cervus_hanglu_yarkandensis'    => 'https://en.wikipedia.org/wiki/Central_Asian_red_deer',
+    'Gymnocanthus_tricuspis'        => 'https://en.wikipedia.org/wiki/Arctic_staghorn_sculpin',
+    'Gallus_gallus'                 => 'https://en.wikipedia.org/wiki/Red_junglefowl',
+    'Malurus_cyaneus_samueli'       => 'https://en.wikipedia.org/wiki/Superb_fairywren',
+    'Marmota_marmota_marmota'       => 'https://en.wikipedia.org/wiki/Alpine_marmot',
+    'Sus_scrofa'                    => 'https://en.wikipedia.org/wiki/Pig',
+    'Sus_scrofa_domesticus'         => 'https://en.wikipedia.org/wiki/Pig',
+  );
+
+  my $wiki_url = $special_wiki{$species} || "https://en.wikipedia.org/wiki/$species";
+ 
   my $html = qq(<h2>More information</h2>
 <p>General information about this species can be found in 
-<a href="http://en.wikipedia.org/wiki/$species" rel="external">Wikipedia</a>.
+<a href="$wiki_url" rel="external">Wikipedia</a>.
 </p>); 
 
   return $html;


### PR DESCRIPTION
Added special wiki links for specific species to override default Wikipedia links.

## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

Some species scientific names do not map cleanly to a valid or correct Wikipedia article when used directly in the URL (e.g. subspecies names, domesticated variants, hybrids). This change adds a lookup table of overrides so those species link to the appropriate Wikipedia page instead of a broken or misleading one.

## Views affected

Species Assembly/Annotation page — the "More information" section that links to Wikipedia.

Example: `https://staging.ensembl.org/Bos_indicus_hybrid/Info/Annotation` (for comparison, without fix in place: `https://www.ensembl.org/Bos_indicus_hybrid/Info/Annotation`)

## Possible complications

Minimal. The change only affects the `_wikipedia_link` method in `SpeciesBlurb.pm`. Species not listed in the override table are unaffected and continue to use the existing URL construction logic.

## Merge conflicts

Branch has been checked against current main. Only changes present are those from this commit.

## Related JIRA Issues (EBI developers only)

No tickets.