### PR TITLE
Add genebuild changes

### DIFF
--- a/modules/EnsEMBL/Web/Component/Info/HomePage.pm
+++ b/modules/EnsEMBL/Web/Component/Info/HomePage.pm
@@ -174,6 +174,9 @@ sub assembly_text {
 );
   }
 
+  # Insert link to image credits page
+  $html .= '<h3 class="light top-margin">Image Credits</h3><p><a href="/info/about/image_credits.html">Credits for species images</a></p>';
+
   return $html;
 }
 

--- a/modules/EnsEMBL/Web/Component/Info/SpeciesBlurb.pm
+++ b/modules/EnsEMBL/Web/Component/Info/SpeciesBlurb.pm
@@ -131,7 +131,7 @@ sub _wikipedia_link {
 
   # Species with faulty links to be overwritten:
   my %special_wiki = (
-    'Anas_platyrhynchos_domesticus' => 'https://en.wikipedia.org/wiki/Mallard',
+    'Anas_platyrhynchos_platyrhynchos' => 'https://en.wikipedia.org/wiki/Mallard',
     'Bos_indicus_x_Bos_taurus'      => 'https://en.wikipedia.org/wiki/Bos',
     'Cervus_hanglu_yarkandensis'    => 'https://en.wikipedia.org/wiki/Central_Asian_red_deer',
     'Gymnocanthus_tricuspis'        => 'https://en.wikipedia.org/wiki/Arctic_staghorn_sculpin',


### PR DESCRIPTION
## Description

Genebuild have asked us to add a link to the photo credits page on the landing page of all verts. Change can be seen on the RC site: https://rc.ensembl.org/Anas_platyrhynchos_platyrhynchos/Info/Index

This PR also includes a fix to a species name in a change done in #1163 
