### PR TITLE
Adjust Pan external URL to match June 2026 archive site

### DIFF
--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -1789,11 +1789,15 @@ sub species_path {
 
         if ($species_division ne $this_site_division) {
 
-          # The ENSEMBL_SERVERNAME will not always have a server prefix.
-          # This is expected for live Ensembl sites and external sites (e.g. Gramene).
-          # In such cases, the URL will refer to the live site of the species division.
           my $server_prefix;
-          if ($SiteDefs::ENSEMBL_SERVERNAME =~ /^(.+)-${this_site_division}\.ensembl\.org$/) {
+          if ($SiteDefs::ENSEMBL_SERVERNAME =~ /\.ensembl\.org$/
+              && $SiteDefs::ARCHIVE_VERSION eq 'Jun2026'
+              && $SiteDefs::ENSEMBL_VERSION eq '116') {
+            $server_prefix = $SiteDefs::ARCHIVE_VERSION;  # a special case for a special release
+          } elsif ($SiteDefs::ENSEMBL_SERVERNAME =~ /^(.+)-${this_site_division}\.ensembl\.org$/) {
+            # The ENSEMBL_SERVERNAME will not always have a server prefix.
+            # This is expected for live Ensembl sites and external sites (e.g. Gramene).
+            # In such cases, the URL will refer to the live site of the species division.
             $server_prefix = $1;
           }
 


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

This PR would update the code to generate Pan Compara URLs, introducing a special case for linking between Ensembl June 2026 archive sites.

## Views affected

This would affect any Pan Compara view with links to Ensembl sister sites.

In the following examples, within a sandbox page, clicking on links for Ensembl sites other than Plants leads to a June 2026 archive site. From the corresponding June 2026 archive page, clicking on such a link leads to the new Ensembl site:
- Pan Compara gene tree of A. thaliana gene AT1G07820 : [sandbox](http://wp-np2-35.ebi.ac.uk:5098/Arabidopsis_thaliana/Gene/PanComparaTree?collapse=none;db=core;g=AT1G07820;r=1:2421089-2422066) vs [June 2026 archive](https://jun2026-plants.ensembl.org/Arabidopsis_thaliana/Gene/PanComparaTree?collapse=none;db=core;g=AT1G07820;r=1:2421089-2422066)
- Pan Compara orthologues for A. thaliana gene AT1G07820 : [sandbox](http://wp-np2-35.ebi.ac.uk:5098/Arabidopsis_thaliana/Gene/Compara_Ortholog/pan_compara?collapse=none;db=core;g=AT1G07820;r=1:2421089-2422066) vs [June 2026 archive](https://jun2026-plants.ensembl.org/Arabidopsis_thaliana/Gene/Compara_Ortholog/pan_compara?collapse=none;db=core;g=AT1G07820;r=1:2421089-2422066)
- Pan Compara orthologues for Rice gene RPL5 : [sandbox](http://wp-np2-35.ebi.ac.uk:5098/Oryza_sativa/Gene/PanComparaTree?collapse=none;db=core;g=Os03g0125000) vs [June 2026 archive](https://jun2026-plants.ensembl.org/Oryza_sativa/Gene/PanComparaTree?collapse=none;db=core;g=Os03g0125000)

## Possible complications

No complications expected, as changes should only have an effect on Ensembl June 2026 archive sites.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- N/A
