### PR TITLE
Update OpenTargets link on Acknowledgements page

### DIFF
--- a/htdocs/info/about/credits.html
+++ b/htdocs/info/about/credits.html
@@ -35,7 +35,7 @@
                 href="http://ec.europa.eu/research/fp7/"><img
                   src="/img/credits/eu_flag_small.jpg" alt="logo" title="EU
                   flag" /></a><br>Co-funded by the European Union</p>
-            <p><a href="http://www.targetvalidation.org/"><img
+            <p><a href="https://opentargets.org/"><img
                   src="/img/credits/open_targets.png" alt="logo" title="Open
                   Targets"/></a></p>
             <p><a href="http://www.thetgmi.org/"><img


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

This PR would update the OpenTargets link on the Ensembl Acknowledgements page.

## Views affected

This change affects the Ensembl Acknowledgements page.

Example: [sandbox](http://wp-np2-35.ebi.ac.uk:5092/info/about/credits.html) vs [June 2026 archive](https://jun2026.archive.ensembl.org/info/about/credits.html)

## Possible complications

None expected

## Merge conflicts

None detected

## Related JIRA Issues (EBI developers only)

N/A
