### PR TITLE
Update default EGB_NCBI URL

### DIFF
--- a/modules/EnsEMBL/Web/Configuration/Location.pm
+++ b/modules/EnsEMBL/Web/Configuration/Location.pm
@@ -238,8 +238,7 @@ sub add_external_browsers {
       if ($chr) { 
           $url = $hub->get_ExtURL('EGB_NCBI', { ACCESSION => $browsers{'ACCESSION'}, CHR => $chr, START => $start, END => $end });
         } else {
-          my $taxid = $species_defs->get_config($hub->species, 'TAXONOMY_ID'); 
-          $url = "http://www.ncbi.nlm.nih.gov/mapview/map_search.cgi?taxid=$taxid";
+          $url = sprintf("https://www.ncbi.nlm.nih.gov/gdv/browser/genome/?id=%s", $browsers{'ACCESSION'});
         }
         
         $self->get_other_browsers_menu->append($self->create_node('NCBI_DB', 'NCBI', [], { url => $url, raw => 1, external => 1 }));


### PR DESCRIPTION
## Description

This PR would update the default `EGB_NCBI` URL in the `EnsEMBL::Web::Configuration::Location` module, which is used to generate a link to an NCBI genome browser  in location views that do not depict a specific region.

It would affect 16 genomes in Ensembl Vertebrates (@EreboPSilva) and 3 genomes in Ensembl Metazoa (@vsitnik).

## Views affected

This would affect the sidebar menu in location views that do not show a specific region (e.g. "Whole genome" view).

The table below shows information for each affected species in Ensembl Vertebrates. There is an equivalent table for Metazoa in [eg-web-common PR 173](https://github.com/EnsemblGenomes/eg-web-common/pull/173).

For each species, the `sandbox_page` and `rc_page` columns contain links to relevant pages in the sandbox and RC sites, respectively. The `genbank_accession` contains the GenBank accession of the assembly as shown in Ensembl, while the `resolved_refseq_accession` shows the RefSeq accession resolved by the GDV when accessed via the Ensembl link for "Other genome browsers". The `accession_correspondence` shows the result of an initial check of the correspondence between the GenBank accession and resolved RefSeq accession.

| sandbox_page | rc_page | genbank_accession | resolved_refseq_accession | accession_correspondence
|--------------|---------|-------------------|---------------------------|-
| [Bos_taurus](http://wp-np2-35.ebi.ac.uk:5092/Bos_taurus/Location/Genome) | [Bos_taurus](https://rc.ensembl.org/Bos_taurus/Location/Genome) | GCA_002263795.4 | GCF_002263795.2 | `not ok`
| [Caenorhabditis_elegans](http://wp-np2-35.ebi.ac.uk:5092/Caenorhabditis_elegans/Location/Genome) | [Caenorhabditis_elegans](https://rc.ensembl.org/Caenorhabditis_elegans/Location/Genome) | GCA_000002985.3 | GCF_000002985.6 | `ok`
| [Canis_lupus_familiaris](http://wp-np2-35.ebi.ac.uk:5092/Canis_lupus_familiaris/Location/Genome) | [Canis_lupus_familiaris](https://rc.ensembl.org/Canis_lupus_familiaris/Location/Genome) | GCA_014441545.1 | GCF_014441545.1 | `ok`
| [Danio_rerio](http://wp-np2-35.ebi.ac.uk:5092/Danio_rerio/Location/Genome) | [Danio_rerio](https://rc.ensembl.org/Danio_rerio/Location/Genome) | GCA_000002035.4 | GCF_000002035.6 | `ok`
| [Drosophila_melanogaster](http://wp-np2-35.ebi.ac.uk:5092/Drosophila_melanogaster/Location/Genome) | [Drosophila_melanogaster](https://rc.ensembl.org/Drosophila_melanogaster/Location/Genome) | GCA_000001215.4 | GCF_000001215.4 | `ok`
| [Equus_caballus](http://wp-np2-35.ebi.ac.uk:5092/Equus_caballus/Location/Genome) | [Equus_caballus](https://rc.ensembl.org/Equus_caballus/Location/Genome) | GCA_002863925.1 | GCF_002863925.1 | `ok`
| [Gallus_gallus](http://wp-np2-35.ebi.ac.uk:5092/Gallus_gallus/Location/Genome) | [Gallus_gallus](https://rc.ensembl.org/Gallus_gallus/Location/Genome) | GCA_016699485.1 | GCF_016699485.2 | `ok`
| [Homo_sapiens](http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/Genome) | [Homo_sapiens](https://rc.ensembl.org/Homo_sapiens/Location/Genome) | GCA_000001405.29 | GCF_000001405.40 | `ok`
| [Macaca_mulatta](http://wp-np2-35.ebi.ac.uk:5092/Macaca_mulatta/Location/Genome) | [Macaca_mulatta](https://rc.ensembl.org/Macaca_mulatta/Location/Genome) | GCA_003339765.3 | GCF_003339765.1 | `ok`
| [Monodelphis_domestica](http://wp-np2-35.ebi.ac.uk:5092/Monodelphis_domestica/Location/Genome) | [Monodelphis_domestica](https://rc.ensembl.org/Monodelphis_domestica/Location/Genome) | GCA_000002295.1 | GCF_000002295.2 | `ok`
| [Mus_musculus](http://wp-np2-35.ebi.ac.uk:5092/Mus_musculus/Location/Genome) | [Mus_musculus](https://rc.ensembl.org/Mus_musculus/Location/Genome) | GCA_000001635.9 | GCF_000001635.27 | `ok`
| [Ovis_aries](http://wp-np2-35.ebi.ac.uk:5092/Ovis_aries/Location/Genome) | [Ovis_aries](https://rc.ensembl.org/Ovis_aries/Location/Genome) | GCA_016772045.2 | GCF_016772045.1 | `not ok` | `ok`
| [Pan_troglodytes](http://wp-np2-35.ebi.ac.uk:5092/Pan_troglodytes/Location/Genome) | [Pan_troglodytes](https://rc.ensembl.org/Pan_troglodytes/Location/Genome) | GCA_000001515.5 | GCF_000001515.7 | `ok`
| [Rattus_norvegicus](http://wp-np2-35.ebi.ac.uk:5092/Rattus_norvegicus/Location/Genome) | [Rattus_norvegicus](https://rc.ensembl.org/Rattus_norvegicus/Location/Genome) | GCA_036323735.1 | GCF_036323735.1 | `ok`
| [Saccharomyces_cerevisiae](http://wp-np2-35.ebi.ac.uk:5092/Saccharomyces_cerevisiae/Location/Genome) | [Saccharomyces_cerevisiae](https://rc.ensembl.org/Saccharomyces_cerevisiae/Location/Genome) | GCA_000146045.2 | GCF_000146045.2 | `ok`
| [Sus_scrofa](http://wp-np2-35.ebi.ac.uk:5092/Sus_scrofa/Location/Genome) | [Sus_scrofa](https://rc.ensembl.org/Sus_scrofa/Location/Genome) | GCA_000003025.6 | GCF_000003025.6 | `ok`

## Possible complications

None expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- N/A