### PR TITLE
Fix EPO-Extended low-coverage species classification

### DIFF
--- a/modules/EnsEMBL/Web/Component/Compara_Alignments.pm
+++ b/modules/EnsEMBL/Web/Component/Compara_Alignments.pm
@@ -120,7 +120,8 @@ sub content {
       #find out if this species is low_coverage and the alignment is EPO_EXTENDED/EPO_LOW_COVERAGE
       if ($method_type =~ /(EPO_EXTENDED|EPO_LOW_COVERAGE)/ && @$align_blocks) {
           # The species is not low-coverage if it's been used in one of the EPO alignments
-          $is_low_coverage_species = !scalar( grep {($_->{type} eq 'EPO') && $_->{species}->{$object->species}}
+          my $prod_name = $hub->species_defs->get_config($object->species, 'SPECIES_PRODUCTION_NAME');
+          $is_low_coverage_species = !scalar( grep {($_->{type} eq 'EPO') && $_->{species}->{$prod_name}}
                                               values %{$hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'ALIGNMENTS'}}
                                             );
       } elsif ($target_slice && $method_type eq 'CACTUS_DB') {


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

[ensembl-webcode PR 1158](https://github.com/Ensembl/ensembl-webcode/pull/1158) updated the web code to support `EPO_EXTENDED` alignments.

However, the code setting `$is_low_coverage_species` was in need of an update to reflect changes in the web code since the switch from `EPO_LOW_COVERAGE` to `EPO_EXTENDED`, in order to ensure that the species production name is used when accessing packed `ALIGNMENTS` metadata.

This PR would implement that update, fetching the production name using the species URL accessed via `$object->species` and using that to access relevant `ALIGNMENTS` metadata.

## Views affected

This affects EPO-Extended alignment views, particularly those with a text alignment slice table.

Example:
- Sauropsids EPO-Extended on [sandbox](http://wp-np2-35.ebi.ac.uk:5092/Gallus_gallus/Location/Compara_Alignments?align=2039;db=core;r=5:38111022-38265293) and [RC site](https://rc.ensembl.org/Gallus_gallus/Location/Compara_Alignments?align=2039;db=core;r=5:38111022-38265293).

## Possible complications

None expected, as this change is in a section of code specific to `EPO_EXTENDED` and `EPO_LOW_COVERAGE` alignments.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- ENSCOMPARASW-8799
