### PR TITLE
Access more homology metadata via multi packed file

### DIFF
--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -1207,6 +1207,69 @@ sub _build_compara_mlss {
   $dest->{'MLSS_IDS'} = \%mlss;
 }
 
+sub _build_gene_tree_stats_mlss {
+  my ($self,$dbh,$dest) = @_;
+
+  # Take the default gene-tree collection, if available.
+  # Otherwise, take the largest gene-tree collection.
+  my $sql = q(
+    select method_link_species_set_id
+      from method_link_species_set mlss
+      join method_link ml
+        using (method_link_id)
+      join species_set_header ssh
+        using (species_set_id)
+      where ml.type = ?
+      order by field(ssh.name, "collection-default", "default") desc, ssh.size desc
+      limit 1
+  );
+
+  my %gene_tree_stats_mlss_ids;
+  foreach my $method_type ('PROTEIN_TREES', 'NC_TREES') {
+    my ($row) = $dbh->selectrow_arrayref($sql, undef, $method_type);
+    if ($row) {
+      $gene_tree_stats_mlss_ids{$method_type} = $row->[0];
+    }
+  }
+
+  $dest->{'GENE_TREE_STATS_MLSS_IDS'} = \%gene_tree_stats_mlss_ids;
+}
+
+sub _build_homology_mlss_tags {
+  my ($self,$dbh,$dest) = @_;
+
+  # Homology MLSS tags may be stored in the method_link_species_set_attr
+  # or method_link_species_set_tag tables. It just so happens that all
+  # the tags we are currently interested in are to be found in the
+  # method_link_species_set_attr table.
+  my $sth = $dbh->prepare(q(
+    select method_link_species_set_id,
+           goc_quality_threshold,
+           wga_quality_threshold
+      from method_link_species_set
+      join method_link
+        using (method_link_id)
+      join method_link_species_set_attr
+        using (method_link_species_set_id)
+      where goc_quality_threshold is not null
+        or wga_quality_threshold is not null
+  ));
+  $sth->execute;
+  my %hom_mlss_tags;
+  while (my ($mlss_id, $goc_threshold, $wga_threshold) = $sth->fetchrow_array) {
+    $hom_mlss_tags{$mlss_id} = {};
+
+    if (defined $goc_threshold) {
+      $hom_mlss_tags{$mlss_id}{goc_quality_threshold} = $goc_threshold;
+    }
+
+    if (defined $wga_threshold) {
+      $hom_mlss_tags{$mlss_id}{wga_quality_threshold} = $wga_threshold;
+    }
+  }
+  $dest->{'HOMOLOGY_MLSS_TAGS'} = \%hom_mlss_tags;
+}
+
 sub _summarise_compara_db {
   my ($self, $code, $db_name) = @_;
  
@@ -1412,6 +1475,8 @@ sub _summarise_compara_db {
 
   $self->_build_compara_default_aligns($dbh,$self->db_tree->{$db_name});
   $self->_build_compara_mlss($dbh,$self->db_tree->{$db_name});
+  $self->_build_gene_tree_stats_mlss($dbh,$self->db_tree->{$db_name});
+  $self->_build_homology_mlss_tags($dbh,$self->db_tree->{$db_name});
 
   ##
   ###################################################################

--- a/modules/EnsEMBL/Web/Document/HTML/Compara/GeneTrees.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara/GeneTrees.pm
@@ -49,17 +49,29 @@ sub format_gene_tree_stats {
   my $page       = $self->hub->param('page');
   return unless $compara_db;
 
-  my $mlss_adaptor    = $compara_db->get_adaptor('MethodLinkSpeciesSet');
-  my $all_mlsss       = $mlss_adaptor->fetch_all_by_method_link_type($method);
-  # Give preference to default gene-tree collection(s), if available.
-  my @default_mlsss   = grep { $_->species_set->name  =~ /^(collection-)?default$/ } @$all_mlsss;
-  $all_mlsss          = \@default_mlsss if (@default_mlsss);
-  # Take the largest relevant gene-tree collection.
-  my ($mlss)          = sort {$b->species_set->size <=> $a->species_set->size} @$all_mlsss;
-  return unless $mlss;
+  my $species_tree;
+  my $mlss_ids_by_method_type = $self->hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'GENE_TREE_STATS_MLSS_IDS'} || {};
+  if (exists $mlss_ids_by_method_type->{$method} && $mlss_ids_by_method_type->{$method}) {
+    # If a pre-selected gene-tree collection is available,
+    # we get that gene-tree collection's species tree.
+    my $mlss_id = $mlss_ids_by_method_type->{$method};
+    my $species_tree_adaptor = $compara_db->get_adaptor('SpeciesTree');
+    # We fetch the 'default' species tree of the gene-tree collection, as
+    # opposed to other kinds of gene tree (e.g. 'cafe', 'full_species_tree').
+    $species_tree = $species_tree_adaptor->fetch_by_method_link_species_set_id_label($mlss_id, 'default');
+  } else {
+    # If a gene-tree collection has not been pre-selected, select it now.
+    my $mlss_adaptor    = $compara_db->get_adaptor('MethodLinkSpeciesSet');
+    my $all_mlsss       = $mlss_adaptor->fetch_all_by_method_link_type($method);
+    # Give preference to default gene-tree collection(s), if available.
+    my @default_mlsss   = grep { $_->species_set->name  =~ /^(collection-)?default$/ } @$all_mlsss;
+    $all_mlsss          = \@default_mlsss if (@default_mlsss);
+    # Take the largest relevant gene-tree collection.
+    my ($mlss)          = sort {$b->species_set->size <=> $a->species_set->size} @$all_mlsss;
+    $species_tree       = $mlss->species_tree if $mlss;
+  }
 
-  my $species_tree_adaptor = $compara_db->get_adaptor('SpeciesTree');
-  my $species_tree = $mlss->species_tree;
+  return unless $species_tree;
 
   # Reads the species set that are defined in the database (if any)
   my $ordered_species = $hub->order_species_by_clade($species_tree->root->get_all_leaves);

--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -821,15 +821,21 @@ sub fetch_homology_species_hash {
   my $homology_description = shift;
   my $compara_db           = shift || 'compara';
   my $name_lookup          = {};
+  my $db_key;
   if ($compara_db =~ /pan/) {
     my $pan_info = $self->hub->species_defs->multi_val('PAN_COMPARA_LOOKUP');
     foreach (keys %$pan_info) {
       $name_lookup->{$_} = $pan_info->{$_}{'species_url'};
     }
+    $db_key = 'DATABASE_COMPARA_PAN_ENSEMBL';
   }
   else {
     $name_lookup = $self->hub->species_defs->prodnames_to_urls_lookup;
+    $db_key = 'DATABASE_COMPARA';
   }
+
+  my $hom_mlss_tags = $self->hub->species_defs->multi_hash->{$db_key}->{'HOMOLOGY_MLSS_TAGS'} // {};
+
   my ($homologies, $classification, $query_member) = $self->get_homologies($homology_source, $homology_description, $compara_db);
   my %homologues;
 
@@ -847,9 +853,18 @@ sub fetch_homology_species_hash {
         $target_member  = $gene_member;
         $dnds_ratio     = $homology->dnds_ratio; 
         $goc_score      = $homology->goc_score;
-        $goc_threshold  = $homology->method_link_species_set->get_value_for_tag('goc_quality_threshold');        
+
+        my $mlss_id = $homology->method_link_species_set_id;
+        if (exists $hom_mlss_tags->{$mlss_id} && exists $hom_mlss_tags->{$mlss_id}{'goc_quality_threshold'}) {
+          $goc_threshold = $hom_mlss_tags->{$mlss_id}{'goc_quality_threshold'};
+        }
+
         $wgac           = $homology->wga_coverage;
-        $wga_threshold  = $homology->method_link_species_set->get_value_for_tag('wga_quality_threshold');
+
+        if (exists $hom_mlss_tags->{$mlss_id} && exists $hom_mlss_tags->{$mlss_id}{'wga_quality_threshold'}) {
+          $wga_threshold = $hom_mlss_tags->{$mlss_id}{'wga_quality_threshold'};
+        }
+
         $highconfidence = $homology->is_high_confidence;
       }      
     }


### PR DESCRIPTION
## Description

This PR aims to mitigate issues with a long-running database query — particularly affecting Ensembl Fungi — by avoiding calling the API method(s) triggering it.

It adds method `ConfigPacker::_build_gene_tree_stats_mlss` to populate `GENE_TREE_STATS_MLSS_IDS`, which is used in `EnsEMBL::Web::Document::HTML::Compara::GeneTrees::format_gene_tree_stats` to fetch the species tree of a gene-tree collection without going through its `MethodLinkSpeciesSet`.

It adds method `ConfigPacker::_build_homology_mlss_tags` to populate `HOMOLOGY_MLSS_TAGS`, which is used in `Ensembl::Web::Object::Gene::fetch_homology_species_hash` to fetch GOC/WGA thresholds with instantiating a `MethodLinkSpeciesSet` object.

## Views affected

These changes would affect respectively gene-tree stats views and homology pages.

Examples are given below of test and baseline sandbox pages, all in sandbox sites in which calls to Compara method [SpeciesSetAdaptor::_left_join](https://github.com/Ensembl/ensembl-compara/blob/580fc9e86ce452c9ba0310399654719d7abdbb69/modules/Bio/EnsEMBL/Compara/DBSQL/SpeciesSetAdaptor.pm#L205) throw an error. The error is not thrown on the test pages because `SpeciesSetAdaptor::_left_join` is not being called.

| test_page | baseline_page
|-----------|-
| [Orthologues page of D. melanogaster gene FBgn0013679](http://wp-np2-35.ebi.ac.uk:5092/Drosophila_melanogaster/Gene/Compara_Ortholog?db=core;g=FBgn0013679) | [Orthologues page of D. melanogaster gene FBgn0013679](http://wp-np2-35.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/Compara_Ortholog?db=core;g=FBgn0013679)
| [Fungi protein-tree stats page](http://wp-np2-35.ebi.ac.uk:5091/info/genome/compara/prot_tree_stats.html) | [Metazoa protein-tree stats page](http://wp-np2-35.ebi.ac.uk:5094/info/genome/compara/prot_tree_stats.html)

## Possible complications

This change would require repacking of all `MULTI.db.packed` files.

Without repacking:
- method `format_gene_tree_stats` would revert to previous behaviour, selecting a species tree dynamically;
- method `fetch_homology_species_hash` would return undefined GOC/WGA thresholds.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- ENSCOMPARASW-9255
